### PR TITLE
Replace Waystones with Tempad

### DIFF
--- a/config/tempad.jsonc
+++ b/config/tempad.jsonc
@@ -1,0 +1,51 @@
+{
+    /*
+     * The distance from the player that the Tempad is summoned.
+     * Range: 1 - 10
+     */
+    "distanceFromPlayer": 3,
+    /*
+     * The amount of time in ticks that the timedoor will wait before closing itself after the owner walked through it.
+     * Type: Integer
+     */
+    "timedoorWaitTime": 60,
+    /*
+     * The amount of time in ticks that the Tempad will add to the wait time when the player is in the Tempad.
+     * Type: Integer
+     */
+    "timedoorAddWaitTime": 40,
+    // Whether or not the Tempad should allow interdimensional travel.
+    "allowInterdimensionalTravel": true,
+    // Whether or not the Tempad should allow exporting of locations onto Location Cards.
+    "allowExporting": true,
+    // Whether or not the Tempad should consume a cooldown when exporting a location.
+    "consumeCooldown": true,
+    // Whether or not the Tempad should allow teleporting to waystones.
+    "waystonesCompat": true,
+    // Whether or not the Tempad should allow teleporting to waystones from the Fabric version of Waystones by LordDeatHunter (fwaystones) (ignore on forge).
+    "fabricWaystonesCompat": false,
+    /*
+     * The amount of fuel that the timedoor will consume on opening of the timedoor.
+     * Type: Integer
+     */
+    "timedoorFuelAmount": 1,
+    /*
+     * The amount of fuel that the timedoor can hold.
+     * Type: Integer
+     */
+    "timedoorFuelCapacity": 10,
+    /*
+     * The amount of fuel that the advanced timedoor will consume on opening of the timedoor.
+     * Type: Integer
+     */
+    "advancedTimedoorFuelAmount": 1,
+    /*
+     * The amount of fuel that the advanced timedoor can hold.
+     * Type: Integer
+     */
+    "advancedTimedoorFuelCapacity": 1000,
+    // The type of fuel that the timedoor will consume.
+    "timedoorFuelType": "tempad:item",
+    // The type of fuel that the advanced timedoor will consume.
+    "advancedTimedoorFuelType": "tempad:unlimited"
+}

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -43,6 +43,9 @@ ItemEvents.tooltip(tooltip => {
     tooltip.addAdvanced(/storagedrawers:/, (item, advanced, text) => {
         text.add(1, [Text.red('Deprecated').bold()])
     })
+    tooltip.addAdvanced(/waystones:/, (item, advanced, text) => {
+        text.add(1, [Text.red('Deprecated. Migrate to Tempad').bold()])
+    })
 
 	// Fix gtceu text
     tooltip.addAdvanced(['gtceu:creative_energy', 'gtceu:creative_tank', 'gtceu:creative_chest', 'gtceu:creative_data_access_hatch'], (item, adv, text) => {

--- a/kubejs/data/enderio/loot_tables/chests/common_loot.json
+++ b/kubejs/data/enderio/loot_tables/chests/common_loot.json
@@ -1,106 +1,110 @@
 {
-    "type": "minecraft:chest",
-    "pools": [
-      {
-        "bonus_rolls": 0.0,
-        "entries": [
-          {
-            "type": "minecraft:item",
-            "conditions": [
-              {
-                "chance": 0.25,
-                "condition": "minecraft:random_chance"
-              }
-            ],
-            "functions": [
-              {
-                "add": false,
-                "count": {
-                  "type": "minecraft:uniform",
-                  "max": 3.0,
-                  "min": 1.0
-                },
-                "function": "minecraft:set_count"
-              }
-            ],
-            "name": "gtceu:dark_steel_ingot"
-          },
-          {
-            "type": "minecraft:item",
-            "conditions": [
-              {
-                "chance": 0.3,
-                "condition": "minecraft:random_chance"
-              }
-            ],
-            "functions": [
-              {
-                "add": false,
-                "count": 1.0,
-                "function": "minecraft:set_count"
-              }
-            ],
-            "name": "minecraft:ender_pearl"
-          },
-          {
-            "type": "minecraft:item",
-            "conditions": [
-              {
-                "chance": 0.5,
-                "condition": "minecraft:random_chance"
-              }
-            ],
-            "name": "enderio:wood_gear"
-          },
-          {
-            "type": "minecraft:item",
-            "conditions": [
-              {
-                "chance": 0.15,
-                "condition": "minecraft:random_chance"
-              }
-            ],
-            "functions": [
-              {
-                "function": "enderio:set_loot_capacitor",
-                "range": {
-                  "type": "minecraft:uniform",
-                  "max": 4.0,
-                  "min": 1.0
-                }
-              }
-            ],
-            "name": "enderio:loot_capacitor"
-          },
-          {
-            "type": "minecraft:item",
-            "conditions": [
-              {
-                "chance": 0.1,
-                "condition": "minecraft:random_chance"
-              }
-            ],
-            "functions": [
-              {
-                "add": false,
-                "damage": {
-                  "type": "minecraft:uniform",
-                  "max": 2000.0,
-                  "min": 1.0
-                },
-                "function": "minecraft:set_damage"
-              }
-            ],
-            "name": "enderio:dark_steel_sword"
-          }
-        ],
-        "name": "Ender IO",
-        "rolls": {
-          "type": "minecraft:uniform",
-          "max": 3.0,
-          "min": 1.0
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": {
+        "type": "minecraft:uniform",
+        "min": 1,
+        "max": 3
+      },
+      "bonus_rolls": 0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "gtceu:dark_steel_ingot",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 1,
+                "max": 3
+              },
+              "add": false
+            }
+          ],
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.25
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:ender_pearl",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1,
+              "add": false
+            }
+          ],
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.3
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "enderio:wood_gear",
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.5
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "enderio:loot_capacitor",
+          "functions": [
+            {
+              "function": "enderio:set_loot_capacitor"
+            }
+          ],
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "enderio:dark_steel_sword",
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "type": "minecraft:uniform",
+                "min": 1,
+                "max": 2000
+              },
+              "add": false
+            }
+          ],
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "tempad:tempad",
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.05
+            }
+          ]
         }
-      }
-    ],
-    "random_sequence": "enderio:chests/common_loot"
-  }
+      ]
+    }
+  ],
+  "random_sequence": "enderio:chests/common_loot"
+}

--- a/kubejs/data/enderio/loot_tables/chests/common_loot.json
+++ b/kubejs/data/enderio/loot_tables/chests/common_loot.json
@@ -1,110 +1,106 @@
 {
-  "type": "minecraft:chest",
-  "pools": [
-    {
-      "rolls": {
-        "type": "minecraft:uniform",
-        "min": 1,
-        "max": 3
-      },
-      "bonus_rolls": 0,
-      "entries": [
-        {
-          "type": "minecraft:item",
-          "name": "gtceu:dark_steel_ingot",
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "type": "minecraft:uniform",
-                "min": 1,
-                "max": 3
-              },
-              "add": false
-            }
-          ],
-          "conditions": [
-            {
-              "condition": "minecraft:random_chance",
-              "chance": 0.25
-            }
-          ]
-        },
-        {
-          "type": "minecraft:item",
-          "name": "minecraft:ender_pearl",
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": 1,
-              "add": false
-            }
-          ],
-          "conditions": [
-            {
-              "condition": "minecraft:random_chance",
-              "chance": 0.3
-            }
-          ]
-        },
-        {
-          "type": "minecraft:item",
-          "name": "enderio:wood_gear",
-          "conditions": [
-            {
-              "condition": "minecraft:random_chance",
-              "chance": 0.5
-            }
-          ]
-        },
-        {
-          "type": "minecraft:item",
-          "name": "enderio:loot_capacitor",
-          "functions": [
-            {
-              "function": "enderio:set_loot_capacitor"
-            }
-          ],
-          "conditions": [
-            {
-              "condition": "minecraft:random_chance",
-              "chance": 0.15
-            }
-          ]
-        },
-        {
-          "type": "minecraft:item",
-          "name": "enderio:dark_steel_sword",
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "type": "minecraft:uniform",
-                "min": 1,
-                "max": 2000
-              },
-              "add": false
-            }
-          ],
-          "conditions": [
-            {
-              "condition": "minecraft:random_chance",
-              "chance": 0.1
-            }
-          ]
-        },
-        {
-          "type": "minecraft:item",
-          "name": "tempad:tempad",
-          "conditions": [
-            {
-              "condition": "minecraft:random_chance",
-              "chance": 0.05
-            }
-          ]
+    "type": "minecraft:chest",
+    "pools": [
+      {
+        "bonus_rolls": 0.0,
+        "entries": [
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.25,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": {
+                  "type": "minecraft:uniform",
+                  "max": 3.0,
+                  "min": 1.0
+                },
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "gtceu:dark_steel_ingot"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.3,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "count": 1.0,
+                "function": "minecraft:set_count"
+              }
+            ],
+            "name": "minecraft:ender_pearl"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.5,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "name": "enderio:wood_gear"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.15,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "function": "enderio:set_loot_capacitor",
+                "range": {
+                  "type": "minecraft:uniform",
+                  "max": 4.0,
+                  "min": 1.0
+                }
+              }
+            ],
+            "name": "enderio:loot_capacitor"
+          },
+          {
+            "type": "minecraft:item",
+            "conditions": [
+              {
+                "chance": 0.1,
+                "condition": "minecraft:random_chance"
+              }
+            ],
+            "functions": [
+              {
+                "add": false,
+                "damage": {
+                  "type": "minecraft:uniform",
+                  "max": 2000.0,
+                  "min": 1.0
+                },
+                "function": "minecraft:set_damage"
+              }
+            ],
+            "name": "enderio:dark_steel_sword"
+          }
+        ],
+        "name": "Ender IO",
+        "rolls": {
+          "type": "minecraft:uniform",
+          "max": 3.0,
+          "min": 1.0
         }
-      ]
-    }
-  ],
-  "random_sequence": "enderio:chests/common_loot"
-}
+      }
+    ],
+    "random_sequence": "enderio:chests/common_loot"
+  }

--- a/kubejs/server_scripts/unification/loottables.js
+++ b/kubejs/server_scripts/unification/loottables.js
@@ -4,4 +4,7 @@ ServerEvents.blockLootTables(event => {
 LootJS.modifiers((event) => {
     event.addBlockLootModifier(/ae2:.*quartz_bud/)
         .replaceLoot("ae2:certus_quartz_dust", "gtceu:certus_quartz_dust")
+    event.addLootTableModifier("minecraft:chests/simple_dungeon")
+        .randomChance(0.02)
+        .addLoot("tempad:tempad");
 })

--- a/kubejs/server_scripts/unification/tags.js
+++ b/kubejs/server_scripts/unification/tags.js
@@ -77,6 +77,9 @@ ServerEvents.tags('item', event => {
 	// enderio!!!!
 	event.add('forge:heads', 'enderio:enderman_head')
 
+    // Tempad fuel
+    event.add('tempad:tempad_fuel', 'kubejs:moni_penny')
+
     unifyChisel(event);
 })
 

--- a/manifest.json
+++ b/manifest.json
@@ -966,8 +966,8 @@
       "required": true
     },
     {
-      "projectID": 245755,
-      "fileID": 4962610,
+      "projectID": 514923,
+      "fileID": 5008918,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -966,6 +966,11 @@
       "required": true
     },
     {
+      "projectID": 245755,
+      "fileID": 4962610,
+      "required": true
+    },
+    {
       "projectID": 514923,
       "fileID": 5008918,
       "required": true


### PR DESCRIPTION
Features:
- Tempad uses Moni pennies as fuel. There is no cooldown as such
- Tempads can be found in dungeon chests (including Lost Cities chests) with a 2% spawn chance
- Tempad recipe is currently unchanged

Notes:
- Someone should probably add a quest for Tempads
- Might be worth reducing the number of FTB homes as Tempads allow TPing anywhere endlessly
- Waystones will be kept in the next release as a deprecated item to let players bookmark their existing waystones
- Tempad has built in compat with Waystones so could be useful if we decide to keep Waystones. This will also make migration easier