### PR TITLE
Dimensional and Monic Circuit Buffs

### DIFF
--- a/kubejs/server_scripts/Monium.js
+++ b/kubejs/server_scripts/Monium.js
@@ -8,7 +8,7 @@ ServerEvents.recipes(event => {
         .EUt(16380)
 
         event.recipes.gtceu.omnic_forge('singularity_containment_unit')
-        .itemInputs('8x gtceu:monium_plate', '4x gtceu:neutron_reflector', '2x gtceu:uiv_sensor', '2x gtceu:uev_sensor', 'gtceu:uiv_field_generator')
+        .itemInputs('4x gtceu:monium_plate', '4x gtceu:neutron_reflector', '1x gtceu:uev_sensor', '2x gtceu:uhv_sensor', 'gtceu:uev_field_generator')
         .itemOutputs('64x kubejs:singularity_containment_unit')
         .duration(300)
         .EUt(16380)

--- a/kubejs/server_scripts/gregtech/circuits.js
+++ b/kubejs/server_scripts/gregtech/circuits.js
@@ -173,7 +173,7 @@ ServerEvents.recipes(event => {
         event.recipes.gtceu.assembly_line('matter_processor_mainframe')
             .itemInputs('2x gtceu:netherite_frame', '2x kubejs:matter_processor_computer', '64x gtceu:advanced_smd_capacitor', 
             '64x gtceu:advanced_smd_transistor', '64x gtceu:advanced_smd_diode', '64x gtceu:advanced_smd_resistor', '64x gtceu:advanced_smd_inductor', 
-            '64x gtceu:ram_chip', 'kubejs:heart_of_a_universe', '8x gtceu:enriched_naquadah_trinium_europium_duranide_double_wire', 
+            '64x gtceu:ram_chip', '8x gtceu:enriched_naquadah_trinium_europium_duranide_double_wire', 
             '8x gtceu:crystal_matrix_plate') // could replace with omnium frame
             .inputFluids('gtceu:soldering_alloy 1152', 'gtceu:omnium 288')
             .itemOutputs('kubejs:matter_processor_mainframe')
@@ -190,10 +190,10 @@ ServerEvents.recipes(event => {
             .EUt(500000)
 
         event.recipes.gtceu.assembler('dimensional_processing_unit')
-            .itemInputs('2x kubejs:dimensional_circuit_board', 'gtceu:infinity_plate', '2x armorplus:the_ultimate_material', 
-            '2x gtceu:netherite_double_wire', 'gtceu:flawless_monazite_gem',  'gtceu:flawless_glass_gem')
+            .itemInputs('4x kubejs:dimensional_circuit_board', 'gtceu:infinity_plate', '4x armorplus:the_ultimate_material', 
+            '4x gtceu:netherite_double_wire', '2x gtceu:flawless_monazite_gem',  '2x gtceu:flawless_glass_gem')
             .inputFluids('gtceu:soldering_alloy 1152')
-            .itemOutputs('2x kubejs:dimensional_processing_unit')
+            .itemOutputs('4x kubejs:dimensional_processing_unit')
             .duration(100)
             .EUt(1966080)
 
@@ -222,7 +222,7 @@ ServerEvents.recipes(event => {
             .EUt(1966080)
 
         event.recipes.gtceu.assembly_line('dimensional_processor_assembly')
-            .itemInputs('kubejs:dimensional_processing_unit', '3x kubejs:dimensional_processor', '32x kubejs:multidimensional_cpu_chip', 
+            .itemInputs('kubejs:dimensional_processing_unit', '2x kubejs:dimensional_processor', '16x kubejs:multidimensional_cpu_chip', 
             '16x kubejs:complex_smd_capacitor', '16x kubejs:complex_smd_transistor', '16x kubejs:complex_smd_diode', '16x kubejs:complex_smd_resistor', 
             '4x gtceu:ruthenium_trinium_americium_neutronate_single_wire')
             .inputFluids('gtceu:soldering_alloy 1152')
@@ -231,7 +231,7 @@ ServerEvents.recipes(event => {
             .EUt(1966080)
 
         event.recipes.gtceu.assembly_line('dimensional_processor_computer')
-            .itemInputs('kubejs:dimensional_processing_unit', '4x kubejs:dimensional_processor_assembly', '64x kubejs:multidimensional_cpu_chip', 
+            .itemInputs('kubejs:dimensional_processing_unit', '4x kubejs:dimensional_processor_assembly', '32x kubejs:multidimensional_cpu_chip', 
             '32x kubejs:complex_smd_capacitor', '32x kubejs:complex_smd_transistor', '32x kubejs:complex_smd_diode', '32x kubejs:complex_smd_resistor', 
             '16x gtceu:uhpic_chip', '4x gtceu:ruthenium_trinium_americium_neutronate_double_wire')
             .inputFluids('gtceu:soldering_alloy 1152')
@@ -240,7 +240,7 @@ ServerEvents.recipes(event => {
             .EUt(1966080)
 
         event.recipes.gtceu.assembly_line('dimensional_processor_mainframe')
-            .itemInputs('2x gtceu:infinity_frame', '2x kubejs:dimensional_processor_computer', '64x kubejs:complex_smd_capacitor', 
+            .itemInputs('2x gtceu:infinity_frame', '4x kubejs:dimensional_processor_computer', '64x kubejs:complex_smd_capacitor', 
             '64x kubejs:complex_smd_transistor', '64x kubejs:complex_smd_diode', '64x kubejs:complex_smd_resistor', '64x kubejs:complex_smd_inductor', 
             '64x kubejs:hyperdynamic_ram_chip', '8x gtceu:ruthenium_trinium_americium_neutronate_double_wire', '4x gtceu:double_holmium_plate') // could replace with omnium frame
             .inputFluids('gtceu:soldering_alloy 1152')
@@ -258,40 +258,40 @@ ServerEvents.recipes(event => {
             .EUt(2000000)
 
         event.recipes.gtceu.assembler('monic_processing_unit')
-            .itemInputs('2x kubejs:monic_circuit_board', '2x gtceu:monium_plate', '4x gtceu:holmium_double_wire', 'kubejs:ultimate_gem',  
-            'gtceu:exquisite_glass_gem')
+            .itemInputs('8x kubejs:monic_circuit_board', '1x gtceu:monium_plate', '16x gtceu:holmium_double_wire', '4x kubejs:ultimate_gem',  
+            '4x gtceu:exquisite_glass_gem')
             .inputFluids('gtceu:soldering_alloy 1152')
-            .itemOutputs('2x kubejs:monic_processing_unit')
+            .itemOutputs('8x kubejs:monic_processing_unit')
             .duration(100)
             .EUt(3932160)
 
             event.recipes.gtceu.circuit_assembler('monic_processor')
-            .itemInputs('kubejs:monic_processing_unit', '8x kubejs:complex_smd_capacitor', '4x kubejs:complex_smd_transistor', 
-            '4x kubejs:contained_singularity', '4x gtceu:fine_holmium_wire')
-            .inputFluids('gtceu:soldering_alloy 144')
-            .itemOutputs('4x kubejs:monic_processor')
+            .itemInputs('kubejs:monic_processing_unit', '16x kubejs:complex_smd_capacitor', '8x kubejs:complex_smd_transistor', 
+            'kubejs:contained_singularity', '16x gtceu:fine_holmium_wire')
+            .inputFluids('gtceu:soldering_alloy 288')
+            .itemOutputs('32x kubejs:monic_processor')
             .duration(160)
             .EUt(1966080)
 
         event.recipes.gtceu.assembly_line('monic_processor_assembly')
-            .itemInputs('kubejs:monic_processing_unit', '3x kubejs:monic_processor', '16x kubejs:contained_singularity', '16x kubejs:complex_smd_capacitor', 
-            '16x kubejs:complex_smd_transistor', '16x kubejs:complex_smd_diode', '16x kubejs:complex_smd_resistor', '4x gtceu:netherite_single_wire')
+            .itemInputs('kubejs:monic_processing_unit', '8x kubejs:monic_processor', '2x kubejs:contained_singularity', '16x kubejs:complex_smd_capacitor', 
+            '16x kubejs:complex_smd_transistor', '16x kubejs:complex_smd_diode', '16x kubejs:complex_smd_resistor', '16x gtceu:netherite_single_wire')
             .inputFluids('gtceu:soldering_alloy 1152')
-            .itemOutputs('kubejs:monic_processor_assembly')
+            .itemOutputs('8x kubejs:monic_processor_assembly')
             .duration(160)
             .EUt(1966080)
 
         event.recipes.gtceu.assembly_line('monic_processor_computer')
-            .itemInputs('kubejs:monic_processing_unit', '4x kubejs:monic_processor_assembly', '32x kubejs:contained_singularity', 
+            .itemInputs('kubejs:monic_processing_unit', '2x kubejs:monic_processor_assembly', '4x kubejs:contained_singularity', 
             '32x kubejs:complex_smd_capacitor', '32x kubejs:complex_smd_transistor', '32x kubejs:complex_smd_diode', '32x kubejs:complex_smd_resistor', 
             '16x gtceu:uhpic_chip', '4x gtceu:netherite_double_wire')
             .inputFluids('gtceu:soldering_alloy 1152')
-            .itemOutputs('kubejs:monic_processor_computer')
+            .itemOutputs('2x kubejs:monic_processor_computer')
             .duration(200)
             .EUt(1966080)
 
         event.recipes.gtceu.assembly_line('monic_processor_mainframe')
-            .itemInputs('4x gtceu:monium_frame', '2x kubejs:monic_processor_computer', '64x kubejs:complex_smd_capacitor', '64x kubejs:complex_smd_transistor',
+            .itemInputs('4x gtceu:monium_frame', '16x kubejs:monic_processor_computer', '64x kubejs:complex_smd_capacitor', '64x kubejs:complex_smd_transistor',
             '64x kubejs:complex_smd_diode', '64x kubejs:complex_smd_resistor', '64x kubejs:complex_smd_inductor', 
             '64x kubejs:contained_singularity', '64x kubejs:contained_singularity', '64x kubejs:multidimensional_cpu_chip', 
             '64x kubejs:hyperdynamic_ram_chip', '64x kubejs:quantum_soc_chip', '4x gtceu:double_infinity_plate', '8x gtceu:sculk_superconductor_double_wire') // could replace with omnium frame

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -498,11 +498,11 @@ ServerEvents.recipes(event => {
         .itemInputs('kubejs:microminer_t11','4x gtceu:max_battery', '2x solarflux:sp_custom_infinity', 'gtceu:uiv_energy_output_hatch','4x kubejs:universe_creation_data',  '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data') // could be increased 
         .itemOutputs('kubejs:creative_energy_data')
         .duration(1200)
-        .EUt(12000000)
+        .EUt(8000000)
 
     event.recipes.gtceu.advanced_microverse_iii('kubejs:t_twelve_first')
-        .itemInputs('kubejs:microminer_t12', '16x gtceu:infinity_ingot', '4x kubejs:universe_creation_data')
-        .itemOutputs('16x gtceu:monium_ingot')
+        .itemInputs('kubejs:microminer_t12', '32x gtceu:infinity_ingot', '4x kubejs:universe_creation_data')
+        .itemOutputs('32x gtceu:monium_ingot')
         .duration(1200)
         .EUt(32000000)
 })

--- a/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
+++ b/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
@@ -34,6 +34,7 @@ ServerEvents.recipes(event => {
     sda_print('creative_data_hatch_data', 1, 'gtceu:creative_data_access_hatch')
     sda_print('creative_energy_data', 1, 'enderio:creative_power')
     sda_print('creative_energy_data', 2, 'ae2:creative_energy_cell')
+    sda_print('creative_energy_data', 3, 'gtceu:creative_energy')
 
     event.recipes.gtceu.subatomic_digital_assembly('kubejs:corrupted_data')
         .itemInputs('kubejs:universe_creation_data')
@@ -66,10 +67,6 @@ ServerEvents.recipes(event => {
         .circuit(1)
         .CWUt(16)
         .duration(10)
-    }
-
-    if (!isHarderMode) {
-        sda_print('creative_energy_data', 3, 'gtceu:creative_energy')
     }
 
 })


### PR DESCRIPTION
A lot to list, TL;DR Dimensional and Monic Processors have gotten massively buffed to make sure they are overall more efficient than previous tiers of circuits. This does notably come with a buff to the Monium mission involving the Tier Twelve Micro Miner.

*Matter Circuits*
- Matter Mainframes got their HotU cost removed since they already require Multidimensional CPUs

*Dimensional Circuits*
- Doubled Infinty Plate : Dimenisonal Processing Unit ratio
-  Reduced Dimensional Processor Assembly cost, now requires half the amount of Multidimensional CPUs and 1 less Dimensional Processor
- Halved the amount of Multidimensional CPUs needed for the Dimensional Computer
- Doubled the amount of Dimensional Computers needed for the Dimensional Mainframe to ensure that initial UIV is still costly after the previous buffs and the previous Infinity Ingot production buff

*Monic Circuits*
- frankly I had to buff these and insane amount
- Increased Monium ingot yield from T12MM from 16 to 32 per mission.
- Singularity Containment Units now cost half the amount of Monium Plates and require lower tier components
- Increased Monium Plate : Monic Processing Unit ratio by like 8x
- Buffed Monic Circuit recipe to only use 1 Contained Singularity, double the amount of Complex SMDs and grant 32 Circuits instead of 4
- Monic Processor Assembly now uses 8 Monic Processors and double the Netherite Wire but uses only 2 Singularities instead of 16, and gives 8 Processor Assemblies
- Monic Computer now only uses 2 Monic Processor Assemblies instead of 4 and 4 Contained Singularities instead of 32, and now gives 2 per recipe.
- The Monic Mainframe now uses 16 Monic Computers instead of 2 to ensure it is still a highly expensive endgame circuit.

*Others*
- The T11MM Creative Energy Mission now costs overall less energy to run, reducing generator spam before you get creative energy. It's also now available in Hardermode.