### PR TITLE
Update ftbchunks-world.snbt

### DIFF
--- a/defaultconfigs/ftbchunks/ftbchunks-world.snbt
+++ b/defaultconfigs/ftbchunks/ftbchunks-world.snbt
@@ -1,4 +1,6 @@
 # Default config file that will be copied to saves\New World\serverconfig\ftbchunks-world.snbt if it doesn't exist!
 # Just copy any values you wish to override in here!
 
-{ }
+{
+    force_load_mode: "always"
+}


### PR DESCRIPTION
Would be for #306

Would make it so that friend servers at-least behave like in vanilla where loaded chunks stay loaded.

Larger servers should probably change this but larger servers in my opinion and own experience should overlook server settings for themselves anyhow as they're probably running their own software in the first place or have people maintaining it.