### PR TITLE
Add thermal mobdrop recipes for HM uses

### DIFF
--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -501,6 +501,25 @@ ServerEvents.recipes(event => {
         .duration(200)
         .EUt(16);
 
+    // Thermal Mobdrops (for HM nether star recipe mostly)
+    event.recipes.gtceu.compressor('blitz_rod')
+        .itemInputs('4x thermal:blitz_powder')
+        .itemOutputs('thermal:blitz_rod')
+        .duration(200)
+        .EUt(2)
+
+    event.recipes.gtceu.compressor('blizz_rod')
+        .itemInputs('4x thermal:blizz_powder')
+        .itemOutputs('thermal:blizz_rod')
+        .duration(200)
+        .EUt(2)
+
+    event.recipes.gtceu.compressor('basalz_rod')
+        .itemInputs('4x thermal:basalz_powder')
+        .itemOutputs('thermal:basalz_rod')
+        .duration(200)
+        .EUt(2)
+
     // Devices
     event.remove({ id: "thermal:device_water_gen" }) // aqua accumulator
     event.shaped(


### PR DESCRIPTION
Added blazerod-like recipes (4 dusts -> 1 rod) for the thermal mobdrops so that the pre-mm nether star recipe is available for HM players.