### PR TITLE
Rebalance Sculk Supercon to use Cryococcus instead of Cryolobus.

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -124,9 +124,9 @@ ServerEvents.recipes(event => {
 
 	// Vacuum Freezer
 	// kubejs Superconductor Wire
-    event.recipes.gtceu.vacuum_freezer("sculk_superconductor_wire")
-        .itemInputs('gtceu:cryolobus_single_wire')
-        .itemOutputs('gtceu:sculk_superconductor_single_wire')
+    event.recipes.gtceu.vacuum_freezer("sculk_superconductor")
+        .itemInputs('gtceu:cryococcus_ingot')
+        .itemOutputs('gtceu:sculk_superconductor_ingot')
         .inputFluids(Fluid.of('gtceu:nether_star', 144))
         .duration(100)
         .EUt(6000)

--- a/kubejs/startup_scripts/material_registry/endgame.js
+++ b/kubejs/startup_scripts/material_registry/endgame.js
@@ -36,7 +36,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .color(0xffffff)
         .iconSet('shiny')
         .flags(GTMaterialFlags.NO_SMELTING, GTMaterialFlags.NO_SMASHING)
-        .cableProperties(524288, 8, 0, true)
+        .cableProperties(2097152, 8, 0, true)
 
     event.create('infinity')
         .ingot()


### PR DESCRIPTION
In its current state, there's not much reason to use Cryolobus wires & conduits - It's too easy to directly upgrade them to Sculk Superconductor with just some Nether Stars.
This change gates Sculk Superconductor behind Cryococcus instead, so there's at least a short span of time when Cryolobus is obtained but before a Discharger is built when it makes sense to use regular Cryolobus wires.