### PR TITLE
Quest updates with clarification about early game water supply blocks

### DIFF
--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -983,7 +983,7 @@
 				""
 				"Feeding a &3Steam Dynamo&f with water by hand is a pretty silly idea."
 				""
-				"A &6Water Condenser&f will take care of that for you, albeit slowly."
+				"A &6Water Condenser&f will take care of that for you, albeit slowly. It does, however, auto-output the water to making it simple to use."
 				""
 				"&2GTCEu has a Primitive Water Pump, which can do it faster. However, it requires Treated Wood, which requires Creosote from a Coke Oven."
 			]

--- a/config/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config/ftbquests/quests/chapters/the_beginning.snbt
@@ -1779,7 +1779,7 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"&bGregTech&r adds a very versatile way of augmenting machines with &aMachine Covers&r. Covers are \"upgrades\" that you can put on any &eGregTech machine, crate, or drum&r to expand its functionality. These are seperate on each side of the machine, meaning you can have up to six different covers! &9Covers can be edited and removed via the given machine's GUI&r, but for the others, you'll need to make yourself a &aScrewdriver&r to configure covers, and a &aCrowbar&r to remove covers without having to break the machine. This quest accepts a &aScrewdriver&r and &aCrowbar&r made from any material."
+				"&bGregTech&r adds a very versatile way of augmenting machines with &aMachine Covers&r. Covers are \"upgrades\" that you can put on any &eGregTech machine, crate, or drum&r to expand its functionality. These are seperate on each side of the machine, meaning you can have up to six different covers! &9Covers can be edited and removed via the given machine's GUI&r, but for the others, you'll need to make yourself a &aScrewdriver&r to configure covers, and a &aCrowbar&r to remove covers without having to break the machine."
 				""
 				"Here's a list of some covers there are in the game, and what they do:"
 				""

--- a/config/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config/ftbquests/quests/chapters/the_beginning.snbt
@@ -673,7 +673,7 @@
 		}
 		{
 			dependencies: ["29A487F0BC43AAF9"]
-			description: ["Needs 2 &6Water Source Blocks&r around it to generate water."]
+			description: ["Needs 2 &6Water Source Blocks&r around it to generate water. You will also need a way to pull the water out of the accumulator, such as using the &5LV water pump&f as a &acover&f."]
 			icon: {
 				Count: 1b
 				id: "thermal:device_water_gen"


### PR DESCRIPTION
I ran into problems understanding that the Aqueous Accumulator required some mechanism to pull water out of it. I expected it to match the behaviour of the Water Condenser, which auto-outputs the water.

I also fixed a bit of text in the Machine Covers that said the quest required something to complete that it no longer does.