### PR TITLE
Fix creative chest recipe

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -460,7 +460,7 @@ ServerEvents.recipes(event => {
 
     // Creative Chest
     event.recipes.extendedcrafting.shaped_table(
-        'gtceu:creative_chest', [
+        '2x gtceu:creative_chest', [
             'ABBBBBBBA',
             'BCTEDETCB',
             'BFSGHGSFB',


### PR DESCRIPTION
Creative chest recipe now gives 2 chests instead of 1, so that the player can have infinite creative chests once they craft it. Same recipe as in Nomi