### PR TITLE
Fix quest flashing issue with Dependencies chapter

### DIFF
--- a/kubejs/server_scripts/_packmode.js
+++ b/kubejs/server_scripts/_packmode.js
@@ -14,7 +14,9 @@ PlayerEvents.loggedIn(event => {
     //     event.player.tell(Text.yellow('Pack mode swapped'))
     // }
 
-    if (!event.hasGameStage(`mode_${global.packmode}`)) {
-        event.removeGameStage(/mode_[A-Za-z]+/)
-        event.addGameStage(`mode_${global.packmode}`);
-}})
+    event.removeGameStage('mode_normal')
+    event.removeGameStage('mode_hard')
+    event.removeGameStage('mode_harder')
+
+    event.addGameStage(`mode_${global.packmode}`);
+})


### PR DESCRIPTION
Solves [this](https://discord.com/channels/914926812948234260/1229929078547550238/1268299394373910618) issue.
It turns out that `event.removeGameStage` cannot take RegEx, and as a result I was left with multiple GameStages upon logging in.
Each quest completes, and in doing so resets the other quests allowing them to trigger again in an endless flashing cycle.