### PR TITLE
Disabling Hazards + Smaller Additions and Changes

### DIFF
--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -321,7 +321,7 @@ tools:
 gameplay:
   # Enable hazardous materials
   # Default: true
-  hazardsEnabled: true
+  hazardsEnabled: false
 
 # Config options for Mod Compatibility
 compat:

--- a/kubejs/server_scripts/gregtech/Post_UV_Components.js
+++ b/kubejs/server_scripts/gregtech/Post_UV_Components.js
@@ -72,6 +72,19 @@ ServerEvents.recipes(event => {
                 .inputFluids('gtceu:crystal_matrix 11520', 'gtceu:soldering_alloy 5760')
                 .duration(1000)
                 .EUt(eut)
+
+                event.recipes.gtceu.assembler(`gtceu:${tier}_energy_input_hatch_4a`)
+                .itemInputs(`gtceu:${tier}_energy_input_hatch`, `2x gtceu:${mat1}_plate`, `2x gtceu:${mat2}_quadruple_wire`)
+                .itemOutputs(`gtceu:${tier}_energy_input_hatch_4a`)
+                .duration(100)
+                .EUt(eut)
+
+                event.recipes.gtceu.assembler(`gtceu:${tier}_energy_input_hatch_16a`)
+                .itemInputs(`2x gtceu:${tier}_energy_input_hatch_4a`, `4x gtceu:${mat1}_plate`, `2x gtceu:${mat2}_octal_wire`, `2x gtceu:uhpic_chip`)
+                .itemOutputs(`gtceu:${tier}_energy_input_hatch_16a`)
+                .duration(100)
+                .EUt(eut)
+
         })
     }
 

--- a/kubejs/server_scripts/gregtech/circuits.js
+++ b/kubejs/server_scripts/gregtech/circuits.js
@@ -203,5 +203,5 @@ ServerEvents.recipes(event => {
             .inputFluids('gtceu:soldering_alloy 1152')
             .itemOutputs('kubejs:monic_processor_mainframe')
             .duration(1200)
-            .EUt(2147483647)
+            .EUt(134217728)
     })

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -190,7 +190,7 @@ ServerEvents.recipes(event => {
         .EUt(194387)
 
         event.recipes.gtceu.advanced_microverse_iii('kubejs:t_nine_forth')
-        .itemInputs('kubejs:microminer_t9', 'kubejs:universe_creation_data', '64x kubejs:corrupted_universe_data', '64x kubejs:shattered_star_data', '64x kubejs:shattered_star_data')
+        .itemInputs('kubejs:microminer_t9', 'kubejs:universe_creation_data', '64x kubejs:shattered_star_data', '64x kubejs:shattered_star_data', '64x kubejs:shattered_star_data', '64x kubejs:shattered_star_data')
         .itemOutputs('kubejs:shattered_universe_data')
         .duration(1000)
         .EUt(194387)

--- a/kubejs/server_scripts/gregtech/post_tank_wafers.js
+++ b/kubejs/server_scripts/gregtech/post_tank_wafers.js
@@ -66,9 +66,9 @@ ServerEvents.recipes(event => {
         .EUt(128000)
 
         event.recipes.gtceu.large_chemical_reactor("multidimensional_cpu_wafer")
-        .itemInputs('kubejs:unactivated_multidimensional_cpu_wafer', '16x kubejs:quantum_flux', 'kubejs:quasi_stable_neutron_star')
-        .inputFluids(Fluid.of('gtceu:xenon', 250))
-        .itemOutputs('kubejs:multidimensional_cpu_wafer')
+        .itemInputs('4x kubejs:unactivated_multidimensional_cpu_wafer', '64x kubejs:quantum_flux', 'kubejs:quasi_stable_neutron_star')
+        .inputFluids(Fluid.of('gtceu:xenon', 1000))
+        .itemOutputs('4x kubejs:multidimensional_cpu_wafer')
         .cleanroom(CleanroomType.CLEANROOM)
         .duration(900)
         .EUt(250000)

--- a/kubejs/server_scripts/microverse.js
+++ b/kubejs/server_scripts/microverse.js
@@ -414,8 +414,10 @@ ServerEvents.recipes(event => {
             '64x gtceu:fine_tritanium_wire')
         .inputFluids('gtceu:soldering_alloy 1152', 'gtceu:naquadria 576')
         .itemOutputs('kubejs:universal_navigator')
+        .stationResearch(b => b.researchStack('kubejs:stellar_creation_data').CWUt(96,384000).EUt(491520))
         .duration(6000)
         .EUt(491520)
+
   
     event.recipes.gtceu.assembly_line('extradimensional_navigator')
         .itemInputs('gtceu:infinity_frame',
@@ -430,13 +432,9 @@ ServerEvents.recipes(event => {
             '32x gtceu:fine_ruthenium_trinium_americium_neutronate_wire')
         .inputFluids('gtceu:soldering_alloy 11520', 'gtceu:crystal_matrix 5760', 'gtceu:naquadria 2304')
         .itemOutputs('kubejs:extradimensional_navigator')
+        .stationResearch(b => b.researchStack('kubejs:universal_navigator').CWUt(160, 640000).EUt(3932160))
         .duration(6000)
         .EUt(3932160)
-        .stationResearch(b => b
-            .researchStack('kubejs:stellar_creation_data')
-            .CWUt(96, 384000)
-            .EUt(491520)
-        )
 
     // Electrum Engine Frame
     event.shaped(


### PR DESCRIPTION
- [ ] **Disabled Hazards**
- [ ] Changed 64 Corrupted Universe Data in 4th T9MM mission into 128 Shattered Star data
- [ ] added recipes for 4A and 16A Energy hatches
- [ ] Reduced Monic Processor Frame's voltage needed from MAX to UXV, as MAX voltage is not attainable
- [ ] Buffed Multidimensional CPU recipe, effectively cuts Quasi-Stable Neutron Star consumption by 75%. Making people send multiple T9MM missions just for like one mainframe felt a little evil.
- [ ] Fixed research for Universal and Extradimensional Navigators