### PR TITLE
QB Changes

### DIFF
--- a/config/ftbquests/quests/chapters/end_game.snbt
+++ b/config/ftbquests/quests/chapters/end_game.snbt
@@ -2193,7 +2193,7 @@
 		}
 		{
 			dependencies: ["281DE48E7260BC8E"]
-			description: ["&6Abyssal Cores&r are the ultimate tier of &bSculk&r core, used for the most powerful and advanced items."]
+			description: ["&6Hadal Cores&r are the ultimate tier of &bSculk&r core, used for the most powerful and advanced items."]
 			id: "3171F83E24C8F740"
 			shape: "hexagon"
 			size: 1.0d
@@ -2204,7 +2204,7 @@
 				item: { Count: 4b, id: "kubejs:hadal_core" }
 				type: "item"
 			}]
-			title: "Abyssal Cores"
+			title: "Hadal Cores"
 			x: 25.5d
 			y: -9.5d
 		}
@@ -2278,7 +2278,9 @@
 			description: [
 				"You have become Death, destroyer of Universes."
 				""
-				"Might probably be obvious, but this miner gathers a &6Heart of a Universe&r."
+				"Might probably be obvious, but this miner is your sole source of &6Hearts of Universes&r. "
+				""
+				"It also can be used later to obtain &6Creative Storage Data&r and &6Creative Data Hatch Data&r, and is used to obtain &9Contained Singularities&r for &6Monic Circuits&r."
 			]
 			id: "27EBB5AAF8A40F3D"
 			shape: "hexagon"
@@ -2303,6 +2305,7 @@
 			]
 			id: "2EBB9A154522348F"
 			size: 5.0d
+			subtitle: "A winner is you"
 			tasks: [{
 				id: "392DAFD3A4019E34"
 				item: "gtceu:creative_chest"
@@ -3249,7 +3252,7 @@
 		{
 			dependencies: ["07057CDE4E021BA7"]
 			description: [
-				"The &3Hyperbolic Microverse Projector&r is the most powerful projector, capiable of running hundreds of missions in parallel. It can perform all microminer missions, and is capiable of a few of it's own as well. "
+				"The &3Hyperbolic Microverse Projector&r is the most powerful projector, capiable of running hundreds of missions in parallel. It can perform all previous microminer missions, and opens the door to many new microminer missions."
 				""
 				"&6Sneak-right click&r the controller to enable the in-world preview."
 			]
@@ -3267,7 +3270,11 @@
 		}
 		{
 			dependencies: ["1B1D3A66B847D129"]
-			description: ["The &6Dimensional Superassembler&r uses dimensional warping to process hundreds of assembly line recipes at once."]
+			description: [
+				"The &6Dimensional Superassembler&r uses dimensional warping to process hundreds of assembly line recipes at once. "
+				""
+				"Notably, the Dimensional Superassembler bypasses the need to use &9ULV Input Buses&r or &9ordered assembly&r, so you are free to stuff the entirety of a recipe into a single input bus."
+			]
 			id: "73A44214C2B44D53"
 			size: 2.0d
 			tasks: [{
@@ -3417,28 +3424,8 @@
 			id: "0FD9B533BB402B17"
 			shape: "hexagon"
 			tasks: [{
-				id: "7DCC421A0B0BC7F9"
-				item: {
-					Count: 1b
-					id: "itemfilters:or"
-					tag: {
-						items: [
-							{
-								Count: 1b
-								id: "kubejs:ruined_capacitor"
-							}
-							{
-								Count: 1b
-								id: "kubejs:ruined_sensor"
-							}
-							{
-								Count: 1b
-								id: "kubejs:ruined_emitter"
-							}
-						]
-					}
-				}
-				title: "Any ruined item"
+				id: "05C1101C77DE5B22"
+				item: "kubejs:alien_scrap"
 				type: "item"
 			}]
 			title: "&9Scrapping"
@@ -3446,7 +3433,11 @@
 			y: -18.0d
 		}
 		{
-			dependencies: ["0FD9B533BB402B17"]
+			dependencies: [
+				"72996D5B09AC57CF"
+				"23F3219BBE486D2E"
+			]
+			dependency_requirement: "one_completed"
 			description: [
 				"Thankfully, &9Holmium&r itself does not require any special processing, and can just be smelted."
 				""
@@ -3715,7 +3706,7 @@
 		}
 		{
 			dependencies: ["39A09DA3903C5564"]
-			description: ["The strongest circuit needs the strongest SoCs"]
+			description: ["The strongest circuit needs the strongest SoCs."]
 			id: "4DED2A24CB1A56F5"
 			shape: "hexagon"
 			tasks: [{
@@ -3731,7 +3722,9 @@
 				"1B1D3A66B847D129"
 				"1D00150456DEF379"
 			]
+			description: ["An upgraded form of &6Infinity Catalyst&r. It processes 4 &cDormant Infinity Compound Ingots&r at a time, essentially increasing your &6Infinity Ingot&r output per &6Heart of a Universe&r by &e4x&r. They also are recyclable afterwards."]
 			id: "06849E067C88C0E9"
+			subtitle: "Gee that's a lot of Infinity Ingots"
 			tasks: [{
 				id: "0BB7A824F7B03BDC"
 				item: "kubejs:fury_enhanced_infinity_catalyst"
@@ -3742,7 +3735,9 @@
 		}
 		{
 			dependencies: ["68734C70E2D19616"]
+			description: ["The final form of the &6Infinity Catalyst&r. It processes 8 &cDormant Infinity Compound Ingots&r at a time, essentially increasing your &6Infinity Ingot&r output per &6Heart of a Universe&r by &e8x&r."]
 			id: "65B610CF9324F6B2"
+			subtitle: "Spend Monium to make Monium"
 			tasks: [{
 				id: "2A554D0488C990D6"
 				item: "kubejs:serenity_enhanced_infinity_catalyst"
@@ -3750,6 +3745,36 @@
 			}]
 			x: 55.0d
 			y: -26.5d
+		}
+		{
+			dependencies: ["0FD9B533BB402B17"]
+			description: [
+				"&9Ruined Hull&r is more abundant than &9Ruined Machine Parts&r but gives less &9Holmium&r overall. "
+				""
+				"It also drops high-end materials such as &6Neutronium&r, &6Tritanium&r, and &6Crystal Matrix Dust&r, although these are mostly irrelevant to you as you already have the &9Creative Quantum Tank.&r"
+			]
+			id: "72996D5B09AC57CF"
+			shape: "hexagon"
+			tasks: [{
+				id: "24211E4714EDB0E9"
+				item: "kubejs:ruined_hull"
+				type: "item"
+			}]
+			x: 45.75d
+			y: -20.25d
+		}
+		{
+			dependencies: ["0FD9B533BB402B17"]
+			description: ["&9Ruined Machine Parts&r provide greater amounts of &9Holmium&r compared to &9Ruined Hull&r."]
+			id: "23F3219BBE486D2E"
+			shape: "hexagon"
+			tasks: [{
+				id: "6A1B3F762DFA4750"
+				item: "kubejs:ruined_machine_parts"
+				type: "item"
+			}]
+			x: 45.75d
+			y: -18.0d
 		}
 	]
 	title: "End Game"

--- a/config/ftbquests/quests/chapters/fun_with_fusion.snbt
+++ b/config/ftbquests/quests/chapters/fun_with_fusion.snbt
@@ -119,7 +119,7 @@
 		}
 		{
 			dependencies: ["25E1DE210726372E"]
-			description: ["&6Fusion Coils&r are &2no longer EBF coil materials, but they are used in the next Fusion Reactors."]
+			description: ["&6Fusion Coils&r are used in the &2Fusion Reactor MK2&r and &2Fusion Reactor MK3&r."]
 			id: "1183B96529D08326"
 			rewards: [{
 				id: "064FF89D54EB9137"
@@ -212,11 +212,7 @@
 		}
 		{
 			dependencies: ["069773756716E192"]
-			description: [
-				"&2Do you remember Darmstadtium tools in CE? You can make their material now!"
-				""
-				"It is formed by fusing Arsenic and Ruthenium, and is the main material for UV machines."
-			]
+			description: ["&9Darmstadium&r is formed by fusing Arsenic and Ruthenium, and is the main material for UV machines."]
 			id: "3FFC053E3E11D586"
 			rewards: [
 				{
@@ -250,8 +246,6 @@
 		{
 			dependencies: ["069773756716E192"]
 			description: [
-				"&2Doesn't look exactly like Europium anymore.&r"
-				""
 				"To make &9Tritanium&r, you first need to make &9Duranium&r. This is done by fusing molten &9Gallium&r and &9Radon&r in a &3Fusion Reactor Mark 1&r or better."
 				""
 				"Once you have Duranium, you can fuse Tritanium in a &3Fusion Reactor Mark 2&r using the Duranium and molten &9Titanium&r."
@@ -396,7 +390,7 @@
 			description: [
 				"&6Americium Ingots&r are obtained by placing &9NuclearCraft&r Americium isotopes into an &3Extractor&r and solidifying the fluid. As with other GT materials, use the ingot or fluid to forge the other forms."
 				""
-				"&2Americium is used in larger quantities in CEu progression.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. These are also the best &aItem Pipe&r material, in terms of throughput."
+				"&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. These are also the best &aItem Pipe&r material, in terms of throughput."
 			]
 			id: "4A8FB1EF600F0882"
 			rewards: [{
@@ -505,11 +499,11 @@
 		{
 			dependencies: ["32E44FFD602C98DF"]
 			description: [
-				"&6Uranium 233&r is obtained exclusively from the fission of &6TBU Fuels&r."
+				"When you have enough materials, you can craft Uranium isotope clumps into Low-Enriched Uranium 235 Fuel (or &6LEU-235&r, for short). This fuel uses an 8:1 ratio of U238 to U235."
 				""
-				"&6LEU-233&r is made from one &6U233&r and eight &6U238&r."
+				"This fuel is processed in your &3Fission Reactor&r by placing it in the controller. When a redstone signal is applied it will burn the fuel, generating some power from the reactor and after a while you'll get a &6Depleted LEU-235 Fuel&r."
 				""
-				"&6Depleted LEU-233&r will give you various &6Plutonium&r isotopes and some &6Americium&r."
+				"The depleted fuel is separated in a regular &3Centrifuge&r, resulting in many tiny clumps of fissile materials: Uranium 238, &6Neptunium 237&r, &6Plutonium 239&r, and &6Plutonium 241&r."
 			]
 			id: "64B145DC53023119"
 			rewards: [{
@@ -518,16 +512,27 @@
 				type: "item"
 			}]
 			tasks: [{
-				id: "3C221A75335837E3"
-				item: "nuclearcraft:fuel_uranium_leu_233"
+				id: "6F33280EE9C07FE2"
+				item: "nuclearcraft:fuel_uranium_leu_235"
 				type: "item"
 			}]
-			title: "LEU-233"
+			title: "Uranium Fission"
 			x: -2.5d
 			y: -11.0d
 		}
 		{
 			dependencies: ["4BE6C4E7FDF7C71B"]
+			description: [
+				"&oNote: this quest accepts Neptunium 236 or 237.&r"
+				""
+				"Low-Enriched Neptunium 236, or &6LEN-236&r, is the next step in the fissile material fuel chain."
+				""
+				"This fuel requires an 8:1 ratio of &6Neptunium 237&r to &6Neptunium 236&r. Using only the results from Thorium fission, it will take two batches of &6Depleted TBU Fuel&r to make your first LEN fuel."
+				""
+				"Of course, higher order reactions also will result in small amounts of Neptunium that you can work with as well."
+				""
+				"&6Depleted LEN 236&r gives a small bit of Neptunium 237 back, but principally provides &6Plutonium&r and &6Americium&r isotopes."
+			]
 			id: "490F04B181217B28"
 			rewards: [{
 				id: "77276677737EC253"
@@ -539,6 +544,7 @@
 				item: "nuclearcraft:fuel_neptunium_len_236"
 				type: "item"
 			}]
+			title: "Neptunium Fusion"
 			x: -2.5d
 			y: -8.0d
 		}

--- a/config/ftbquests/quests/chapters/into_the_microverse.snbt
+++ b/config/ftbquests/quests/chapters/into_the_microverse.snbt
@@ -385,8 +385,6 @@
 		{
 			dependencies: ["56FB624B384FFAF5"]
 			description: [
-				"&2This is new to CEu! Before, you could only distil Liquid Air."
-				""
 				"&9Ender Air&r, collected from a &3Gas Collector&r, can be sent into the &3Vacuum Freezer&r to turn it into &9Liquid Ender Air&r."
 				""
 				"&9Liquid Ender Air&r can be sent into a &2Distillation Tower&r to break it down into its components."
@@ -1062,7 +1060,11 @@
 			y: 0.0d
 		}
 		{
-			dependencies: ["131EAE1541E9C780"]
+			dependencies: [
+				"131EAE1541E9C780"
+				"6A8764DDD3489EE8"
+			]
+			dependency_requirement: "one_completed"
 			description: ["Place down a &6Waystone&r and set a memorable name and enable &6Global&r if you want other players to access it, in order to be able to easily warp to that location, either using a &6Warp Scroll&r, a &6Warp Stone&r or a second Waystone."]
 			icon: "waystones:waystone"
 			id: "5EB185AD9BD0D069"
@@ -1081,6 +1083,18 @@
 			title: "Thinking with Waystones"
 			x: 9.0d
 			y: -6.0d
+		}
+		{
+			description: ["Waystones also &anaturally generate&r across the world, so nothing is stopping you from simply roaming around and stealing Waystones for your own needs."]
+			icon: "minecraft:ender_eye"
+			id: "6A8764DDD3489EE8"
+			tasks: [{
+				id: "096445386AE9F109"
+				type: "checkmark"
+			}]
+			title: "You Can Also Find One!"
+			x: 9.0d
+			y: -8.5d
 		}
 	]
 	title: "Into The Microverse"

--- a/config/ftbquests/quests/chapters/late_game.snbt
+++ b/config/ftbquests/quests/chapters/late_game.snbt
@@ -262,6 +262,8 @@
 				"* Dense Coal Ore"
 				"* Dense Emerald Ore"
 				"* Dense Redstone Ore&r"
+				""
+				"Eventually, when you unlock the &aHyperbolic Microverse Projector&r, you can also use it to gain a massive amount of &bStellar Creation Data&r at once."
 			]
 			id: "15DBB22E3DC0AFB7"
 			rewards: [{
@@ -900,6 +902,8 @@
 				"&6* Boron Dust"
 				"* Molybdenite Ore"
 				"* Beryllium Ore"
+				""
+				"This microminer will also be important much later, as the sole source of &2Stabilized Oganesson&r."
 			]
 			id: "023197AB7CDBDD6E"
 			rewards: [{
@@ -984,8 +988,8 @@
 				}
 			]
 			title: "Automating Extended Crafting"
-			x: 6.0d
-			y: 3.0d
+			x: 11.25d
+			y: -1.5d
 		}
 		{
 			dependencies: [
@@ -1139,6 +1143,12 @@
 				"&2* Uraninite Ore"
 				"* Iridosmine 80/20 Ore"
 				"* Osmiridium 80/20 Ore"
+				""
+				"Once you reach the &aHyperbolic Microverse Projector&r, this microminer can also get the following:"
+				""
+				"&6* Perfect Diamonds"
+				"&6* Perfect Rubies"
+				"&6* Perfect Cinnabar"
 			]
 			id: "49B872B193268554"
 			rewards: [{
@@ -1203,7 +1213,10 @@
 			y: 20.25d
 		}
 		{
-			dependencies: ["49B872B193268554"]
+			dependencies: [
+				"49B872B193268554"
+				"62AC7103FF9D25FD"
+			]
 			description: ["&9Omnium&r, as the name suggests, is an incredible material composed of all elements and alloys you've encountered so far."]
 			icon: "kubejs:mote_of_omnium"
 			id: "7A7FFE9E89D19A2F"
@@ -1238,7 +1251,7 @@
 			description: [
 				"&2Upgraded forms of the EBF and Vacuum Freezer.&r"
 				""
-				"Accepts any &6Parallel Control Hatch&r, parallelizing up to &e256x&r with the best hatch!."
+				"Accepts any &6Parallel Control Hatch&r, parallelizing up to &e4096x&r with the best hatch!."
 				""
 				"The &aRotary Hearth Furnace&r is quite big!"
 			]
@@ -1799,7 +1812,7 @@
 		{
 			dependencies: ["1CC092A2F2CD4589"]
 			description: [
-				"&9Sculk Cores&r are the first crafting step into &9Hypogen Infusion&r."
+				"&9Mesol Cores&r are the first crafting step into &9Hypogen Infusion&r."
 				""
 				"These serve as the basis for crafting many items and can be upgraded into different tiers of cores via &9Sculk&r."
 			]
@@ -1815,7 +1828,7 @@
 				item: "kubejs:mesol_core"
 				type: "item"
 			}]
-			title: "&9Sculk Cores"
+			title: "&9Mesol Cores"
 			x: 25.25d
 			y: 8.25d
 		}
@@ -1896,7 +1909,7 @@
 		}
 		{
 			dependencies: ["713FAECEE5046121"]
-			description: ["&9Echo Cores&r are the second tier of core, used for intermediate crafting recipes."]
+			description: ["&9Bathyal Cores&r are the second tier of core, used for intermediate crafting recipes."]
 			id: "20CB8F878CADA235"
 			rewards: [{
 				id: "6C1605F1E280EA28"
@@ -1909,7 +1922,7 @@
 				item: "kubejs:bathyal_core"
 				type: "item"
 			}]
-			title: "&9Echo Cores"
+			title: "&9Bathyal Cores"
 			x: 27.25d
 			y: 10.25d
 		}
@@ -1964,7 +1977,7 @@
 				"6391447F1A411281"
 			]
 			description: [
-				"The main source of &9Abyss Shards&r."
+				"The main source of &9Hadal Shards&r."
 				""
 				"&9This microminer is also to bring back Ender dragon eggs and Ender dragon scales, as well as neutronium, depending on the mission&r."
 			]
@@ -2036,7 +2049,7 @@
 		{
 			dependencies: ["0562D9F4C441EAF9"]
 			description: [
-				"&6Resonant Cores&r are the third tier of &bSculk&r core, and are common components of endgame recipes."
+				"&6Abyssal Cores&r are the third tier of &bSculk&r core, and are common components of endgame recipes."
 				""
 				"These cores are made with &6Cryococcus&r and also cost &e3 Billion RF&r to craft."
 			]
@@ -2052,7 +2065,7 @@
 				item: "kubejs:abyssal_core"
 				type: "item"
 			}]
-			title: "&9Resonant Core"
+			title: "&9Abyssal Core"
 			x: 25.25d
 			y: 21.0d
 		}
@@ -2090,6 +2103,8 @@
 				"Combines &bStellar Creation Data&r into the &9Universe Creation Data&r, which is a crucial component for the Tier Ten Micro Miner mission."
 				""
 				"The alternate mission brings a decent quantity of &6Neutronium&r. It might be easier to just make all your Neutronium in the reactor, but it's up to you."
+				""
+				"The Tier Nine Micro Miner will also be important in the Post-Tank game, as it will be your main source of &9Quasi-Stable Neutron Stars&r."
 			]
 			id: "6BF4A76C5B84EEE9"
 			rewards: [{
@@ -2133,7 +2148,7 @@
 		{
 			dependencies: ["03F04B4005F2CBE1"]
 			description: [
-				"&6Abyss Shards&r are a component in &bHypogean infusion&r."
+				"&6Hadal Shards&r are a component in &bHypogean infusion&r."
 				""
 				"They are the base material for abyssal Tier materials and come exclusively from Tier Eight Micro Miners. You'll need the Tier Seven Micro Miner for the &6Lair of the Warden Data&r."
 			]
@@ -2145,11 +2160,11 @@
 			}]
 			shape: "hexagon"
 			tasks: [{
-				id: "31B73CD828CA2128"
-				item: "kubejs:abyss_shard"
+				id: "5E20DE67BAF768B6"
+				item: "kubejs:hadal_shard"
 				type: "item"
 			}]
-			title: "&9Abyss Shards"
+			title: "&9Hadal Shards"
 			x: 27.25d
 			y: 21.0d
 		}
@@ -2209,7 +2224,7 @@
 			description: [
 				"The highest tier of hypogean infusion injectors, used to bring sculk to the lowest temptures. You will these to reach the &9Creative Tank&r."
 				""
-				"Each injector requires four ingots of &6Neutronium&r and four &6Abyss Shards&r, as well as two &6Crystal Matrix&r blocks."
+				"Each injector requires four ingots of &6Neutronium&r and four &6Hadal Shards&r, as well as two &6Crystal Matrix&r blocks."
 				""
 				"Hope you've got those Tier Eight Micro Miners automated."
 			]
@@ -2462,8 +2477,8 @@
 				type: "item"
 			}]
 			title: "&2Implosion Compressor"
-			x: 19.25d
-			y: 1.0d
+			x: 5.9375d
+			y: 24.0625d
 		}
 		{
 			dependencies: ["3E51686E2DBD380F"]
@@ -2480,8 +2495,8 @@
 				item: "minecraft:tnt"
 				type: "item"
 			}]
-			x: 19.25d
-			y: -0.5d
+			x: 3.0d
+			y: 24.0d
 		}
 		{
 			dependencies: ["49D33146A1F417E8"]
@@ -2703,13 +2718,13 @@
 				}
 			]
 			title: "PackagedAuto"
-			x: 9.0d
-			y: 3.0d
+			x: 13.0d
+			y: -1.5d
 		}
 		{
 			dependencies: [
-				"15DBB22E3DC0AFB7"
 				"555BEBF7FD6012B7"
+				"7615FABC8B262803"
 			]
 			description: [
 				"This is the largest Extended Crafting Table, capable of handling 9x9 recipes."
@@ -2725,8 +2740,8 @@
 				type: "item"
 			}]
 			title: "&9Ultimate Crafting Table"
-			x: 6.0d
-			y: 1.0d
+			x: 9.0d
+			y: -1.5d
 		}
 		{
 			dependencies: ["7A7FFE9E89D19A2F"]

--- a/config/ftbquests/quests/chapters/matterenergy.snbt
+++ b/config/ftbquests/quests/chapters/matterenergy.snbt
@@ -899,7 +899,7 @@
 		{
 			dependencies: ["60BC08DE447E5007"]
 			description: [
-				"The ultimate item storage component in &bApplied Energistics&r."
+				"The ultimate item storage component in base &bApplied Energistics&r."
 				""
 				"These have a massive capacity, hundreds of times that of a &61k ME Storage Component&r."
 			]
@@ -1424,6 +1424,73 @@
 			title: "&9Pattern P2P"
 			x: 2.5d
 			y: 7.0d
+		}
+		{
+			dependencies: [
+				"241FADD2C751BE74"
+				"4FAFF184242F5EB8"
+			]
+			description: [
+				"If somehow being able to store over a million items in a single &9256k Item Storage Cell&r isn't enough for you, there is now &eMEGA Cells&r!"
+				""
+				"&eMEGA Cells&r go up to 256M bytes, allowing them to store an insane amount of items. You will need high end materials to make the housings for these cells."
+			]
+			id: "31A4355401B03644"
+			rewards: [{
+				id: "51D92E40EA9356F3"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "125C5CCA8906DC11"
+				item: "megacells:cell_component_1m"
+				type: "item"
+			}]
+			title: "MEGA Cells"
+			x: 7.25d
+			y: -8.0d
+		}
+		{
+			dependencies: ["295E3D32083676E6"]
+			description: ["Run the plates through the respective &3Inscribers&r with &aPresses&r to make the printed plates, then combine the plates and circuit to form the Accumulation Processor."]
+			id: "4FAFF184242F5EB8"
+			rewards: [{
+				id: "444FF1C6F8EEB5AF"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			subtitle: "&6Logic Processors&r are made from a &6Black Steel Plate&r, a &6Silicon Plate&r, and any tier three circuit."
+			tasks: [{
+				id: "4B2E214B3A13DCD5"
+				item: "megacells:accumulation_processor"
+				type: "item"
+			}]
+			x: 7.25d
+			y: 0.5d
+		}
+		{
+			dependencies: [
+				"4FAFF184242F5EB8"
+				"4A96659253CCFACF"
+			]
+			description: [
+				"For the big autocrafters. "
+				""
+				"These Crafting Units can be crafted with &eMEGA Cell Storage Components&r to make even larger crafting units, or can be crafted with &6Engineering Processors&r and &6Standard AE2 Storage Components&r to make denser &9Crafting Co-Processors&r."
+			]
+			id: "0C08F09EBCDFDAD0"
+			rewards: [{
+				id: "23F41A3707BE058F"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "1DE29491688CFFFB"
+				item: "megacells:mega_crafting_unit"
+				type: "item"
+			}]
+			x: 7.25d
+			y: 2.5d
 		}
 	]
 	title: "Matter-Energy"

--- a/config/ftbquests/quests/chapters/mid_game.snbt
+++ b/config/ftbquests/quests/chapters/mid_game.snbt
@@ -648,9 +648,11 @@
 				"&6* Tungstate Ore"
 				"&6* Radium Salt&r"
 				""
-				"As well as the &6Stellar Creation Data&r, which will be useful much, much later."
+				"It is also a primary source of &6Stellar Creation Data&r, which will be useful much, much later."
 				""
-				"&2A new mission is available in CEu. This mission costs HV Electric Pumps and Cryotheum Dust. This nets you Solidified Neon, Xenon and Krypton, although it is better to get those from distilling Liquid Nether and Ender Air, as of the useful byproducts you get, and the tiny amount of each element you get in this mission."
+				"When you eventually obtain the &aAdvanced Microverse Projector II&r, this Micro Miner can perform a mission that gives you large amounts of &6Dilithium Ore&r, as well as &6Certus Quartz, Nether Quartz, and Monazite Ore.&r"
+				""
+				"&2A new mission is available in CEu. This mission costs HV Electric Pumps and Cryotheum Dust. This nets you Solidified Neon, Xenon and Krypton, although it is better to get those from distilling Liquid Nether and Ender Air, as of the useful byproducts you get, and the tiny amount of each element you get in this mission.&r"
 			]
 			id: "53C00EA9D9BEE776"
 			rewards: [{
@@ -1820,7 +1822,18 @@
 				"&6* Redstone Ore"
 				"&6* Certus Quartz Ore"
 				"&6* Almandine Ore"
-				"&6* Lepidolite Ore&r"
+				"&6* Lepidolite Ore"
+				"&2* Cobaltite Ore"
+				"&2* Laurite Ore"
+				"&2* Cuprorhodsite Ore&r"
+				""
+				"Or with a Super Chest III:"
+				"&6* Salt Ore"
+				"&2* Barite Ore"
+				"&2* Neodymium Ore"
+				"&2* Apatite Ore"
+				"&2* Chromite Ore"
+				"&2* Pyrope Ore"
 				""
 				"When equipped with Gemstone Sensor:"
 				"&2* Perfect Diamonds"
@@ -1830,6 +1843,8 @@
 				"&6* Sapphire Ore"
 				"&6* Silver Ore"
 				"&6* Gold Ore"
+				""
+				"The Tier Three Micro Miner will also be used to obtain &2Netherite&r in the endgame."
 			]
 			id: "664107ED03A944CD"
 			rewards: [{
@@ -2254,9 +2269,9 @@
 		{
 			dependencies: ["605062720747B482"]
 			description: [
-				"&2This is the highest tier of polymer. It is used in crafting Advanced SMD components, ZPM+ Machine Hulls, among other things."
+				"This is the highest tier of polymer. It is used in crafting &2Advanced SMD components and ZPM+ Machine Hulls,&r among other things."
 				""
-				"This polymer requires at least 14 processing steps to craft. Good luck!"
+				"This polymer can require up to &914 steps&r to create from scratch, but multiple steps are able to be skipped through distillation of various liquids. &6Check what steps you can easily skip!&r"
 			]
 			icon: "gtceu:polybenzimidazole_bucket"
 			id: "51A463024F35DC2E"
@@ -3140,6 +3155,7 @@
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
+			subtitle: "That's it?! That's the nuclear power?!?"
 			tasks: [
 				{
 					id: "1CB0BAF39BD9486E"
@@ -3162,6 +3178,145 @@
 			title: "&9High Pressure Steam"
 			x: 47.0d
 			y: 13.5d
+		}
+		{
+			dependencies: [
+				"0B9D5F865C3F8B31"
+				"555BEBF7FD6012B7"
+				"1321299E1528EF92"
+			]
+			description: [
+				"This is the largest Extended Crafting Table, capable of handling 9x9 recipes."
+				""
+				"&9PackagedAuto is now available, so just use that to automate these recipes."
+			]
+			id: "6BD7144B324B286C"
+			shape: "hexagon"
+			size: 2.0d
+			tasks: [{
+				id: "6CEE1668C0288ACE"
+				item: "extendedcrafting:ultimate_table"
+				type: "item"
+			}]
+			title: "&9Ultimate Crafting Table"
+			x: 35.5d
+			y: 15.5d
+		}
+		{
+			dependencies: [
+				"2181102841205407"
+				"77582C534A994D7C"
+				"22EE79257B57E56B"
+				"6FFF396CDA6A42CE"
+			]
+			description: [
+				"Now that you have &6Osmium&r and &6Iridium&r from the &6Tier Four Micro Miner&r or &6Platinum Group Processing&r, you have access to something vastly better for Extended Crafting Table Automation&r: &bPackagedExCrafting."
+				""
+				"To begin, you'll need to craft one of each extended &3Package Crafter&r listed on the right. Put an &3Unpackager&r on top of each one, and then a &3Packager&r anywhere you want. These are all AE2 devices, so you'll need to connect them to an ME Network."
+				""
+				"Next, right-click the &3Package Recipe Encoder&r, and you should see a button saying \"Processing\": this button cycles through recipe types, including the various Extended Crafting tables. You'll have to choose the appropriate table for the recipe you want to encode."
+				""
+				"&6Holders&r must be encoded in pairs: one for the Packager, and one for the Unpackager. Select the appropriate table for the recipe, look up the recipe you want to encode, and press &6[+]&r in &bREI&r to fill it in. Put two Holders in the top-left slot and press Save to encode the recipe to both of them. Finally, put each Holder into the respective machines."
+				""
+				"If you've done everything correctly, you should see the item appear as craftable in a Terminal."
+				""
+				"While it might seem that the crafting process is slow, &ePackagedAuto is excellent at parallelizing&r. You can surround an Unpackager with Crafters and it will use all of them. It's also possible to add more Unpackagers with Crafters to keep up with the Packager, as long as the Holders are all the same."
+			]
+			icon: "packagedexcrafting:ultimate_crafter"
+			id: "1321299E1528EF92"
+			rewards: [{
+				count: 5
+				id: "352BA907B62D2C5D"
+				item: "kubejs:moni_quarter"
+				type: "item"
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					id: "3A80AB73797B107D"
+					item: "packagedexcrafting:advanced_crafter"
+					type: "item"
+				}
+				{
+					id: "731AC8C89597DEB5"
+					item: "packagedexcrafting:elite_crafter"
+					type: "item"
+				}
+				{
+					id: "122B999D5378E270"
+					item: "packagedexcrafting:ultimate_crafter"
+					type: "item"
+				}
+				{
+					count: 3L
+					id: "4E503219CA818091"
+					item: "packagedauto:unpackager"
+					type: "item"
+				}
+				{
+					count: 3L
+					id: "6CD39F5C3666E39D"
+					item: "packagedauto:packager"
+					type: "item"
+				}
+				{
+					count: 6L
+					id: "797E33035C2F3A99"
+					item: "packagedauto:recipe_holder"
+					type: "item"
+				}
+			]
+			title: "Automating Extended Crafting"
+			x: 37.86989795918369d
+			y: 15.509353741496604d
+		}
+		{
+			dependencies: ["74469710D910C19D"]
+			description: [
+				"&bPackagedAuto&r is an addon for &bApplied Energistics 2&r. Its main purpose in &5Monifactory&r is to allow you to eventually automate &bExtended Crafting&r recipes, but you may come up with other fun uses for it as well."
+				""
+				"&bApplied Energistics 2&r stores recipes in &aPatterns&r, but so far they have been limited to at most 9 stacks of items as input (a standard 3x3 crafting grid). PackagedAuto stores recipes in &aPackage Recipe Holders&r, which don't have this limitation. Additionally, each Holder can store up to &e20 different recipes&r. Holders must be encoded in the &3Package Recipe Encoder&r."
+				""
+				"In the vast majority of situations you'll need two identically-encoded Holders, as the following machines work together."
+				""
+				"The &3Packager&r is a machine that compresses ingredients for a specific recipe into a set of &6Recipe Packages&r. Each package in a set can hold up to 9 stacks of ingredient items. A simple recipe might consist of one package, but a complex recipe can have up to 9 packages in its set (for 81 total item stacks)."
+				""
+				"The &3Unpackager&r is a machine that extracts ingredient items from complete sets of Recipe Packages made in a Packager, ejecting the items into an adjacent inventory. It will only extract the items if &eall packages in a set are present&r."
+				""
+				"When both a Packager and Unpackager are connected to an ME Network and have the same recipe, the resulting item will appear as craftable in your &aTerminal&r."
+				""
+				"&3Packager Extensions&r will act like a clone of an adjacent Packager - including access to patterns in its Package Recipe Holder - allowing you to craft recipe packages faster. Simply place the Packager Extensions around the Packager. Up to 26 extensions in a 3x3x3 cube around the Packager are supported."
+			]
+			disable_toast: true
+			icon: "packagedauto:package"
+			id: "6FFF396CDA6A42CE"
+			shape: "hexagon"
+			tasks: [
+				{
+					id: "014BDF2A6D29355F"
+					item: "packagedauto:packager"
+					type: "item"
+				}
+				{
+					id: "7E2552844A34871F"
+					item: "packagedauto:unpackager"
+					type: "item"
+				}
+				{
+					id: "03B4D4F9D0033DE0"
+					item: "packagedauto:recipe_holder"
+					type: "item"
+				}
+				{
+					id: "292E9C1D30909C24"
+					item: "packagedauto:encoder"
+					type: "item"
+				}
+			]
+			title: "PackagedAuto"
+			x: 39.5d
+			y: 15.5d
 		}
 	]
 	title: "Mid Game"

--- a/config/ftbquests/quests/chapters/progression.snbt
+++ b/config/ftbquests/quests/chapters/progression.snbt
@@ -1197,7 +1197,7 @@
 				""
 				"Once you have Duranium, you can fuse Tritanium in a &3Fusion Reactor Mark 2&r using the Duranium and molten &9Titanium&r."
 				""
-				"If you're having trouble figuring out the right item and fluid ratios for batching up these processes, consider plugging the relevant recipes into the &aCrafting Calculator&r."
+				"If you're having trouble figuring out the right item and fluid ratios for batching up these processes, consider plugging the relevant recipes into &aEMI&r."
 			]
 			disable_toast: true
 			id: "46CD6750E8963351"
@@ -1598,7 +1598,7 @@
 				item: "gtceu:max_machine_hull"
 				type: "item"
 			}]
-			title: "&9Max Circuit"
+			title: "&9MAX Circuit"
 			x: 7.25d
 			y: 11.0d
 		}
@@ -1721,7 +1721,7 @@
 				"2343B68110805282"
 				"434142F777A2CCBE"
 			]
-			description: ["The final processing unit, these require ultimate gems."]
+			description: ["The final processing unit, these require &6Ultimate Gems&r."]
 			id: "7979D07FBDC6D170"
 			tasks: [{
 				id: "3B038F650DFA2526"
@@ -2661,11 +2661,6 @@
 			]
 			description: ["With &6Enderium&r, you can assemble a &6Crystal Processor Supercomputer&r."]
 			id: "26CA20E74A62FA6E"
-			rewards: [{
-				id: "72BB8009C757EA33"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
 			shape: "hexagon"
 			tasks: [{
 				id: "24CC69AAE2D715C1"
@@ -2850,7 +2845,11 @@
 		}
 		{
 			dependencies: ["23A57C125DC0F948"]
-			description: ["[MISSING DESCRIPTION]"]
+			description: [
+				"The prelude to the final coil tier. "
+				""
+				"Traditionally made by combining 9 &9Omnium Nuggets&r into an ingot, but by the time you are making &6Omnic Matrix Coils&r, you will probably already have the &3Creative Quantum Tank&r and be able to simply solidify all the required ingots."
+			]
 			id: "6DF2C1E88BE7CE5F"
 			shape: "hexagon"
 			tasks: [{

--- a/config/ftbquests/quests/chapters/simulating_resources.snbt
+++ b/config/ftbquests/quests/chapters/simulating_resources.snbt
@@ -82,7 +82,7 @@
 				""
 				"Paired with a self-sustaining &bDeep Mob Evolution&r setup, this dynamo can burn through &6Diamonds&r to produce large amounts of &eRF power&r."
 				""
-				"Just like other &bThermal Expansion&r dynamos, the &6Numismatic Dynamo&r can be given tier upgrades to produce more power and gain access to more &aAugment Slots&r."
+				"Just like other &bThermal Expansion&r dynamos, the &6Numismatic Dynamo&r can be given &eAugments&r to produce more power."
 			]
 			id: "6FDF37EE046349F7"
 			rewards: [{
@@ -553,8 +553,6 @@
 		{
 			dependencies: ["7A67E519745A8361"]
 			description: [
-				"&2This is new to CEu! Before, you could only distill Liquid Air."
-				""
 				"&9Nether Air&r, collected from &3Gas Collectors&r, can be sent into the &3Vacuum Freezer&r to turn it into &9Liquid Nether Air&r."
 				""
 				"&9Liquid Nether Air&r can be sent into a &2Distillation Tower&r to break it down into its components."


### PR DESCRIPTION
- Changed all former mentions of Abyss Shards/Cores to Hadal Shards/Cores
- Added mentions of future uses for MMs especially post-tank
- Modified Hyperbolic Microverse Projector Quest to say that it contains many more MM missions instead of just a few
- Modified Dimensional Superassembler Quest to mention it bypasses many requirements needed for normal Assembly Line function
- Added new quests for Ruined Hull and Ruined Machine Parts, modified Endgame questline accordingly
- Added descriptions for Fury and Serenity Enhanced Infinity Catalysts
- Fixed duplicated LEU-233 quest, which is replaced by Uranium Fission Quest
- Added description for Neptunium Fission quest
- Removed all mentions of changes coming from CE to CEu since they're not relevant
- Changed PBI quest description to be less scary
- Added quests relevant to MEGA Cells
- Added description to Omnium Ingots quest in Progression tab
- Added quest in Into the Microverse chapter mentioning how you can steal Waystones from the world
- Moved PackagedAuto and Ultimate Crafting Table related quests to Midgame under HSS-G since they're no longer locked by Osmiridium
- Added funny subtitle to High Pressure Steam quest