### PR TITLE
Suggestion: Removal Hot MV Ingots + faster Kanthal

### DIFF
--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -107,6 +107,9 @@ JEIEvents.hideItems(event => {
 
     //Greg Hot MV ingots
     event.hide(['gtceu:hot_kanthal_ingot', 'gtceu:hot_silicon_ingot'])
+
+    // AE2 stuff
+    event.hide(['ae2:fluix_dust', 'ae2:fluix_crystal', 'ae2:fluix_block', 'ae2:certus_quartz_crystal', 'ae2:charged_certus_quartz_crystal'])
 })
 
 JEIEvents.hideFluids(event => {

--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -104,6 +104,9 @@ JEIEvents.hideItems(event => {
 
     //Greg Milk
     event.hide('gtceu:milk')
+
+    //Greg Hot MV ingots
+    event.hide(['gtceu:hot_kanthal_ingot', 'gtceu:hot_silicon_ingot'])
 })
 
 JEIEvents.hideFluids(event => {

--- a/kubejs/server_scripts/gregtech/Alloys_Recipes.js
+++ b/kubejs/server_scripts/gregtech/Alloys_Recipes.js
@@ -178,6 +178,25 @@ ServerEvents.recipes(event => {
 })
 
 ServerEvents.recipes(event => {
+    event.remove(['gtceu:electric_blast_furnace/blast_kanthal','gtceu:electric_blast_furnace/blast_kanthal_gas'])
+    event.recipes.gtceu.electric_blast_furnace("kubejs:kanthal")
+        .itemInputs('gtceu:kanthal_dust')
+        .itemOutputs('gtceu:kanthal_ingot')
+        .duration(700)
+        .EUt(480)
+        .circuit(1)
+        .blastFurnaceTemp(1800)
+    event.recipes.gtceu.electric_blast_furnace("kubejs:kanthal_gas")
+        .itemInputs('gtceu:kanthal_dust')
+        .itemOutputs('gtceu:kanthal_ingot')
+        .inputFluids(Fluid.of('gtceu:nitrogen', 1000))
+        .duration(469)
+        .EUt(480)
+        .circuit(2)
+        .blastFurnaceTemp(1800)
+})
+
+ServerEvents.recipes(event => {
     event.remove('gtceu:alloy_blast_smelter/red_alloy')
     event.recipes.gtceu.alloy_blast_smelter("kubejs:red_alloy_fluid")
         .itemInputs('2x gtceu:copper_dust', '3x #forge:dusts/redstone')

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -811,4 +811,27 @@ ServerEvents.recipes(event => {
         mode: "press",
         result: { item: "ae2wtlib:quantum_bridge_card" }
     }).id('kubejs:ae2wtlib/quantum_bridge_card')
+
+    //Fluix Dust Inscriber 
+    // event.remove({ id: 'jei:ae2/inscriber/fluix_dust' }) (I don't know what's wrong with that recipe but it doesn't want to be removed or replaceoutput)
+    event.custom({
+        "type": "ae2:inscriber",
+        "ingredients": {
+            "middle": {
+                "item": "gtceu:fluix_gem"
+            }
+        },
+        "mode": "inscribe",
+        "result": {
+            "item": "gtceu:fluix_dust"
+        }
+    }).id('kubejs:ae2/fluix_dust_inscriber')
+
+    //Certus Quartz Crystal
+    event.remove({ input: 'ae2:certus_quartz_crystal'})
+    event.replaceOutput(
+        { output: 'ae2:certus_quartz_crystal' },
+        'ae2:certus_quartz_crystal',
+        'gtceu:certus_quartz_gem'
+    )
 })

--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -27,7 +27,6 @@ ServerEvents.recipes(event => {
         }
     ).id('kubejs:item_conduit')
 
-	// event.remove({ id: "enderio:ender_fluid_conduit" })
     // Manual ender fluid conduit
     event.shaped(
         "4x enderio:ender_fluid_conduit", [
@@ -40,6 +39,8 @@ ServerEvents.recipes(event => {
             P: "enderio:pressurized_fluid_conduit"
         }
     ).id("kubejs:ender_fluid_conduit_upgrade")
+
+    event.remove({ id: "enderio:ender_fluid_conduit_upgrade" })
 
     // Assembler item conduit
     event.recipes.gtceu.assembler("kubejs:efficent_item_conduit")

--- a/kubejs/server_scripts/mods/gregtech.js
+++ b/kubejs/server_scripts/mods/gregtech.js
@@ -210,6 +210,15 @@ ServerEvents.recipes(event => {
         }
     )
 
+    //Hot MV ingots
+    event.remove({ input: ['gtceu:hot_kanthal_ingot', "gtceu:hot_silicon_ingot"]})
+    event.replaceOutput(
+        { output: 'gtceu:hot_silicon_ingot' },
+        'gtceu:hot_silicon_ingot',
+        'gtceu:silicon_ingot'
+    )
+
+
     //Ender Pearl dust Electrolysis
     //event.remove({ id: 'gtceu:electrolyzer/decomposition_electrolyzing_ender_pearl' })
 


### PR DESCRIPTION
As some of us already discussed about in the Discord Server having Kanthal and Silicon being the only 'hot' ingots in MV + that requires washing to cool feels weird.

Kanthal is also very slow to farm to get your first 24 coils unless you have multiple EBF which the player doesn't generally have the energy for in early/mid MV (~around 1h30 (from Pansmith words)) so I made its recipes faster too.


This draft is to get your opinion on the changes I've made (see below) I will mark this draft as ready once we're happy with the changes:


. Hot Kanthal Ingot and Hot Silicon Ingot has been completely removed
. EBF recipes for Kanthal and Silicon ingots now gives their cooled down version
. EBF recipes for Kanthal decresed from 45s to 35s (gas variant has been accordingly changed too)