### PR TITLE
Adding UEV+ Energy Hatches

### DIFF
--- a/kubejs/server_scripts/gregtech/Post_UV_Components.js
+++ b/kubejs/server_scripts/gregtech/Post_UV_Components.js
@@ -67,6 +67,13 @@ ServerEvents.recipes(event => {
                 .inputFluids('gtceu:crystal_matrix 11520', 'gtceu:soldering_alloy 5760')
                 .duration(1000)
                 .EUt(eut)
+                
+            event.recipes.gtceu.assembly_line(`gtceu:${tier}_energy_input_hatch`)
+                .itemInputs(`gtceu:${tier}_machine_hull`, `4x gtceu:${mat2}_single_wire`, '16x gtceu:uhpic_chip', `#gtceu:circuits/${tier}`, `2x gtceu:${mat2}_double_wire`)
+                .itemOutputs(`gtceu:${tier}_energy_input_hatch`)
+                .inputFluids('gtceu:sodium_potassium 12000', 'gtceu:omnium 1152', 'gtceu:soldering_alloy 576')
+                .duration(100)
+                .EUt(eut)
 
                 //event.recipes.gtceu.assembler(`gtceu:${tier}_energy_input_hatch_4a`)
                // .itemInputs(`gtceu:${tier}_energy_input_hatch`, `2x gtceu:${mat1}_plate`, `2x gtceu:${mat2}_quadruple_wire`)


### PR DESCRIPTION
This is progression critical! Currently, there is no way to do UIV+ recipes such as the Creative Energy or T12MM missions since your recipe overclock tier is capped out at UEV.