### PR TITLE
New dilithium mission

### DIFF
--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -279,6 +279,25 @@ ServerEvents.recipes(event => {
 
 // Advanced Microverse II Recipes
 ServerEvents.recipes(event => {
+
+    event.recipes.gtceu.advanced_microverse_ii('kubejs:t_two_fourth')
+    .itemInputs(
+        'kubejs:microminer_t2', 
+        'gtceu:advanced_power_thruster', 
+        'kubejs:gem_sensor', 
+        '64x kubejs:quantum_flux'
+    )
+    .itemOutputs('64x gtceu:endstone_dilithium_ore', 
+        '64x gtceu:endstone_dilithium_ore', 
+        '64x gtceu:endstone_dilithium_ore',
+        '64x gtceu:endstone_dilithium_ore',
+        '64x gtceu:endstone_certus_quartz_ore',
+        '64x gtceu:endstone_nether_quartz_ore',
+        '64x gtceu:endstone_monazite_ore',
+    )
+    .duration(600)
+    .EUt(62500)
+
     event.recipes.gtceu.advanced_microverse_ii('kubejs:t_seven_first')
         .itemInputs(
             'kubejs:microminer_t7', 
@@ -430,10 +449,12 @@ ServerEvents.recipes(event => {
         .itemOutputs('kubejs:creative_data_hatch_data')
         .duration(3000)
         .EUt(1000000)
+
 })
 
 // Advanced Microverse III
 ServerEvents.recipes(event => {
+
     event.recipes.gtceu.advanced_microverse_iii('kubejs:t_nine_third')
         .itemInputs(
             'kubejs:microminer_t9', 

--- a/kubejs/server_scripts/mods/kubeJS.js
+++ b/kubejs/server_scripts/mods/kubeJS.js
@@ -243,14 +243,6 @@ ServerEvents.recipes(event => {
         .duration(400)
         .EUt(110)
 
-    event.recipes.gtceu.macerator('dilithium_dust')
-        .itemInputs('gtceu:dilithium_ore')
-        .itemOutputs('2x gtceu:dilithium_dust')
-        .duration(200)
-        .EUt(420)
-
-    event.recipes.minecraft.smelting('gtceu:dilithium_dust', 'gtceu:dilithium_ore')
-
     event.remove({ output: 'gtceu:infinity_plate' })
     event.recipes.gtceu.bender('infinity_plate')
         .itemInputs('gtceu:infinity_ingot')

--- a/kubejs/startup_scripts/Block_Registry.js
+++ b/kubejs/startup_scripts/Block_Registry.js
@@ -127,12 +127,12 @@ StartupEvents.registry("block", event => {
 			.requiresTool(true);
 
     //EMERGENCY FIX
-    event.create('gtceu:dilithium_ore')
+    /*event.create('gtceu:dilithium_ore')
 		.soundType('stone')
 		.hardness(2)
 		.resistance(2)
 		.tagBlock("mineable/pickaxe")
-		.requiresTool();
+		.requiresTool();*/
 
     //Casing stuff
 
@@ -196,14 +196,12 @@ StartupEvents.registry("block", event => {
         .hardness(5)
         .requiresTool(true)
         .soundType('metal')
-        .tagBlock("mineable/pickaxe")
         .textureOverrideRenderer('minecraft:block/cube_all', {'all': new ResourceLocation('kubejs', 'block/omnium/casing')})
         
     event.create('dimensional_stabilization_netherite_casing', 'gtceu:renderer')
         .hardness(5)
         .requiresTool(true)
         .soundType('metal')
-        .tagBlock("mineable/pickaxe")
         .textureOverrideRenderer('minecraft:block/cube_all', {'all': new ResourceLocation('kubejs', 'block/netherite/casing')})
 
     event.create('omnic_matrix_coil_block', 'gtceu:coil')
@@ -216,7 +214,8 @@ StartupEvents.registry("block", event => {
         .hardness(5)
         .requiresTool(true)
         .soundType('metal')
-        .tagBlock("mineable/pickaxe")
+
+
 });
 
 // StartupEvents.registry('block', event => {

--- a/kubejs/startup_scripts/material_registry/misc.js
+++ b/kubejs/startup_scripts/material_registry/misc.js
@@ -21,8 +21,12 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 GTCEuStartupEvents.registry('gtceu:material', event => {
     event.create("dilithium")
         .dust()
+        .ore(2, 1)
         .color(0xd1b5b4)
         .iconSet(GTMaterialIconSet.CERTUS)
+        .components('2x lithium')
+        .addOreByproducts('lithium', 'cobalt', 'platinum')
+
 })
 
 //PERFECT GEMS
@@ -149,4 +153,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .dust()
         .color(0xD29092)
         .components('2x holmium', '3x oxygen')
+
+
 })
+


### PR DESCRIPTION
New dilithium mission per #345.
Also makes Dilithium a real GregTech ore instead of a fake one. Dilithium has doubled yield compared to before, 4 if you oreproc and 2 if you just smelt. The new dilithium mission gives about 2048 crystals per operation, and also gives End Monazite Ore for the endgame as it is used in Dimensional Processing Units.