### PR TITLE
Add Lava from Magma CR recipe

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -50,6 +50,13 @@ ServerEvents.recipes(event => {
         .duration(20)
         .EUt(32)
 
+    // Lava from Magma
+    event.recipes.gtceu.chemical_reactor('lava_from_magma')
+        .itemInputs('minecraft:magma_block')
+        .outputFluids(Fluid.of('minecraft:lava', 1000))
+        .EUt(32)
+        .duration(120)
+
     // Infinity Dust Blocks
     comapcting(event, 'kubejs:infinity_dust_block', 'enderio:grains_of_infinity');
     comapcting(event, 'kubejs:compressed_infinity_dust_block', 'kubejs:infinity_dust_block');


### PR DESCRIPTION
Added a Magma Block to Lava recipe for Chemical Reactor that is present in Nomi but is missing from Moni (Nomi has it at 32 EU/t though)

![image](https://github.com/ThePansmith/Monifactory/assets/48847457/fda913b9-c6c9-4ac2-b979-cd2e4ae87da6)
