### PR TITLE
Shortcut Recipes and Misc Recipe Fixes

### DIFF
--- a/config/solarflux/custom_panels.js
+++ b/config/solarflux/custom_panels.js
@@ -120,7 +120,7 @@ function init()
     // Infinity
     panel()
     .name("infinity")
-    .generation(16777216)
+    .generation(33554432)
     .transfer(65536000)
     .capacity(262144000000)
     .build()

--- a/config/solarflux/panels.cfg
+++ b/config/solarflux/panels.cfg
@@ -50,7 +50,7 @@ C "Avaritia"={
 		I "Capacity"=262144000000
 		
 		/* How much FE does this solar panel produce per tick? (Range: [1; 9223372036854775807]) */
-		I "Generation Rate"=16777216
+		I "Generation Rate"=33554432
 		
 		/* How high is this solar panel? (Range: [0.0; 16.0)) */
 		D "Height"=6.0

--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -59,6 +59,14 @@ ServerEvents.recipes(event => {
     .duration(300)
     .EUt(491250)
 
+    // Fluxed Electrum Mixer Recipe
+    event.recipes.gtceu.mixer("mixer_electrum_flux")
+    .itemInputs("6x gtceu:trinium_dust", "gtceu:lumium_dust",  "gtceu:signalum_dust")
+    .itemOutputs("8x gtceu:electrum_flux_dust")
+    .circuit(2)
+    .duration(300)
+    .EUt(129)
+
     // Atomic Casing Buff
     event.remove({ id: 'gcyr:shaped/casing_atomic' })
     event.remove({ id: 'gcyr:assembler/casing_atomic' })

--- a/kubejs/server_scripts/Remove_Recipes.js
+++ b/kubejs/server_scripts/Remove_Recipes.js
@@ -13,6 +13,7 @@ ServerEvents.recipes(event => {
     //GT
     event.remove({ id: 'minecraft:lapis_lazuli_from_smelting_deepslate_lapis_ore' })
     event.remove({ id: 'gtceu:smelting/dust_mythril__demagnetize_from_dust' })
+    event.remove({ id: 'gtceu:mixer/rhodium_plated_palladium' })
     
     //FIXME will get fixed
     event.remove({ id: "gtceu:centrifuge/decomposition_centrifuging__fireclay" })

--- a/kubejs/server_scripts/gregtech/omnic_forge.js
+++ b/kubejs/server_scripts/gregtech/omnic_forge.js
@@ -85,24 +85,30 @@ ServerEvents.recipes(event => {
         .duration(1000)
         .EUt(1966080)
 
-    //Simplified Crafting
-    event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_dark_soularium_thruster')
-    .itemInputs('4x gtceu:dark_soularium_plate', '6x gtceu:vibrant_alloy_plate', '2x enderio:ender_crystal', '2x enderio:prescient_crystal', 'enderio:cryolobus_conduit', 'kubejs:flight_control_unit')
-    .itemOutputs(Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:dark_soularium"}'))
-    .duration(100)
-    .EUt(7680)
+        //Simplified Crafting
+        event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_dark_soularium_thruster')
+        .itemInputs('4x gtceu:dark_soularium_plate', '6x gtceu:vibrant_alloy_plate', '2x enderio:ender_crystal', '2x enderio:prescient_crystal', 'enderio:cryolobus_conduit', 'kubejs:flight_control_unit')
+        .itemOutputs(Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:dark_soularium"}'))
+        .duration(100)
+        .EUt(7680)
 
-    event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_ultra_dense_hydrogen')
-    .itemInputs('64x kubejs:solidified_hydrogen')
-    .itemOutputs('kubejs:ultra_dense_hydrogen')
-    .duration(20)
-    .EUt(120)
+        event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_flux_thruster')
+        .itemInputs('3x redstone_arsenal:flux_plating', '4x gtceu:enderium_plate', '2x gtceu:signalum_plate', 'thermal:dynamo_numismatic', 'kubejs:glowstone_elevation_unit', 'kubejs:cryotheum_coolant_unit')
+        .itemOutputs(Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:fluxed"}'))
+        .duration(50)
+        .EUt(7680)
 
-    event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_quantum_flux')
-    .itemInputs('redstone_arsenal:flux_gem', '2x kubejs:primal_mana', '2x minecraft:dragon_breath', 'minecraft:wither_skeleton_skull')
-    .itemOutputs('32x kubejs:quantum_flux')
-    .duration(50)
-    .EUt(1920)
+        event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_ultra_dense_hydrogen')
+        .itemInputs('64x kubejs:solidified_hydrogen')
+        .itemOutputs('kubejs:ultra_dense_hydrogen')
+        .duration(20)
+        .EUt(120)
+
+        event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_quantum_flux')
+        .itemInputs('redstone_arsenal:flux_gem', '2x kubejs:primal_mana', '2x minecraft:dragon_breath', 'minecraft:wither_skeleton_skull')
+        .itemOutputs('32x kubejs:quantum_flux')
+        .duration(50)
+        .EUt(1920)
 
 
 })

--- a/kubejs/server_scripts/gregtech/omnic_forge.js
+++ b/kubejs/server_scripts/gregtech/omnic_forge.js
@@ -85,4 +85,24 @@ ServerEvents.recipes(event => {
         .duration(1000)
         .EUt(1966080)
 
+    //Simplified Crafting
+    event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_dark_soularium_thruster')
+    .itemInputs('4x gtceu:dark_soularium_plate', '6x gtceu:vibrant_alloy_plate', '2x enderio:ender_crystal', '2x enderio:prescient_crystal', 'enderio:cryolobus_conduit', 'kubejs:flight_control_unit')
+    .itemOutputs(Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:dark_soularium"}'))
+    .duration(100)
+    .EUt(7680)
+
+    event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_ultra_dense_hydrogen')
+    .itemInputs('64x kubejs:solidified_hydrogen')
+    .itemOutputs('kubejs:ultra_dense_hydrogen')
+    .duration(20)
+    .EUt(120)
+
+    event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_quantum_flux')
+    .itemInputs('redstone_arsenal:flux_gem', '2x kubejs:primal_mana', '2x minecraft:dragon_breath', 'minecraft:wither_skeleton_skull')
+    .itemOutputs('32x kubejs:quantum_flux')
+    .duration(50)
+    .EUt(1920)
+
+
 })

--- a/kubejs/server_scripts/gregtech/sculkreverberator.js
+++ b/kubejs/server_scripts/gregtech/sculkreverberator.js
@@ -62,7 +62,7 @@ ServerEvents.recipes(event => {
     Reactor('kubejs_reaction_casing', 'moni_multiblocks:abyssal_coil_block', ['moni_multiblocks:bathyal_coil_block', '2x minecraft:nether_star', '2x kubejs:bathyal_core', '2x minecraft:dragon_egg'], '0.00001', 6000000000)
     Reactor('abyssal_energy_core', 'kubejs:abyssal_energy_core', ['kubejs:bathyal_energy_core', '4x gtceu:cryococcus_ingot', '2x kubejs:abyssal_core', '2x gtceu:energy_module', '2x gtceu:restonia_empowered_block'], '0.00000001', 419430000)
     Reactor('cryococcus_block', '5x gtceu:cryococcus_block', ['5x gtceu:cryolobus_block', '4x kubejs:bathyal_core', '2x kubejs:warden_heart'], '0.00001', 24000000000)
-    Reactor('abyssal_core', 'kubejs:abyssal_core', ['minecraft:nether_star', '4x kubejs:bathyal_core', '2x gtceu:cryococcus_block'], '0.00001', 3000000000)
+    Reactor('abyssal_core', 'kubejs:abyssal_core', ['minecraft:nether_star', '4x kubejs:bathyal_core', '2x gtceu:cryococcus_block', 'kubejs:stabilized_einsteinium'], '0.00001', 3000000000)
     Reactor('hadal_core', 'kubejs:hadal_core', ['minecraft:nether_star', '4x kubejs:hadal_shard', '2x gtceu:neutronium_ingot', '2x gtceu:omnium_ingot'], '0.000000000001', 30000000000)
     Reactor('hadal_warp_engine', 'kubejs:hadal_warp_engine', ['gtceu:cryococcus_frame', 'kubejs:warp_engine', 'gtceu:cryococcus_plate', '2x gtceu:cryolobus_plate', 'kubejs:bathyal_core', 'gtceu:zpm_field_generator', 'kubejs:abyssal_energy_core', 'kubejs:hadal_shard'], '0.000000000001', 30000000000)
 })

--- a/kubejs/server_scripts/gregtech/supercomputer.js
+++ b/kubejs/server_scripts/gregtech/supercomputer.js
@@ -12,7 +12,7 @@ ServerEvents.recipes(event => {
     ////// Machine Recipe //////
 
     event.recipes.gtceu.assembly_line('simulation_supercomputer')
-        .itemInputs('gtceu:atomic_casing', '6x gcyr:trinaquadalloy_plate', '4x hostilenetworks:sim_chamber', '#gtceu:circuits/uev', '4x #gtceu:circuits/uhv', '2x gtceu:uv_robot_arm', '2x gtceu:uv_field_generator', 'kubejs:resonant_energy_core')
+        .itemInputs('gtceu:atomic_casing', '6x gcyr:trinaquadalloy_plate', '4x hostilenetworks:sim_chamber', '#gtceu:circuits/uev', '4x #gtceu:circuits/uhv', '2x gtceu:uv_robot_arm', '2x gtceu:uv_field_generator', 'kubejs:abyssal_energy_core')
         .inputFluids('gtceu:soldering_alloy 1152')
         .itemOutputs('gtceu:simulation_supercomputer')
         // .stationResearch(b => b.researchStack(Item.of('hostilenetworks:simulaton_chamber')).EUt(1966080).CWUt(8192))

--- a/kubejs/server_scripts/gregtech/superfabricator.js
+++ b/kubejs/server_scripts/gregtech/superfabricator.js
@@ -11,7 +11,7 @@ ServerEvents.recipes(event => {
     ////// Machine Recipe //////
 
     event.recipes.gtceu.assembly_line('loot_superfabricator')
-        .itemInputs('gtceu:atomic_casing', '6x gcyr:trinaquadalloy_plate', '4x hostilenetworks:loot_fabricator', '#gtceu:circuits/uev', '4x #gtceu:circuits/uhv', '2x gtceu:uv_robot_arm', '2x gtceu:uv_emitter',  'kubejs:resonant_energy_core')
+        .itemInputs('gtceu:atomic_casing', '6x gcyr:trinaquadalloy_plate', '4x hostilenetworks:loot_fabricator', '#gtceu:circuits/uev', '4x #gtceu:circuits/uhv', '2x gtceu:uv_robot_arm', '2x gtceu:uv_emitter',  'kubejs:abyssal_energy_core')
         .inputFluids('gtceu:soldering_alloy 1152')
         .itemOutputs('gtceu:loot_superfabricator')
         // .stationResearch(b => b.researchStack(Item.of('hostilenetworks:loot_fabricator')).EUt(1966080).CWUt(8192))

--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -410,6 +410,14 @@ if (isHarderMode) {
         .duration(200)
         .EUt(30)
 
+    // Conduit Binder Composite Mixer Recipe
+    event.recipes.gtceu.mixer("kubejs:conduit_binder_composite")
+        .itemInputs('2x minecraft:clay_ball', '3x minecraft:gravel', '2x #minecraft:smelts_to_glass')
+        .itemOutputs('8x enderio:conduit_binder_composite')
+        .duration(64)
+        .EUt(7)
+
+
     // Enchanter
     event.remove({ output: ['enderio:enchanter'] })
     event.shaped(

--- a/kubejs/server_scripts/mods/Iron_Furnaces.js
+++ b/kubejs/server_scripts/mods/Iron_Furnaces.js
@@ -115,4 +115,79 @@ ServerEvents.recipes(event => {
             I: "minecraft:iron_ingot"
         }
     )
+
+    // Assembler Recipes for Iron Furnaces
+    event.recipes.gtceu.assembler('kubejs:stone_to_iron_furnace')
+    .itemInputs('minecraft:furnace', '4x gtceu:iron_plate')
+    .itemOutputs('ironfurnaces:iron_furnace')
+    .duration(200)
+    .EUt(30)
+    .circuit(8)
+
+    event.recipes.gtceu.assembler('kubejs:stone_to_copper_furnace')
+    .itemInputs('minecraft:furnace', '4x gtceu:iron_plate', '4x gtceu:copper_plate')
+    .itemOutputs('ironfurnaces:copper_furnace')
+    .duration(200)
+    .EUt(30)
+    .circuit(8)
+
+    var stonefurnaceupgrade = [
+        ['silver', 'iron', 'copper', 'silver'],
+        ['gold', 'copper', 'silver', 'gold'],
+        ['diamond', 'silver', 'gold', 'diamond'],
+
+    ]
+
+    stonefurnaceupgrade.forEach(([tier, mat1, mat2, mat3]) => {
+        event.recipes.gtceu.assembler('kubejs:stone_to_' + tier + '_furnace')
+        .itemInputs('minecraft:furnace', `2x gtceu:${mat1}_plate`, `4x gtceu:${mat2}_plate`, `4x gtceu:${mat3}_plate`)
+        .itemOutputs(`ironfurnaces:${tier}_furnace`)
+        .duration(300)
+        .EUt(30)
+        .circuit(8)
+        })
+
+    event.recipes.gtceu.assembler('kubejs:stone_to_obsidian_furnace')
+    .itemInputs('2x minecraft:furnace', '4x gtceu:gold_plate', '8x gtceu:diamond_plate', '4x gtceu:obsidian_plate')
+    .itemOutputs('ironfurnaces:obsidian_furnace')
+    .duration(400)
+    .EUt(30)
+    .circuit(8)
+
+    event.recipes.gtceu.assembler('kubejs:stone_to_netherite_furnace')
+    .itemInputs('4x minecraft:furnace', '16x gtceu:diamond_plate', '16x gtceu:obsidian_plate', 'gtceu:black_steel_block', '4x gtceu:black_steel_plate')
+    .itemOutputs('ironfurnaces:netherite_furnace')
+    .duration(500)
+    .EUt(30)
+    .circuit(8)
+
+    var furnaceupgrade = [
+        ['copper', 'iron'],
+        ['silver', 'copper'],
+        ['gold', 'silver'],
+        ['diamond', 'gold'],
+    ]
+
+    furnaceupgrade.forEach(([tier, mat1]) => {
+        event.recipes.gtceu.assembler('kubejs:' + mat1 + '_to_' + tier + '_furnace')
+        .itemInputs(`ironfurnaces:${mat1}_furnace`, `4x gtceu:${tier}_plate`)
+        .itemOutputs(`ironfurnaces:${tier}_furnace`)
+        .duration(300)
+        .EUt(30)
+        .circuit(4)
+        })
+
+    event.recipes.gtceu.assembler('kubejs:diamond_to_obsidian_furnace')
+    .itemInputs('2x ironfurnaces:diamond_furnace', '4x gtceu:obsidian_plate')
+    .itemOutputs('ironfurnaces:obsidian_furnace')
+    .duration(200)
+    .EUt(30)
+    .circuit(4)
+
+    event.recipes.gtceu.assembler('kubejs:obsidian_to_netherite_furnace')
+    .itemInputs('4x ironfurnaces:obsidian_furnace', 'gtceu:black_steel_block', '4x gtceu:black_steel_plate')
+    .itemOutputs('ironfurnaces:netherite_furnace')
+    .duration(200)
+    .EUt(30)
+    .circuit(4)
 })

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -717,6 +717,30 @@ ServerEvents.recipes(event => {
     .duration(40)
     .EUt(30)
 
+    //Cleanroom Hatch
+    event.remove({ id: 'gtceu:shaped/maintenance_hatch_cleaning'})
+    event.shaped(
+        "gtceu:cleaning_maintenance_hatch", [
+        'CMC',
+        'RHR',
+        'WCW'
+    ], {
+        R: "gtceu:luv_robot_arm",
+        W: "gtceu:niobium_titanium_single_cable",
+        M: "gtceu:auto_maintenance_hatch",
+        H: "gtceu:luv_machine_hull",
+        C: "#gtceu:circuits/luv"
+    })
+    
+    //ZPM Field Gen
+    event.remove({ id: 'gtceu:assembly_line/field_generator_zpm'})
+    event.recipes.gtceu.assembly_line('kubejs:assembly_line/zpm_field_generator')
+    .itemInputs('gtceu:naquadah_alloy_frame','6x gtceu:naquadah_alloy_plate', 'gtceu:quantum_star','2x gtceu:zpm_emitter','2x #gtceu:circuits/zpm','64x gtceu:fine_uranium_rhodium_dinaquadide_wire', '64x gtceu:fine_uranium_rhodium_dinaquadide_wire','4x gtceu:vanadium_gallium_single_cable')
+    .inputFluids('gtceu:soldering_alloy 1152', 'gtceu:cryococcus 1152')
+    .itemOutputs('gtceu:zpm_field_generator')
+    .duration(600)
+    .EUt(24000)
+    .stationResearch(b => b.researchStack('gtceu:luv_field_generator').CWUt(4, 16000).EUt(30720))
 
 })
  


### PR DESCRIPTION
- Re-added Abyssal Energy Cores to DME Supercomputer and Superfabricator (previously resonant energy cores, names never got changed in the recipes)
- Abyssal Cores now requires 1 Stabilized Einsteinium, returning Stabilized Einsteinium as being required for T9MM and upwards.
- Removed Rhodium Plated Palladium recipe that didn't have Lumium in it
- Moved Cleaning Maintenance Hatch down from UV to LuV. Rejoice, for now you only have to play Multiblock Tetris for one tier.
- Added back mixer recipe for Fluxed Electrum
- Added Liquid Cryoccocus to the ZPM Field Generator recipe for parity with Nomi CEu
- Added multiple assembler recipes for Iron Furnace mod, primary intent is to reduce the amount of Molecular Assembler operations required to craft higher tier furnaces for Dynamos
- Doubled Infinity Solar's Power output since it takes 4 Neutronium Solars to make anyways and can now be more unironically considered for power pre-Creative Energy
- Added Omnic Forge recipes for Dark Soularium Thruster, Fluxed Thruster, Ultra Dense Hydrogen, and Quantum Flux, all aimed at reducing craft times in the endgame