### PR TITLE
fixed unobtainable ABS

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -573,5 +573,6 @@ ServerEvents.recipes(event => {
         Z: 'gtceu:zinc_foil',
         L: 'gtceu:lead_plate'
     })
-
+    //Making ABS take aluminium rather than osmium so it's obtainable in EV
+    event.replaceInput( { id:"gtceu:shaped/blast_alloy_smelter"}, "gtceu:osmium_quadruple_wire", "gtceu:aluminium_single_cable")
 })


### PR DESCRIPTION
Changed ABS recipe to instead of 4x osmium wire take 1x aluminium cable, making it obtainable in EV as intended (Recipe copied from Nomi Ceu)