### PR TITLE
Update LDLib

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -457,7 +457,7 @@
     },
     {
       "projectID": 626676,
-      "fileID": 5316054,
+      "fileID": 5437704,
       "required": true
     },
     {


### PR DESCRIPTION
update ldlib as there's a weird incompatibility with gtceu-1.20.1-1.3.1
fixes the below error that occurs if you don't login into a sp world before connecting to a server

"13:47:39] [Netty Client IO #2/WARN] [com.co.Connectivity/]: Packet data: { "f132075": "translation{key='disconnect.genericReason', args=[Internal Exception: java.lang.NullPointerException: Cannot invoke "net.minecraft.core.HolderLookup$Provider.m254861_(net.minecraft.resources.ResourceKey)" because "this.val$p_255950" is null]}" }"