### PR TITLE
Attempt 2 at making a EIO Clear Glass recipe

### DIFF
--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -339,6 +339,18 @@ if (isHarderMode) {
         .duration(80)
         .EUt(16)
 
+    // Clear Glass
+    event.recipes.gtceu.alloy_smelter("kubejs:clear_glass_soda_ash")
+        .itemInputs('minecraft:glass', 'gtceu:tiny_soda_ash_dust')
+        .itemOutputs('enderio:clear_glass')
+        .duration(80)
+        .EUt(16)
+    event.recipes.gtceu.alloy_smelter("kubejs:clear_glass_quicklime")
+        .itemInputs('minecraft:glass', 'gtceu:tiny_quicklime_dust')
+        .itemOutputs('enderio:clear_glass')
+        .duration(80)
+        .EUt(16)
+
     // Enlightened fused quartz
     event.recipes.gtceu.alloy_smelter("kubejs:enlightened_fused_quartz")
         .itemInputs('#enderio:fused_quartz', 'minecraft:glowstone')


### PR DESCRIPTION
This time, the recipe is same for all modes (Normal, Hard, Harder)
Both Quicklime and Soda Ash (common glass additives) can be used to provide the player a choice on which recipe they prefer.
1 tiny pile of either dust per Clear Glass because it's a cosmetic block.