### PR TITLE
Add in Clear Glass recipe to match EnderIO Primitive Alloy Smelter

### DIFF
--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -336,6 +336,22 @@ ServerEvents.recipes(event => {
         .duration(200)
         .EUt(32)
 
+    //Clear Glass
+    if (isNormalMode) {
+        event.recipes.gtceu.alloy_smelter("kubejs:clear_glass")
+            .itemInputs('minecraft:glass')
+            .itemOutputs('enderio:clear_glass')
+            .duration(80)
+            .EUt(16)
+    }
+    if (isHardMode) {
+        event.recipes.gtceu.alloy_smelter("kubejs:clear_glass")
+            .itemInputs('minecraft:glass', 'gtceu:tiny_soda_ash_dust')
+            .itemOutputs('enderio:clear_glass')
+            .duration(80)
+            .EUt(16)
+    }
+
     // Enlightened clear glass
     event.recipes.gtceu.alloy_smelter("kubejs:enlightened_clear_glass")
         .itemInputs('#enderio:clear_glass', 'minecraft:glowstone')


### PR DESCRIPTION
Creates an EnderIO Clear Glass recipe (with hardmode variant) in response to a few mentions of the issue on Discord:

[https://discord.com/channels/914926812948234260/1229854271613436066/1249177969088266341](https://discord.com/channels/914926812948234260/1229854271613436066/1249177969088266341)
[https://discord.com/channels/914926812948234260/1229929228875726962/1246588928081920031](https://discord.com/channels/914926812948234260/1229929228875726962/1246588928081920031)
[https://discord.com/channels/914926812948234260/1229854271613436066/1243441927421038672](https://discord.com/channels/914926812948234260/1229854271613436066/1243441927421038672)