### PR TITLE
Added check for HM on stabilized T4.5 and T8.5MM recipes

### DIFF
--- a/kubejs/server_scripts/_hardmode/expert_missions.js
+++ b/kubejs/server_scripts/_hardmode/expert_missions.js
@@ -11,6 +11,7 @@ ServerEvents.recipes(event => {
     }
 
     //Manual fix for half tier miners
+    if (isHardMode) {
     event.recipes.gtceu.assembly_line(`stable_t4half`)
         .itemInputs(`kubejs:microminer_t4half`, 'kubejs:heart_of_a_universe', '4x kubejs:abyss_shard', '24x gtceu:uv_field_generator', '7x gtceu:dense_iridium_plate', '7x gtceu:dense_iridium_plate', '7x gtceu:dense_iridium_plate', '7x gtceu:dense_iridium_plate')
         .inputFluids('gtceu:rocket_fuel 40800', 'gtceu:omnium 576', 'gtceu:neutronium 576')
@@ -24,6 +25,7 @@ ServerEvents.recipes(event => {
         .itemOutputs(`kubejs:stabilized_microminer_t8half`)
         .duration(125)
         .EUt(1966080)
+    }
 
     // Pristine matter recipe
     function pristine_matter(tier, microtier) {


### PR DESCRIPTION
- This broke stuff and this should fix it by not making it pop up in NM