### PR TITLE
Unified Charged Certus Quartz

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -575,13 +575,76 @@ ServerEvents.recipes(event => {
 
     //Certus
 
+    event.remove({ id: /^ae2:transform.*budding_quartz$/ })
     event.replaceInput(
-        { id: /^ae2:transform/ },
+        {},
         'ae2:charged_certus_quartz_crystal',
         'gtceu:charged_certus_quartz_gem'
     )
 
-    // FLuix
+    event.custom({
+        "type": "ae2:transform",
+        "ingredients": [
+            {
+                "item": "gtceu:charged_certus_quartz_gem"
+            },
+            {
+                "tag": "forge:storage_blocks/certus_quartz"
+            }
+        ],
+        "result": {
+            "count": 1,
+            "item": "ae2:damaged_budding_quartz"
+        }
+    })
+    event.custom({
+        "type": "ae2:transform",
+        "ingredients": [
+            {
+                "item": "gtceu:charged_certus_quartz_gem"
+            },
+            {
+                "item": "ae2:damaged_budding_quartz"
+            }
+        ],
+        "result": {
+            "count": 1,
+            "item": "ae2:chipped_budding_quartz"
+        }
+    })
+    event.custom({
+        "type": "ae2:transform",
+        "ingredients": [
+            {
+                "item": "gtceu:charged_certus_quartz_gem"
+            },
+            {
+                "item": "ae2:chipped_budding_quartz"
+            }
+        ],
+        "result": {
+            "count": 1,
+            "item": "ae2:flawed_budding_quartz"
+        }
+    })
+    event.custom({
+        "type": "ae2:transform",
+        "ingredients": [
+            {
+                "item": "gtceu:charged_certus_quartz_block"
+            },
+            {
+                "item": "ae2:flawed_budding_quartz"
+            }
+        ],
+        "result": {
+            "count": 1,
+            "item": "ae2:flawless_budding_quartz"
+        }
+    })
+
+            
+    // Fluix
 
     event.remove({ id: 'ae2:transform/fluix_crystal' })
     event.remove({ id: 'ae2:transform/fluix_crystals' })

--- a/kubejs/server_scripts/unification/loottables.js
+++ b/kubejs/server_scripts/unification/loottables.js
@@ -1,3 +1,7 @@
 ServerEvents.blockLootTables(event => {
     event.addSimpleBlock('ae2:quartz_cluster', '4x gtceu:certus_quartz_gem') // To drop a different item
 })
+LootJS.modifiers((event) => {
+    event.addBlockLootModifier(/ae2:.*quartz_bud/)
+        .replaceLoot("ae2:certus_quartz_dust", "gtceu:certus_quartz_dust")
+})


### PR DESCRIPTION
- Also added a recipe for the Flawless Quartz Bud as a funny alternative source of certus quartz. Shouldn't break balance since cobbleworks already gives certus in ample quantities.

resolves #63 