### PR TITLE
Change GTCEu glowstone centrifuging recipe to match the mixing recipe for the same.

### DIFF
--- a/kubejs/server_scripts/gregtech/Alloys_Recipes.js
+++ b/kubejs/server_scripts/gregtech/Alloys_Recipes.js
@@ -119,6 +119,8 @@ ServerEvents.recipes(event => {
         .duration(140)
         .EUt(30)
 
+    //Replace default GTCEu glowstone separation recipe to match mixing recipe
+    event.replaceOutput({ id: "gtceu:centrifuge/glowstone_separation" }, 'minecraft:redstone', 'gtceu:tricalcium_phosphate_dust')
     event.recipes.gtceu.mixer("kubejs:glowstone_dust")
         .itemInputs('gtceu:tricalcium_phosphate_dust', '#forge:dusts/gold')
         .itemOutputs('2x minecraft:glowstone_dust')
@@ -145,6 +147,8 @@ ServerEvents.recipes(event => {
         .duration(300)
         .EUt(1920)
 
+    //Remove old rhodium plated palladium recipe
+    event.remove({ id: "gtceu:mixer/rhodium_plated_palladium" })
     event.recipes.gtceu.mixer("kubejs:rhodium_plated_palladium_dust")
         .itemInputs('3x gtceu:palladium_dust', 'gtceu:rhodium_dust', '2x gtceu:lumium_dust')
         .itemOutputs('6x gtceu:rhodium_plated_palladium_dust')

--- a/kubejs/startup_scripts/material_registry/misc.js
+++ b/kubejs/startup_scripts/material_registry/misc.js
@@ -157,7 +157,10 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 })
 
 GTCEuStartupEvents.materialModification(event => {
-    GTMaterials.get("rhodium_plated_palladium").setComponents("3x palladium", "1x rhodium", "2x lumium")
+    GTMaterials.RhodiumPlatedPalladium.setComponents("3x palladium", "1x rhodium", "2x lumium")
     GTMaterials.RhodiumPlatedPalladium.setFormula('Pd3Rh(SnFe)4(CuAg4)2', true)
+
+    GTMaterials.Glowstone.setComponents("1x tricalcium_phosphate", "1x gold")
+    GTMaterials.Glowstone.setFormula('AuCa3(PO4)2', true)
 })
 


### PR DESCRIPTION
This fixes the mixing/centrifuging recipes of Glowstone and Rhodium Plated Palladium.
It also adds a chemical formula to Glowstone.