### PR TITLE
[Workaround] Set environmentalHazardDecayRate to 1

### DIFF
--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -376,6 +376,10 @@ gameplay:
   # Default: true
   environmentalHazards: false
 
+  # How much environmental hazards decay per chunk, per tick.
+  # Default: 0.001
+  environmentalHazardDecayRate: 1.0
+
   # Whether the GTCEu's ingame guidebook, 'Compass', be enabled.
   # WARNING: INCOMPLETE
   # Default: false


### PR DESCRIPTION
Workaround for the Pollution bug, all pollutions should be cleared instantly and not effect the player. Change this again, when pollution is fixxt on GTM.