### PR TITLE
Add NBT data to 'Recharge Your Prospector!' reward

### DIFF
--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -2127,7 +2127,13 @@
 			optional: true
 			rewards: [{
 				id: "21CED765A341AC89"
-				item: "gtceu:prospector.hv"
+				item: {
+					Count: 1b
+					id: "gtceu:prospector.hv"
+					tag: {
+							Charge: 1600000L
+					}
+				}
 				type: "item"
 			}]
 			tasks: [


### PR DESCRIPTION
Recharge Your Prospector doesn't set the NBT data so doesn't actually recharge.

Stole the NBT data from the original quest.