### PR TITLE
Add Chipped functionality

### DIFF
--- a/kubejs/assets/emi/recipe/filters/hidecategories.json
+++ b/kubejs/assets/emi/recipe/filters/hidecategories.json
@@ -178,6 +178,27 @@
         },
         {
             "category": "emi_loot:gameplay_drops"
+        },
+        {
+            "category": "minecraft:alchemy_bench"
+        },
+        {
+            "category": "minecraft:botanist_workbench"
+        },
+        {
+            "category": "minecraft:glassblower"
+        },
+        {
+            "category": "minecraft:carpenters_table"
+        },
+        {
+            "category": "minecraft:loom_table"
+        },
+        {
+            "category": "minecraft:mason_table"
+        },
+        {
+            "category": "minecraft:tinkering_table"
         }
     ]
 }

--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -2,7 +2,7 @@
 
 JEIEvents.hideItems(event => {
     //Hides useless items
-    event.hide(['hammerlib:gears/netherite', 'hammerlib:gears/gold', 'hammerlib:gears/copper'])
+    event.hide(['hammerlib:gears/netherite', 'hammerlib:gears/gold', 'hammerlib:gears/copper', 'thermal:constantan_coin'])
 
     //i really hate these kind of mods
     event.hide('ironfurnaces:million_furnace') // rainbow furnace
@@ -26,7 +26,7 @@ JEIEvents.hideItems(event => {
 
     //EnderIO
     event.hide(['enderio:energy_conduit', 'enderio:plant_matter_green', 'enderio:plant_matter_brown', 'enderio:clayed_glowstone', 'enderio:flour', 'enderio:organic_green_dye', 'enderio:organic_brown_dye', 'enderio:industrial_insulation_block', "enderio:primitive_alloy_smelter", "enderio:alloy_smelter", "enderio:sag_mill", "enderio:stirling_generator"])
-    //EnderIO (grinding balls) haha grind my balls -clown
+    //EnderIO (grinding balls) haha grind my balls - Juicey
     event.hide(['enderio:soularium_grinding_ball', 'enderio:conductive_alloy_grinding_ball', 'enderio:pulsating_alloy_grinding_ball', 'enderio:redstone_alloy_grinding_ball', 'enderio:energetic_alloy_grinding_ball', 'enderio:vibrant_alloy_grinding_ball', 'enderio:copper_alloy_grinding_ball', 'enderio:dark_steel_grinding_ball', 'enderio:end_steel_grinding_ball'])
 
     //GT Steam Age
@@ -81,8 +81,15 @@ JEIEvents.hideItems(event => {
 
     // Wireless Chargers
     event.hide(['wirelesschargers:basic_wireless_block_charger', 'wirelesschargers:advanced_wireless_block_charger'])
+
+    // Chipped
+    event.hide(['chipped:botanist_workbench', 'chipped:glassblower', 'chipped:carpenters_table', 'chipped:loom_table', 'chipped:mason_table', 'chipped:alchemy_bench', 'chipped:tinkering_table'])
 })
 
 JEIEvents.hideFluids(event => {
     event.hide(/^nuclearcraft:.+/)
+})
+
+JEIEvents.removeCategories(event => {
+    event.remove('chipped:')
 })

--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -26,7 +26,7 @@ JEIEvents.hideItems(event => {
 
     //EnderIO
     event.hide(['enderio:energy_conduit', 'enderio:plant_matter_green', 'enderio:plant_matter_brown', 'enderio:clayed_glowstone', 'enderio:flour', 'enderio:organic_green_dye', 'enderio:organic_brown_dye', 'enderio:industrial_insulation_block', "enderio:primitive_alloy_smelter", "enderio:alloy_smelter", "enderio:sag_mill", "enderio:stirling_generator"])
-    //EnderIO (grinding balls) haha grind my balls - Juicey
+    //EnderIO (grinding balls) haha grind my balls - clown
     event.hide(['enderio:soularium_grinding_ball', 'enderio:conductive_alloy_grinding_ball', 'enderio:pulsating_alloy_grinding_ball', 'enderio:redstone_alloy_grinding_ball', 'enderio:energetic_alloy_grinding_ball', 'enderio:vibrant_alloy_grinding_ball', 'enderio:copper_alloy_grinding_ball', 'enderio:dark_steel_grinding_ball', 'enderio:end_steel_grinding_ball'])
 
     //GT Steam Age
@@ -88,8 +88,4 @@ JEIEvents.hideItems(event => {
 
 JEIEvents.hideFluids(event => {
     event.hide(/^nuclearcraft:.+/)
-})
-
-JEIEvents.removeCategories(event => {
-    event.remove('chipped:')
 })

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,21 @@
   "overrides": "overrides",
   "files": [
     {
+      "projectID": 456956,
+      "fileID": 5270039
+      "required": true
+    },
+    {    
+      "projectID": 938916,
+      "fileID": 5126390
+      "required": true
+    },
+    {    
+      "projectID": 971089,
+      "fileID": 5222767
+      "required": true
+    },
+    {
       "projectID": 233019,
       "fileID": 4578262,
       "required": true


### PR DESCRIPTION
#32

- [x] Add Chipped, Chipped Chisel Integration, and Chipped Express
- [x] Hide the chipped crafting stations (irreverent with chipped express, which lets you do them all in the stonecutter)
- [x] Hide the chipped crafting station EMI recipe tabs
- [x] Replace unifyChisel in tags.js with Chipped variants (done by #35)