### PR TITLE
Superconductor Changes and Minor Balancing

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -86,7 +86,7 @@ ServerEvents.recipes(event => {
 
     // Sterilising Filter Casing
     event.shaped(
-        'gtceu:sterilizing_filter_casing', [
+        '4x gtceu:sterilizing_filter_casing', [
             'PEP',
             'FBF',
             'MSR'
@@ -97,7 +97,7 @@ ServerEvents.recipes(event => {
             M: 'gtceu:luv_electric_motor',
             P: 'gtceu:polybenzimidazole_large_fluid_pipe',
             R: 'gtceu:iridium_rotor', 
-            S: 'gtceu:black_steel_frame'
+            S: 'gtceu:tritanium_frame'
         }
     ).id('gtceu:shaped/filter_casing_sterile')
 
@@ -184,6 +184,12 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.implosion_compressor("implosion_compressor_ominium_nugget")
         .itemInputs('kubejs:mote_of_omnium', 'minecraft:tnt')
         .itemOutputs('gtceu:omnium_nugget')
+        .duration(20)
+        .EUt(30)
+
+    event.recipes.gtceu.implosion_compressor("implosion_compressor_ominium_nugget_itnt")
+        .itemInputs('4x kubejs:mote_of_omnium', 'gtceu:industrial_tnt')
+        .itemOutputs('4x gtceu:omnium_nugget')
         .duration(20)
         .EUt(30)
 

--- a/kubejs/server_scripts/gregtech/Alloys_Recipes.js
+++ b/kubejs/server_scripts/gregtech/Alloys_Recipes.js
@@ -265,6 +265,14 @@ ServerEvents.recipes(event => {
         .EUt(16)
         .blastFurnaceTemp(1200)
 
+    // End Steel
+    event.recipes.gtceu.mixer("kubejs:end_steel_dust")
+        .itemInputs('gtceu:dark_steel_dust', 'gtceu:blue_steel_dust', '#forge:dusts/endstone')
+        .itemOutputs('3x gtceu:end_steel_dust')
+        .duration(260)
+        .EUt(120)
+
+
 	// moni ceu 1.7 normal
 	event.recipes.gtceu.electric_blast_furnace('kubejs:dark_soularium_ingot')
 		.itemInputs('#forge:ingots/soularium', '#forge:ingots/dark_steel')

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -515,6 +515,24 @@ ServerEvents.recipes(event => {
     .duration(500)
     .EUt(62500)
 
+    event.recipes.gtceu.advanced_microverse_iii('kubejs:t_eight_fourth')
+    .itemInputs('kubejs:microminer_t8', 
+                '64x kubejs:quantum_flux', 
+                '64x kubejs:dilithium_crystal', 
+                '64x kubejs:dilithium_crystal', 
+                '64x kubejs:dilithium_crystal', 
+                '64x kubejs:dilithium_crystal', 
+                '64x minecraft:sculk_catalyst', 
+                'kubejs:shattered_universe_data',
+                'kubejs:lair_of_the_warden_data')
+    .itemOutputs('64x kubejs:hadal_shard',
+                 '64x kubejs:warden_heart',
+                 '64x kubejs:warden_horn',
+                 '64x kubejs:warden_horn'
+    )
+    .duration(2000)
+    .EUt(180000)
+
         event.recipes.gtceu.advanced_microverse_iii('kubejs:t_nine_forth')
         .itemInputs(
             'kubejs:microminer_t9', 

--- a/kubejs/server_scripts/gregtech/omnic_forge.js
+++ b/kubejs/server_scripts/gregtech/omnic_forge.js
@@ -105,8 +105,8 @@ ServerEvents.recipes(event => {
         .EUt(120)
 
         event.recipes.gtceu.omnic_forge('kubejs:omnic_forge_quantum_flux')
-        .itemInputs('redstone_arsenal:flux_gem', '2x kubejs:primal_mana', '2x minecraft:dragon_breath', 'minecraft:wither_skeleton_skull')
-        .itemOutputs('32x kubejs:quantum_flux')
+        .itemInputs('redstone_arsenal:flux_gem', '4x kubejs:primal_mana', '2x enderio:ender_crystal_powder', 'gtceu:nether_star_dust')
+        .itemOutputs('64x kubejs:quantum_flux')
         .duration(50)
         .EUt(1920)
 

--- a/kubejs/server_scripts/mods/DraconicEvolution.js
+++ b/kubejs/server_scripts/mods/DraconicEvolution.js
@@ -27,6 +27,12 @@ ServerEvents.recipes(event => {
         C: "gtceu:palis_empowered_block"
     }).id('kubejs:components/mesol_core')
 
+    event.recipes.gtceu.assembler("kubejs:mesol_core_assembler")
+    .itemInputs("gtceu:palis_empowered_block", "4x gtceu:tungsten_carbide_ingot", "4x gtceu:cryolobus_ingot")
+    .itemOutputs("kubejs:mesol_core")
+    .duration(100)
+    .EUt(30)
+
     event.shaped('kubejs:bathyal_energy_core', [
         'ABA',
         'BCB',
@@ -36,5 +42,11 @@ ServerEvents.recipes(event => {
         B: "gtceu:restonia_empowered_block",
         C: "gtceu:lapotronic_energy_orb"
     }).id('kubejs:components/bathyal_energy_core')
+
+event.recipes.gtceu.assembler("kubejs:bathyal_energy_core_assembler")
+    .itemInputs("gtceu:lapotronic_energy_orb", "4x gtceu:restonia_empowered_block", "4x kubejs:bathyal_core")
+    .itemOutputs("kubejs:bathyal_energy_core")
+    .duration(100)
+    .EUt(30)
 
 })

--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -380,11 +380,12 @@ if (isHarderMode) {
         .EUt(32)
 
     // Stellar Alloy
-    event.recipes.gtceu.alloy_smelter('kubejs:stellar_alloy')
-        .itemInputs('gtceu:end_steel_ingot', '8x enderio:grains_of_infinity')
+    event.recipes.gtceu.autoclave('kubejs:stellar_alloy')
+        .itemInputs('gtceu:lumium_ingot', '2x enderio:grains_of_infinity')
+        .inputFluids('gtceu:nether_star 72')
         .itemOutputs('gtceu:stellar_alloy_ingot')
         .duration(200)
-        .EUt(2000)
+        .EUt(480)
 
     // Remove useless/op conduit recipes from enderio
     event.remove({ input: '#enderio:fused_quartz', output: 'enderio:pressurized_fluid_conduit' })

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -255,13 +255,13 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.arc_furnace("sterile_filter_recycling")
         .itemInputs("gtceu:sterilizing_filter_casing")
         .inputFluids("gtceu:oxygen 1265")
-        .itemOutputs("4x gtceu:iridium_ingot", "2x gtceu:black_steel_ingot", "6x gtceu:small_ash_dust")
+        .itemOutputs("4x gtceu:iridium_ingot", "2x gtceu:tritanium_ingot", "6x gtceu:small_ash_dust")
         .duration(691)
         .EUt(30)
 
     event.recipes.gtceu.macerator("sterile_filter_crushing")
         .itemInputs("gtceu:sterilizing_filter_casing")
-        .itemOutputs("12x gtceu:polybenzimidazole_dust", "4x gtceu:iridium_dust", "2x gtceu:black_steel_dust")
+        .itemOutputs("12x gtceu:polybenzimidazole_dust", "4x gtceu:iridium_dust", "2x gtceu:tritanium_dust")
         .duration(696)
         .EUt(32)
 
@@ -725,11 +725,11 @@ ServerEvents.recipes(event => {
         'RHR',
         'WCW'
     ], {
-        R: "gtceu:luv_robot_arm",
-        W: "gtceu:niobium_titanium_single_cable",
+        R: "gtceu:iv_robot_arm",
+        W: "gtceu:graphene_single_cable",
         M: "gtceu:auto_maintenance_hatch",
-        H: "gtceu:luv_machine_hull",
-        C: "#gtceu:circuits/luv"
+        H: "gtceu:iv_machine_hull",
+        C: "#gtceu:circuits/iv"
     })
     
     //ZPM Field Gen
@@ -741,6 +741,19 @@ ServerEvents.recipes(event => {
     .duration(600)
     .EUt(24000)
     .stationResearch(b => b.researchStack('gtceu:luv_field_generator').CWUt(4, 16000).EUt(30720))
+
+    // Quantum Ring Assembler Recipes
+    event.recipes.gtceu.assembler('kubejs:quantum_ring')
+        .itemInputs('4x gtceu:stainless_steel_plate', '2x ae2:calculation_processor', '2x ae2:engineering_processor', 'gtceu:quantum_star')
+        .itemOutputs('ae2:quantum_ring')
+        .duration(100)
+        .EUt(30)
+
+    event.recipes.gtceu.assembler('kubejs:quantum_link')
+        .itemInputs('4x ae2:fluix_pearl', '4x ae2:quartz_glass', 'gtceu:certus_quartz_plate')
+        .itemOutputs('ae2:quantum_link')
+        .duration(100)
+        .EUt(30)
 
 })
  

--- a/kubejs/startup_scripts/material_registry/eio.js
+++ b/kubejs/startup_scripts/material_registry/eio.js
@@ -55,8 +55,10 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .ingot().fluid()
         .color(0xd6d980).iconSet('metallic')
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR)
+        .blastTemp(3600, 'mid', 480, 900)
         .toolStats(new ToolProperty(4.0, 3.5, 1024, 3, []))
-        .cableProperties(2048, 1, 0, true)
+        .cableProperties(2048, 4, 0, true)
+        .components('dark_steel', 'endstone', 'blue_steel')
 
     event.create("dark_soularium")
         .ingot()
@@ -65,5 +67,6 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     event.create("stellar_alloy")
         .ingot().fluid()
+        .cableProperties(8192, 4, 0, true)
         .color(0xc5c8c8).iconSet('metallic')
 })

--- a/kubejs/startup_scripts/material_registry/elements.js
+++ b/kubejs/startup_scripts/material_registry/elements.js
@@ -11,7 +11,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .color(0x042228).iconSet('metallic')
         .blastTemp(6800, 'higher')
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FRAME)
-        .cableProperties(524288, 1, 0, true);
+        .cableProperties(524288, 8, 0, true);
 
     event.create("cryococcus")
         .ingot().fluid()

--- a/kubejs/startup_scripts/material_registry/endgame.js
+++ b/kubejs/startup_scripts/material_registry/endgame.js
@@ -36,7 +36,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .color(0xffffff)
         .iconSet('shiny')
         .flags(GTMaterialFlags.NO_SMELTING, GTMaterialFlags.NO_SMASHING)
-        .cableProperties(524288, 4, 0, true)
+        .cableProperties(524288, 16, 0, true)
 
     event.create('infinity')
         .ingot()

--- a/kubejs/startup_scripts/material_registry/thermal.js
+++ b/kubejs/startup_scripts/material_registry/thermal.js
@@ -25,15 +25,15 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .blastTemp(4000, 'mid', 7680, 1400)
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR)
 		.components('4x annealed_copper', '2x ardite', '2x red_alloy')
-        .cableProperties(32768, 1, 0, true)
+        .cableProperties(32768, 4, 0, true)
 
     event.create("lumium")
         .ingot().fluid()
         .color(0xf6ff99).iconSet('bright')
-        .blastTemp(4500, 'mid', 7680, 1600)
+        .blastTemp(4500, 'mid', 4800, 1000)
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE)
 		.components('4x tin_alloy', '2x sterling_silver')
-        .cableProperties(8192, 1, 0, true)
+        .cableProperties(8192, 2, 0, true)
         .fluidPipeProperties(4500, 256, true, true, true, false)
 
     event.create("enderium")
@@ -42,7 +42,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .blastTemp(6400, 'highest', 30720, 1600)
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE)
 		.components('4x lead', '2x platinum', 'blue_steel', 'osmium')
-        .cableProperties(131072, 1, 0, true)
+        .cableProperties(131072, 4, 0, true)
 
     event.create("electrum_flux")
         .ingot().fluid()


### PR DESCRIPTION
**Supercon Changes**
- End Steel is now 2A at 1x Wire, but now requires a Nichrome EBF at HV and Blue Steel
- Lumium now cooks significantly faster (80 -> 50 seconds) and is now 2A at 1x Wire
- Stellar Allow is now a 4A at 1x wire IV Superconductor, and has been changed to be made in an Autoclave with Lumium, 2 Grains of Infinity and 72mB of Nether Star fluid
- Signalum and Enderium are now 4A at 1x Wire
- Cryolobus is now 8A at 1x wire
- Sculk Superconductor is now 16A at 1x wire

**Everything Else**
- New T8MM mission in Hyperbolic Microverse Projector that offers more Hadal Shards per Warden Data (should cut down on Wither Realm Data requirements which was a problem with its equivalent in Nomi CEu)
- New recipe for Omnium Nuggets using Industrial TNT, 4x as efficient in terms of time compared to using normal TNT
- Gated Sterilizing Cleanroom behind MK2 Fusion a la standard GregTech (now requires Tritanium Frame vs. Black Steel beforehand) to ensure Crystal Circuits see more significant usage, now gives 4 Sterilizing Filter Casings per craft as compensation
- Added assembler recipes for Mesol Core and Bathyal Energy Core to allow for faster crafting of them in the endgame
- Quantum Ring and Link also have assembler recipes now
- Knocked down Cleaning Maintenance hatch another tier from LuV to IV, no more Multiblock Tetris
- Buffed Omnic Forge Quantum Flux recipe, also modified to be used in HM