### PR TITLE
Numismatic Dynamo quests rewrite

### DIFF
--- a/config/ftbquests/quests/chapters/early_game.snbt
+++ b/config/ftbquests/quests/chapters/early_game.snbt
@@ -2303,7 +2303,9 @@
 		{
 			dependencies: ["73C1AB31431B5C11"]
 			description: [
-				"The &6Numismatic Dynamo&r is the main source of power through the Mid Game of the pack. Paired with a &aLapidary Calibration Augment&r and a self-sustaining &bDeep Mob Evolution&r setup, this dynamo can burn through &6Diamonds&r to produce large amounts of &eRF power&r."
+				"The &6Numismatic Dynamo&r is the main source of power through the Mid Game of the pack." 
+				""
+				"Paired with a self-sustaining &bDeep Mob Evolution&r setup, this dynamo can burn through &6Diamonds&r to produce large amounts of &eRF power&r."
 				""
 				"Just like other &bThermal Expansion&r dynamos, the &6Numismatic Dynamo&r can be given tier upgrades to produce more power and gain access to more &aAugment Slots&r."
 			]

--- a/config/ftbquests/quests/chapters/simulating_resources.snbt
+++ b/config/ftbquests/quests/chapters/simulating_resources.snbt
@@ -78,7 +78,9 @@
 		{
 			dependencies: ["73C1AB31431B5C11"]
 			description: [
-				"The &6Numismatic Dynamo&r is the main source of power through the Mid Game of the pack. Paired with a &aLapidary Calibration Augment&r and a self-sustaining &bHostile Neural Networks&r setup, this dynamo can burn through &6Diamonds&r to produce large amounts of &eRF power&r."
+				"The &6Numismatic Dynamo&r is the main source of power through the Mid Game of the pack."
+				""
+				"Paired with a self-sustaining &bDeep Mob Evolution&r setup, this dynamo can burn through &6Diamonds&r to produce large amounts of &eRF power&r."
 				""
 				"Just like other &bThermal Expansion&r dynamos, the &6Numismatic Dynamo&r can be given tier upgrades to produce more power and gain access to more &aAugment Slots&r."
 			]

--- a/kubejs/server_scripts/mods/gregtech.js
+++ b/kubejs/server_scripts/mods/gregtech.js
@@ -218,14 +218,6 @@ ServerEvents.recipes(event => {
         'gtceu:silicon_ingot'
     )
 
-    //Stainless Steel
-    event.remove({ id: 'gtceu:mixer/stainless_steel_from_invar'})
-    event.recipes.gtceu.mixer("stainless_steel_invar")
-    .itemInputs("4x gtceu:iron_dust", "gtceu:invar_dust", "gtceu:manganese_dust", "gtceu:chromium_dust")
-    .itemOutputs("9x gtceu:stainless_steel_dust")
-    .duration(600)
-    .EUt(120)
-    .circuit(1)
 
     //Ender Pearl dust Electrolysis
     //event.remove({ id: 'gtceu:electrolyzer/decomposition_electrolyzing_ender_pearl' })

--- a/kubejs/server_scripts/mods/gregtech.js
+++ b/kubejs/server_scripts/mods/gregtech.js
@@ -218,6 +218,14 @@ ServerEvents.recipes(event => {
         'gtceu:silicon_ingot'
     )
 
+    //Stainless Steel
+    event.remove({ id: 'gtceu:mixer/stainless_steel_from_invar'})
+    event.recipes.gtceu.mixer("stainless_steel_invar")
+    .itemInputs("4x gtceu:iron_dust", "gtceu:invar_dust", "gtceu:manganese_dust", "gtceu:chromium_dust")
+    .itemOutputs("9x gtceu:stainless_steel_dust")
+    .duration(600)
+    .EUt(120)
+    .circuit(1)
 
     //Ender Pearl dust Electrolysis
     //event.remove({ id: 'gtceu:electrolyzer/decomposition_electrolyzing_ender_pearl' })

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -31,7 +31,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.gas_collector('void_air')
         .dimension('javd:void')
         .outputFluids(Fluid.of('gtceu:air', 10000))
-        .circuit(1)
+        .circuit(4)
         .EUt(16)
         .duration(200)
 


### PR DESCRIPTION
Numismatic Dynamo quests rewrite to remove the part about the Lapidary Calibration augment which no longer exists + fix the use of "Hostile Neural Network" in one of the quest for consistency between the two