### PR TITLE
Ender IO loot tables rework

### DIFF
--- a/kubejs/data/enderio/loot_tables/chests/alloy_loot.json
+++ b/kubejs/data/enderio/loot_tables/chests/alloy_loot.json
@@ -1,0 +1,123 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+      {
+        "bonus_rolls": 0.0,
+        "entries": [
+                    {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.3,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": 1.0,
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "gtceu:pulsating_alloy_ingot"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.2,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": 1.0,
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "gtceu:vibrant_alloy_ingot"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.4,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": {
+                  "type": "minecraft:uniform",
+                  "max": 2.0,
+                  "min": 1.0
+                },
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "enderio:stone_gear"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.25,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": 1.0,
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "enderio:iron_gear"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.125,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": 1.0,
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "enderio:energized_gear"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.0625,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": 1.0,
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "enderio:vibrant_gear"
+          }
+        ],
+        "name": "Ender IO",
+        "rolls": {
+          "type": "minecraft:uniform",
+          "max": 2.0,
+          "min": 0.0
+        }
+      }
+    ],
+    "random_sequence": "enderio:chests/alloy_loot"
+  }

--- a/kubejs/data/enderio/loot_tables/chests/common_loot.json
+++ b/kubejs/data/enderio/loot_tables/chests/common_loot.json
@@ -1,0 +1,106 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+      {
+        "bonus_rolls": 0.0,
+        "entries": [
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.25,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": {
+                  "type": "minecraft:uniform",
+                  "max": 3.0,
+                  "min": 1.0
+                },
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "gtceu:dark_steel_ingot"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.3,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": 1.0,
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "minecraft:ender_pearl"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.5,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "name": "enderio:wood_gear"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.15,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "function": "enderio:set_loot_capacitor",
+                "range": {
+                  "type": "minecraft:uniform",
+                  "max": 4.0,
+                  "min": 1.0
+                }
+              }
+            ],
+            "name": "enderio:loot_capacitor"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.1,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "damage": {
+                  "type": "minecraft:uniform",
+                  "max": 2000.0,
+                  "min": 1.0
+                },
+                "function": "minecraft:set_damage"
+              }
+            ],
+            "name": "enderio:dark_steel_sword"
+          }
+        ],
+        "name": "Ender IO",
+        "rolls": {
+          "type": "minecraft:uniform",
+          "max": 3.0,
+          "min": 1.0
+        }
+      }
+    ],
+    "random_sequence": "enderio:chests/common_loot"
+  }


### PR DESCRIPTION
- Remove ingots that don't have uses
- Replace other ingots with GT equivalent

Fixes #62