### PR TITLE
Remove Monazite

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -996,11 +996,6 @@
       "required": true
     },
     {
-      "projectID": 1015315,
-      "fileID": 5332118,
-      "required": true
-    },
-    {
       "projectID": 693382,
       "fileID": 5188994,
       "required": true


### PR DESCRIPTION
It's functionality has been merged into gtm, and having it breaks EMI compat:
```
[21Jul2024 11:30:34.546] [Thread-80/ERROR] [EMI/]: [EMI] CallbackInfo;)V in monazite.mixins.json:gtm.GTOreVeinWidgetMixin failed injection check, (0
[21Jul2024 11:30:34.546] [Thread-80/ERROR] [EMI/]: [EMI] 1) succeeded. Scanned 1 target(s). Using refmap monazite-1.20.1-refmap.json
```