### PR TITLE
Rebalance Hardmode EnderIO Grain -> XP Juice recipes 

### DIFF
--- a/kubejs/server_scripts/_hardmode/hardmode.js
+++ b/kubejs/server_scripts/_hardmode/hardmode.js
@@ -35,9 +35,9 @@ ServerEvents.recipes(event => {
         const xpjuice = [
             ["enderio:pulsating_powder", 2240],
             ["enderio:vibrant_powder", 4480],
-            ["kubejs:grains_of_innocence", 6720],
-            ["enderio:prescient_powder", 8960],
-            ["enderio:ender_crystal_powder", 11200],
+            ["kubejs:grains_of_innocence", 17920],
+            ["enderio:prescient_powder", 35840],
+            ["enderio:ender_crystal_powder", 44800],
         ]
     
         for (const [input, output] of xpjuice) {


### PR DESCRIPTION
This is so 'compound' crystals become viable XP sources at the cost of more processing, since each of them _cost_ XP juice to manufacture.