### PR TITLE
Quick recipe fixes

### DIFF
--- a/kubejs/server_scripts/_hardmode/expert_missions.js
+++ b/kubejs/server_scripts/_hardmode/expert_missions.js
@@ -200,7 +200,7 @@ ServerEvents.recipes(event => {
                 '64x kubejs:dragon_lair_data',
                 '64x kubejs:dragon_lair_data',
                 '64x minecraft:dragon_breath',
-                '64x minecraft:ender_dragon_scale',
+                '64x kubejs:ender_dragon_scale',
                 'minecraft:dragon_head'
             )
             .duration(100*20)
@@ -214,12 +214,12 @@ ServerEvents.recipes(event => {
                 '8x kubejs:dragon_lair_data'
             )
             .itemOutputs(
-                '64x minecraft:ender_dragon_scale',
-                '64x minecraft:ender_dragon_scale',
-                '64x minecraft:ender_dragon_scale',
-                '64x minecraft:ender_dragon_scale',
-                '64x minecraft:ender_dragon_scale',
-                '64x minecraft:ender_dragon_scale',
+                '64x kubejs:ender_dragon_scale',
+                '64x kubejs:ender_dragon_scale',
+                '64x kubejs:ender_dragon_scale',
+                '64x kubejs:ender_dragon_scale',
+                '64x kubejs:ender_dragon_scale',
+                '64x kubejs:ender_dragon_scale',
                 '64x minecraft:dragon_breath',
                 '64x minecraft:dragon_breath',
                 '64x minecraft:dragon_breath',
@@ -248,11 +248,12 @@ ServerEvents.recipes(event => {
                 'kubejs:microminer_t4half',
                 '8x kubejs:quantum_flux',
                 '64x kubejs:aerotheum_dust',
-                '16x minecraft:sculk_catalyst'
+                '16x minecraft:deepslate'
             )
             .itemOutputs(
                 '64x kubejs:deep_dark_data',
                 '64x kubejs:deep_dark_data',
+                '16x minecraft:sculk_catalyst',
                 '32x kubejs:warden_horn'
             )
             .duration(100*20)

--- a/kubejs/server_scripts/_hardmode/expert_missions.js
+++ b/kubejs/server_scripts/_hardmode/expert_missions.js
@@ -248,12 +248,11 @@ ServerEvents.recipes(event => {
                 'kubejs:microminer_t4half',
                 '8x kubejs:quantum_flux',
                 '64x kubejs:aerotheum_dust',
-                '16x minecraft:deepslate'
+                '16x minecraft:sculk_catalyst'
             )
             .itemOutputs(
                 '64x kubejs:deep_dark_data',
                 '64x kubejs:deep_dark_data',
-                '16x minecraft:sculk_catalyst',
                 '32x kubejs:warden_horn'
             )
             .duration(100*20)

--- a/kubejs/server_scripts/mods/Gregicality_Rocketry.js
+++ b/kubejs/server_scripts/mods/Gregicality_Rocketry.js
@@ -145,6 +145,7 @@ ServerEvents.recipes(event => {
     ).id('gcyr:shaped/space_station_packager')
 
     //Motors and Tanks
+    event.remove({ output: 'gcyr:basic_rocket_motor' })
     event.shaped(
         'gcyr:basic_rocket_motor', [
             ' P ',
@@ -155,6 +156,7 @@ ServerEvents.recipes(event => {
             T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:electrical_steel"}').weakNBT()
         })
 
+    event.remove({ output: 'gcyr:basic_fuel_tank' })
     event.shaped(
         'gcyr:basic_fuel_tank', [
             'PTP',


### PR DESCRIPTION
- Rename minecraft:ender_dragon_scale to kubejs:ender_dragon_scale
- Remove Assembly recipes for basic rocket parts
- T4.5MM recipe change as suggested in 
https://discord.com/channels/914926812948234260/1229929078547550238/1270344320427495535