### PR TITLE
Release Workflows

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -3,14 +3,24 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'Build what'
+        description: "Build what"
         required: true
-        default: 'build-client'
+        default: "build-client"
         type: choice
         options:
           - build-client
           - build-server
           - build-all
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        default: "build-all"
+        type: string
+    secrets:
+      API_TOKEN:
+        required: true
+
 jobs:
   pack_pr:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )

--- a/.github/workflows/get_version_info.yml
+++ b/.github/workflows/get_version_info.yml
@@ -1,0 +1,115 @@
+name: Get Version Info
+on:
+  workflow_call:
+    inputs:
+      format_only:
+        description: "Only get version format"
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      version_format:
+        description: "Versioning format"
+        value: ${{ jobs.get-version-format.outputs.version_format }}
+      version:
+        description: "Version"
+        value: ${{ jobs.get-version-format.outputs.version }}
+      major:
+        description: "Major"
+        value: ${{ jobs.get-version-format.outputs.major }}
+      minor:
+        description: "Minor"
+        value: ${{ jobs.get-version-format.outputs.minor }}
+      patch:
+        description: "Patch"
+        value: ${{ jobs.get-version-format.outputs.patch }}
+      increment:
+        description: "Increment"
+        value: ${{ jobs.get-version-format.outputs.increment }}
+      version_type:
+        description: "Version Type"
+        value: ${{ jobs.get-version-format.outputs.version_type }}
+      version_tag:
+        description: "Version Tag"
+        value: ${{ jobs.get-version-format.outputs.version_tag }}
+      changed:
+        description: "Changed"
+        value: ${{ jobs.get-version-format.outputs.changed }}
+      is_tagged:
+        description: "Is Tagged"
+        value: ${{ jobs.get-version-format.outputs.is_tagged }}
+      authors:
+        description: "Authors"
+        value: ${{ jobs.get-version-format.outputs.authors }}
+      current_commit:
+        description: "Current Commit"
+        value: ${{ jobs.get-version-format.outputs.current_commit }}
+      previous_commit:
+        description: "Previous Commit"
+        value: ${{ jobs.get-version-format.outputs.previous_commit }}
+      previous_version:
+        description: "Previous Version"
+        value: ${{ jobs.get-version-format.outputs.previous_version }}
+
+permissions: {}
+
+jobs:
+  get-version-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine version format
+        id: version_format
+        run: |
+          v_format="\${major}.\${minor}.\${patch}"
+          echo "Version Format is $v_format"
+          echo "version_format=$v_format" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Checkout
+        if: ${{ inputs.format_only == false }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get semantic version
+        id: sem_version
+        if: ${{ inputs.format_only == false }}
+        uses: PaulHatch/semantic-version@v5.4.0
+        with:
+          version_format: "${{ steps.version_format.outputs.version_format }}"
+          tag_prefix: ""
+
+      - name: Get short Sha
+        id: short_sha
+        run: |
+          short_sha=$(echo "${{ steps.sem_version.outputs.current_commit }}" | cut -c1-7)
+          echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Get version string
+        id: version
+        run: |
+          if [[ "${{ github.event.inputs.type }}" == "Stable" ]]; then
+                    version="${{ steps.sem_version.outputs.version}}"
+          else
+            version="${{ steps.sem_version.outputs.version}}+${{steps.short_sha.outputs.short_sha}}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+    outputs:
+      version_format: ${{ steps.version_format.outputs.version_format }}
+      version: ${{ steps.version.outputs.version }}
+      major: ${{ steps.sem_version.outputs.major }}
+      minor: ${{ steps.sem_version.outputs.minor }}
+      patch: ${{ steps.sem_version.outputs.patch }}
+      increment: ${{ steps.sem_version.outputs.increment }}
+      version_type: ${{ steps.sem_version.outputs.version_type}}
+      version_tag: ${{ steps.sem_version.outputs.version_tag }}
+      changed: ${{ steps.sem_version.outputs.changed }}
+      is_tagged: ${{ steps.sem_version.outputs.is_tagged }}
+      authors: ${{ steps.sem_version.outputs.authors }}
+      current_commit: ${{ steps.sem_version.outputs.current_commit }}
+      previous_commit: ${{ steps.sem_version.outputs.previous_commit }}
+      previous_version: ${{ steps.sem_version.outputs.previous_version }}
+      current_commit_short: ${{ steps.short_sha.outputs.short_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ on:
         options:
           - "Stable"
           - "Pre-release"
-      prefix:
-        description: "Release Type"
+      cf_type:
+        description: "CF Release Type"
         required: true
         type: choice
         options:
@@ -20,7 +20,7 @@ on:
           - "alpha"
         default: "alpha"
       draft:
-        description: "Draft release"
+        description: "Draft GitHub release (CF release will always be normal)"
         type: boolean
         default: true
       generate_release_notes:
@@ -87,21 +87,16 @@ jobs:
       - name: Determine tag
         id: tag
         run: |
-          if [[ "${{ github.event.inputs.type }}" == "Stable" ]]; then
-            tag="${{needs.pre-build.outputs.version_tag}}"
-          else
-            echo "Unknown type: ${{ github.event.inputs.type }}"
-            exit 1
-          fi
+          tag="${{needs.pre-build.outputs.version_tag}}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Determine name
         id: name
         run: |
-          if [[ "${{ github.event.inputs.prefix }}" != "" ]]; then
+          if [[ "${{ github.event.inputs.cf_type }}" != "" ]]; then
             # Get prefix first char capitalized
-            prefix=$(echo "${{ github.event.inputs.prefix }}" | awk '{print toupper(substr($0, 1, 1)) tolower(substr($0, 2))}')
+            prefix=$(echo "${{ github.event.inputs.cf_type }}" | awk '{print toupper(substr($0, 1, 1)) tolower(substr($0, 2))}')
             name="${prefix} ${{needs.pre-build.outputs.version}}"
           else
             name="${{needs.pre-build.outputs.version}}"
@@ -173,3 +168,26 @@ jobs:
         run: |
           echo "Release URL: ${{ steps.release.outputs.html_url }}"
         shell: bash
+
+      - name: Get server and client file paths
+        id: filepaths
+        run: |
+          server_file=$(ls artifacts/build-zipzip/*server*.zip)
+          client_file=$(ls artifacts/build-zipzip/*client*.zip)
+          echo "server_file=$server_file" >> "$GITHUB_OUTPUT"
+          echo "client_file=$client_file" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - uses: henkelmax/upload-curseforge-modpack-action@v1.0.0
+        if: ${{ inputs.skip_cf_release == false }}
+        with:
+          api-token: ${{ secrets.RELEASE_TOKEN  }}
+          project-id: ${{vars.CF_PROJECT_ID}}
+          modpack-path: "${{steps.filepaths.outputs.client_file}}"
+          modpack-server-path: "${{steps.filepaths.outputs.server_file}}"
+          changelog: "For a detailed changelog, see the GitHub release: ${{ steps.release.outputs.html_url }}"
+          changelog-format: "text"
+          game-version: "1.20.1"
+          display-name: "Monifactory-${{steps.name.outputs.name}}"
+          server-display-name: "Monifactory-${{steps.name.outputs.name}} Server"
+          release-type: ${{ github.event.inputs.cf_type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,175 @@
+name: Build and Release
+on:
+  # checkov:skip=CKV_GHA_7
+  workflow_dispatch:
+    inputs:
+      type:
+        description: "Release type"
+        required: true
+        type: choice
+        options:
+          - "Stable"
+          - "Pre-release"
+      prefix:
+        description: "Release Type"
+        required: true
+        type: choice
+        options:
+          - "release"
+          - "beta"
+          - "alpha"
+        default: "alpha"
+      draft:
+        description: "Draft release"
+        type: boolean
+        default: true
+      generate_release_notes:
+        description: "Auto generate release notes"
+        type: boolean
+        default: true
+        required: false
+      skip_build:
+        description: "Skip build/test step"
+        type: boolean
+        default: false
+      run_id:
+        description: "Run ID to grab artifacts from if skipping build"
+        type: number
+        required: false
+      skip_github_release:
+        description: "Skip GitHub release"
+        type: boolean
+        default: false
+        required: false
+      skip_cf_release:
+        description: "Skip CurseForge release"
+        type: boolean
+        default: false
+        required: false
+
+permissions: {}
+
+jobs:
+  pre-build:
+    uses: ./.github/workflows/get_version_info.yml
+
+  build:
+    needs: pre-build
+    if: inputs.skip_build != true
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build_pr.yml
+    with:
+      target: build-all
+    secrets: inherit
+
+  release:
+    permissions:
+      contents: write
+      packages: read
+      statuses: write
+    needs: [build, pre-build]
+    runs-on: ubuntu-latest
+    if: success() || needs.build.result == 'skipped'
+    steps:
+      - name: Check Build or Skip
+        if: ${{ needs.build.result == 'failure'  || needs.pre-build.result == 'failure'}}
+        run: exit 1
+        shell: bash
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [[ "${{ github.event.inputs.type }}" == "Stable" ]]; then
+            tag="${{needs.pre-build.outputs.version_tag}}"
+          else
+            echo "Unknown type: ${{ github.event.inputs.type }}"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Determine name
+        id: name
+        run: |
+          if [[ "${{ github.event.inputs.prefix }}" != "" ]]; then
+            # Get prefix first char capitalized
+            prefix=$(echo "${{ github.event.inputs.prefix }}" | awk '{print toupper(substr($0, 1, 1)) tolower(substr($0, 2))}')
+            name="${prefix} ${{needs.pre-build.outputs.version}}"
+          else
+            name="${{needs.pre-build.outputs.version}}"
+          fi
+          echo "Release name will be $name"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Download artifacts - Current Flow
+        if: ${{ inputs.skip_build == false }}
+        uses: actions/download-artifact@v4.1.8
+        with:
+          path: artifacts
+
+      - name: Download artifacts - Previous Flow
+        if: ${{ inputs.skip_build == true}}
+        uses: actions/download-artifact@v4.1.8
+        with:
+          path: artifacts
+          run-id: ${{ github.event.inputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rename artifacts
+        id: artifacts
+        run: |
+          cd artifacts/build-zipzip
+          for file in ./*; do
+            if [[ $file == *.zip ]]; then
+              base=$(basename $file)
+              versioned_file="Monifactory-${{steps.name.outputs.name}}-$base"
+              mv "$file" "$versioned_file"
+            fi
+          done
+          wait
+          echo "Cleaning up - Removing non-zip files"
+          shopt -s extglob
+          rm -rf !(*.zip)
+        shell: bash
+
+      - name: Create body
+        id: body
+        run: |
+          ACTION_RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          message="${{ github.event.inputs.type }} release ${{needs.pre-build.outputs.version}}.
+          The latest commit is ${{  needs.pre-build.outputs.current_commit }}.
+
+          Refer to the [action run]($ACTION_RUN_URL) that created this release."
+          echo "body<<EOF"$'\n'"$message"$'\n'EOF >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1.14.0
+        id: release
+        if: ${{ inputs.skip_github_release == false }}
+        with:
+          artifacts: artifacts/build-zipzip/*
+          name: ${{ steps.name.outputs.name }}
+          tag: ${{ steps.tag.outputs.tag }}
+          generateReleaseNotes: ${{ inputs.generate_release_notes }}
+          prerelease: ${{ github.event.inputs.type == 'Pre-release' }}
+          draft: ${{ github.event.inputs.draft }}
+          body: ${{ steps.body.outputs.body }}
+          allowUpdates: true
+          updateOnlyUnreleased: true
+          removeArtifacts: true
+          commit: ${{  needs.pre-build.outputs.current_commit }}
+
+      - name: Echo Release URL
+        run: |
+          echo "Release URL: ${{ steps.release.outputs.html_url }}"
+        shell: bash


### PR DESCRIPTION
Implements release workflows for GitHub and CurseForge.

Hooks into existing build workflow.
Utilizes automated semantic versioning.
Files are renamed to have the version in them.
Option to autogenerate change logs via pull request names.

Workflow has advanced options to take the artifacts from a previous run instead of making a new build.

**Requires a Curse Forge release token to be set as RELEASE_TOKEN in secrets.**
**Requires CF project id to be set as CF_PROJECT_ID in variables**


Example of a GitHub release (No manual edits or inputs at all):

![image](https://github.com/user-attachments/assets/a5a25737-2643-4b83-8eb1-c8c637fc9f36)
