### PR TITLE
Re-enable manual compression for EM

### DIFF
--- a/config-overrides/harder/gtceu.yaml
+++ b/config-overrides/harder/gtceu.yaml
@@ -6,7 +6,7 @@ recipes:
 
   # Whether to remove Block/Ingot compression and decompression in the Crafting Table.
   # Default: true
-  disableManualCompression: true
+  disableManualCompression: false
 
   # Change the recipe of Rods in the Lathe to 1 Rod and 2 Small Piles of Dust, instead of 2 Rods.
   # Default: false


### PR DESCRIPTION
This allows EM players to make Wrought Iron before obtaining an Alloy Smelter, so that they may complete quests as they progress.
The other option is to _not_ allow this, and instead change the harder questline to require regular Iron all the way up until the Alloy Smelter