### PR TITLE
Hardmode Progression Fixes + Other Small Things

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -407,6 +407,7 @@ ServerEvents.recipes(event => {
     )
 
     // Creative Chest
+    if (isNormalMode) {
     event.recipes.extendedcrafting.shaped_table(
         '2x gtceu:creative_chest', [
             'BMMMMMMMMMB',
@@ -444,6 +445,48 @@ ServerEvents.recipes(event => {
             Z: 'kubejs:infinity_wire_cutter'            
         }
     )
+    }
+
+    if (!isNormalMode) {
+        event.recipes.extendedcrafting.shaped_table(
+            '2x gtceu:creative_chest', [
+                'BMMMMMMMMMB',
+                'MIPOPPPOPIM',
+                'MIFNNNNNFIM',
+                'GUNNEEENNUG',
+                'RDEEQQQEEDR',
+                'RSSSSHSSSSR',
+                'RDTTQQQTTDR',
+                'GUNNTTTNNUG',
+                'MIFNNNNNFIM',
+                'MIPVWXYZPIM',
+                'BMMMMMMMMMB'
+            ], {
+                B: 'gtceu:monium_block',
+                M: 'gtceu:monium_plate',
+                D: 'gtceu:double_monium_plate',
+                G: 'gtceu:monium_gear',
+                I: 'gtceu:infinity_block',
+                N: 'gtceu:dense_netherite_plate',
+                S: 'kubejs:creative_storage_data',
+                E: 'kubejs:creative_energy_data',
+                T: 'kubejs:omnic_data',
+                Q: 'kubejs:field_stabilised_omnic_pulsar_compound',
+                U: 'gtceu:subatomic_digital_assembler', 
+                R: 'gtceu:uiv_robot_arm',
+                F: 'gtceu:uiv_field_generator',
+                O: 'gtceu:uiv_sensor',
+                P: 'kubejs:monic_processor_mainframe',
+                H: 'gtceu:max_machine_hull',
+                V: 'kubejs:infinity_file',
+                W: 'kubejs:infinity_screwdriver',
+                X: 'kubejs:infinity_wrench',
+                Y: 'kubejs:infinity_hammer',
+                Z: 'kubejs:infinity_wire_cutter'            
+            }
+        )
+        }
+    
 
     // Creative Catalyst augment
     event.recipes.extendedcrafting.shaped_table(

--- a/kubejs/server_scripts/_hardmode/expert_missions.js
+++ b/kubejs/server_scripts/_hardmode/expert_missions.js
@@ -10,6 +10,21 @@ ServerEvents.recipes(event => {
             .EUt(1966080)
     }
 
+    //Manual fix for half tier miners
+    event.recipes.gtceu.assembly_line(`stable_t4half`)
+        .itemInputs(`kubejs:microminer_t4half`, 'kubejs:heart_of_a_universe', '4x kubejs:abyss_shard', '24x gtceu:uv_field_generator', '7x gtceu:dense_iridium_plate', '7x gtceu:dense_iridium_plate', '7x gtceu:dense_iridium_plate', '7x gtceu:dense_iridium_plate')
+        .inputFluids('gtceu:rocket_fuel 40800', 'gtceu:omnium 576', 'gtceu:neutronium 576')
+        .itemOutputs(`kubejs:stabilized_microminer_t4half`)
+        .duration(125)
+        .EUt(1966080)
+
+    event.recipes.gtceu.assembly_line(`stable_t8half`)
+        .itemInputs(`kubejs:microminer_t8half`, 'kubejs:heart_of_a_universe', '4x kubejs:abyss_shard', '24x gtceu:uv_field_generator', '7x gtceu:dense_iridium_plate', '7x gtceu:dense_iridium_plate', '7x gtceu:dense_iridium_plate', '7x gtceu:dense_iridium_plate')
+        .inputFluids('gtceu:rocket_fuel 40800', 'gtceu:omnium 576', 'gtceu:neutronium 576')
+        .itemOutputs(`kubejs:stabilized_microminer_t8half`)
+        .duration(125)
+        .EUt(1966080)
+
     // Pristine matter recipe
     function pristine_matter(tier, microtier) {
         if (microtier == 1) {

--- a/kubejs/server_scripts/_hardmode/hardmode.js
+++ b/kubejs/server_scripts/_hardmode/hardmode.js
@@ -48,8 +48,14 @@ ServerEvents.recipes(event => {
             .EUt(480)
             .duration(100)
         }
-    
+
         event.replaceInput({ output: 'buildinggadgets2:gadget_exchanging' }, 'minecraft:redstone', 'gtceu:iv_emitter')
+
+        event.remove({ output: 'gtceu:extractor/tank_data' })
+        event.recipes.gtceu.extractor('omnicdata')
+        .itemInputs('kubejs:heart_of_a_universe')
+        .itemOutputs('kubejs:omnic_data')
+        .duration(1000).EUt(180000)
 
         event.remove({ id: "watercollector:watercollector" })
         event.remove({ id: "thermal:device_rock_gen" })

--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -780,7 +780,15 @@ ServerEvents.recipes(event => {
         .chancedOutput('gtceu:lutetium_dust', 600, 0)
         .chancedOutput('gtceu:europium_dust', 600, 0)
         .duration(50).EUt(1966080)
- 
+        
+    // Quantum Flux Recipe
+    event.recipes.gtceu.mixer('quantum_flux_hm')
+        .itemInputs('redstone_arsenal:flux_gem')
+        .inputFluids(Fluid.of('kubejs:molten_primal_mana', 250))
+        .itemOutputs('8x kubejs:quantum_flux')
+        .duration(100)
+        .EUt(480)
+        
         //Commented out in favor of GCYM's chain
 
         // event.recipes.gtceu.chemical_reactor('kubejs:chemical_reactor/durene_hm')

--- a/kubejs/server_scripts/gregtech/Custom_Ore_Veins.js
+++ b/kubejs/server_scripts/gregtech/Custom_Ore_Veins.js
@@ -71,6 +71,11 @@ GTCEuServerEvents.oreVeins(event => {
 
 })
 
+//Remove Naquadah veins
+GTCEuServerEvents.oreVeins(event => {
+    event.remove("gtceu:naquadah_vein") 
+})
+
 GTCEuServerEvents.fluidVeins(event => {
 
     event.add('kubejs:void/oil', vein => {

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -410,7 +410,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.advanced_microverse_ii('kubejs:t_ten_second')
         .itemInputs(
             'kubejs:microminer_t10', 
-            '16x minecraft:netherite_block',
+            '16x #forge:storage_blocks/netherite',
             '64x kubejs:stellar_creation_data'
         )
         .itemOutputs('kubejs:creative_storage_data')

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -481,6 +481,12 @@ ServerEvents.recipes(event => {
         .duration(900)
         .EUt(180000)
 
+    event.recipes.gtceu.advanced_microverse_iii('kubejs:t_four_fourth')
+        .itemInputs('kubejs:microminer_t4', '64x kubejs:ultra_dense_hydrogen', '64x kubejs:ultra_dense_hydrogen', '64x kubejs:ultra_dense_hydrogen', '64x kubejs:ultra_dense_hydrogen', '1x gtceu:data_module', '1x gtceu:uhv_sensor')
+        .itemOutputs('64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data') 
+        .duration(600)
+        .EUt(180000)
+
     event.recipes.gtceu.advanced_microverse_iii('kubejs:t_eleven_second')
         .itemInputs('kubejs:microminer_t11','4x gtceu:max_battery', '2x solarflux:sp_custom_infinity', 'gtceu:uiv_energy_output_hatch','4x kubejs:universe_creation_data',  '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data') // could be increased 
         .itemOutputs('kubejs:creative_energy_data')

--- a/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
+++ b/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
@@ -58,6 +58,16 @@ ServerEvents.recipes(event => {
         sda_print('creative_storage_data', 3, 'gtceu:uhv_quantum_tank')
     }
 
+    if (!isNormalMode) {
+        event.recipes.gtceu.subatomic_digital_assembly("omnicdata")
+        .notConsumable('kubejs:omnic_data')
+        .itemOutputs('kubejs:mote_of_omnium')
+        .EUt(16000)
+        .circuit(1)
+        .CWUt(16)
+        .duration(10)
+    }
+
     if (!isHarderMode) {
         sda_print('creative_energy_data', 3, 'gtceu:creative_energy')
     }

--- a/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
+++ b/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
@@ -61,7 +61,7 @@ ServerEvents.recipes(event => {
     if (!isNormalMode) {
         event.recipes.gtceu.subatomic_digital_assembly("omnicdata")
         .notConsumable('kubejs:omnic_data')
-        .itemOutputs('kubejs:mote_of_omnium')
+        .itemOutputs('gtceu:omnium_nugget')
         .EUt(16000)
         .circuit(1)
         .CWUt(16)

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -680,6 +680,7 @@ ServerEvents.recipes(event => {
         .itemOutputs('2x gtceu:fluix_gem')
         .duration(20)
         .EUt(7)
+        .circuit(3)
 
     // cable recipes
     event.remove({ id: "ae2:network/cables/covered_fluix" })

--- a/kubejs/server_scripts/mods/extended_crafting.js
+++ b/kubejs/server_scripts/mods/extended_crafting.js
@@ -91,7 +91,7 @@ ServerEvents.recipes(event => {
     ], {
         S: 'gtceu:black_steel_plate',
         L: 'extendedcrafting:luminessence',
-        A: 'gtceu:osmiridium_plate',
+        A: 'gtceu:hssg_plate',
         B: 'extendedcrafting:crystaltine_ingot'
     })
 

--- a/kubejs/server_scripts/mods/optionalCompats/create.js
+++ b/kubejs/server_scripts/mods/optionalCompats/create.js
@@ -154,6 +154,7 @@ if (Platform.isLoaded('create')) {
             .itemOutputs('create:rose_quartz')
             .duration(200)
             .EUt(16)
+            .circuit(6)
         event.recipes.gtceu.sifter("kubejs:polished_rose_quartz")
             .itemInputs('create:rose_quartz')
             .itemOutputs('create:polished_rose_quartz')

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -118,11 +118,14 @@ ServerEvents.recipes(event => {
     }
     ).id('gtceu:shaped/mv_macerator')
     // Data Stuff
+    
+    if (isNormalMode) {
     event.recipes.gtceu.extractor("tank_data")
         .itemInputs("kubejs:heart_of_a_universe")
         .itemOutputs("kubejs:creative_tank_data")
         .duration(1000)
         .EUt(180000)
+    }
 
     // Crystal Chip shit
     event.recipes.gtceu.autoclave("starter_enderium_chip")
@@ -636,4 +639,9 @@ ServerEvents.recipes(event => {
 
     // Electrum
     event.replaceInput({ id: /redstone_arsenal/ }, 'redstone_arsenal:flux_metal_block', 'gtceu:electrum_flux_block')
+
+
+
+
 })
+ 

--- a/kubejs/startup_scripts/material_registry/endgame.js
+++ b/kubejs/startup_scripts/material_registry/endgame.js
@@ -43,7 +43,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .element(GTElements.get("infinity"))
         .color(0xffffff)
         .iconSet('infinity')
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD,  GTMaterialFlags.GENERATE_LONG_ROD, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_ROUND, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_SMALL_GEAR, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.GENERATE_FRAME)
+        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD,  GTMaterialFlags.GENERATE_LONG_ROD, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_ROUND, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_SMALL_GEAR, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE)
         
     event.create('monium')
         .ingot()
@@ -75,5 +75,5 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     GTMaterials.Zeron100.addFlags(GTMaterialFlags.GENERATE_DENSE)
     GTMaterials.get('gcyr:bisalloy_400').addFlags(GTMaterialFlags.GENERATE_DENSE)
     GTMaterials.BlueAlloy.addFlags(GTMaterialFlags.GENERATE_DENSE)
-    GTMaterials.Neutronium.addFlags(GTMaterialFlags.GENERATE_LONG_ROD, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_ROUND, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_SMALL_GEAR, GTMaterialFlags.GENERATE_BOLT_SCREW)
+    GTMaterials.Neutronium.addFlags(GTMaterialFlags.GENERATE_LONG_ROD, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_ROUND, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_SMALL_GEAR, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.GENERATE_DENSE)
 })


### PR DESCRIPTION
Hardmode Relevant Changes

- Fully replaced Creative Tank Data with Omnic Data, a new data that can be used in the Subatomic Digital Assembler to create Omnium Nuggets. Post Stabilization HM players will cry... less. Omnic Data is used in place of Creative Tank Data for HM players in the Creative Chest recipe.
- Added the recipe from Nomi CEu to make Quantum Flux in the mixer so people can actually progress in MMs without going to the moon
- Forced stabilization recipes for the T4.5 and T8.5 micro miners

Everything Else

- Added new recipe in the Hyperbolic Microverse Projector that mass produces Stellar Creation Data using T4MM
- Gave Fluix recipe and Rose Quartz (create compat) recipe separate circuit numbers to stop a recipe conflict (mentioned in #29)
- Added Dense Neutronium and Infinity plates, as those were intended to be used in high tier World Accelerator recipes
- Swapped Osmiridium Plates in Crystaltine Components for HSS-G plates
- Removed Naquadah veins from the end
- Changed Creative Storage Data recipe to accept any type of Netherite block instead of the uncraftable vanilla Minecraft Netherite blocks