### PR TITLE
Remove ULV trophy from HM/EM

### DIFF
--- a/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
@@ -225,21 +225,8 @@
 			]
 			icon: "minecraft:iron_ingot"
 			id: "2E8BFA2E719B1C47"
-			rewards: [{
-				id: "318894ADCA9CF9DB"
-				item: {
-					Count: 1b
-					id: "trofers:large_pillar"
-					tag: {
-						BlockEntityTag: {
-							Trophy: "monifactory:wrought_iron"
-						}
-					}
-				}
-				type: "item"
-			}]
 			shape: "hexagon"
-			subtitle: "ULV Beginnings"
+			subtitle: "Steam Beginnings"
 			tasks: [{
 				count: 24L
 				id: "674259A69F1EEC1C"

--- a/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
@@ -244,21 +244,8 @@
 			]
 			icon: "gtceu:wrought_iron_ingot"
 			id: "2E8BFA2E719B1C47"
-			rewards: [{
-				id: "318894ADCA9CF9DB"
-				item: {
-					Count: 1b
-					id: "trofers:large_pillar"
-					tag: {
-						BlockEntityTag: {
-							Trophy: "monifactory:wrought_iron"
-						}
-					}
-				}
-				type: "item"
-			}]
 			shape: "hexagon"
-			subtitle: "ULV Beginnings"
+			subtitle: "Steam Beginnings"
 			tasks: [
 				{
 					count: 12L


### PR DESCRIPTION
Since HM/EM go through Steam, they don't actually go through a ULV age (Unless the progression is ULV -> Steam -> LV -> ... which is weird)
Thus HM/EM players should get a Steam trophy _instead_ of a ULV trophy, not in addition to it.