### PR TITLE
Average Bug Fix PR

### DIFF
--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -106,6 +106,9 @@ JEIEvents.hideItems(event => {
 
     //Greg Milk
     event.hide('gtceu:milk')
+
+    // AE2 stuff
+    event.hide(['ae2:fluix_dust', 'ae2:fluix_crystal', 'ae2:fluix_block', 'ae2:certus_quartz_crystal', 'ae2:charged_certus_quartz_crystal'])
 })
 
 JEIEvents.hideFluids(event => {

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -811,4 +811,27 @@ ServerEvents.recipes(event => {
         mode: "press",
         result: { item: "ae2wtlib:quantum_bridge_card" }
     }).id('kubejs:ae2wtlib/quantum_bridge_card')
+
+        //Fluix Dust Inscriber 
+        // event.remove({ id: 'jei:ae2/inscriber/fluix_dust' }) (I don't know what's wrong with that recipe but it doesn't want to be removed or replaceoutput)
+        event.custom({
+            "type": "ae2:inscriber",
+            "ingredients": {
+                "middle": {
+                    "item": "gtceu:fluix_gem"
+                }
+            },
+            "mode": "inscribe",
+            "result": {
+                "item": "gtceu:fluix_dust"
+            }
+        }).id('kubejs:ae2/fluix_dust_inscriber')
+
+        //Certus Quartz Crystal
+        event.remove({ input: 'ae2:certus_quartz_crystal'})
+        event.replaceOutput(
+            { output: 'ae2:certus_quartz_crystal' },
+            'ae2:certus_quartz_crystal',
+            'gtceu:certus_quartz_gem'
+        )
 })

--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -27,7 +27,6 @@ ServerEvents.recipes(event => {
         }
     ).id('kubejs:item_conduit')
 
-	// event.remove({ id: "enderio:ender_fluid_conduit" })
     // Manual ender fluid conduit
     event.shaped(
         "4x enderio:ender_fluid_conduit", [
@@ -40,6 +39,8 @@ ServerEvents.recipes(event => {
             P: "enderio:pressurized_fluid_conduit"
         }
     ).id("kubejs:ender_fluid_conduit_upgrade")
+
+    event.remove({ id: "enderio:ender_fluid_conduit_upgrade" })
 
     // Assembler item conduit
     event.recipes.gtceu.assembler("kubejs:efficent_item_conduit")


### PR DESCRIPTION
. Change the last craft still using AE2 Certus Quartz to use the gtceu version
. Overwrite the Inscriber recipe for fluix dust which would give the AE2 version (Removing / hide the vanilla recipe failed)
. Hide unused AE2 stuff
. Remove vanilla recipe for Ender Fluid Conduit (not supposed to be here + uncraftable)