### PR TITLE
Rework infinite Cobble/Water Sources

### DIFF
--- a/config-overrides/hardmode/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/the_beginning.snbt
@@ -670,7 +670,7 @@
 			y: -0.5d
 		}
 		{
-			dependencies: ["29A487F0BC43AAF9"]
+			dependencies: ["025543EDB0A4AC22"]
 			description: ["Needs 2 &6Water Source Blocks&r around it to generate water. You will also need a way to pull the water out of the accumulator, such as using the &5LV water pump&f as a &acover&f."]
 			icon: {
 				Count: 1b
@@ -693,8 +693,8 @@
 				type: "item"
 			}]
 			title: "&9Infiniter Water"
-			x: 1.0357142857142563d
-			y: -0.4761904761904816d
+			x: 8.5d
+			y: -0.5d
 		}
 		{
 			dependencies: ["29A487F0BC43AAF9"]

--- a/config-overrides/normal/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/the_beginning.snbt
@@ -670,7 +670,7 @@
 			y: -0.5d
 		}
 		{
-			dependencies: ["29A487F0BC43AAF9"]
+			dependencies: ["025543EDB0A4AC22"]
 			description: ["Needs 2 &6Water Source Blocks&r around it to generate water. You will also need a way to pull the water out of the accumulator, such as using the &5LV water pump&f as a &acover&f."]
 			icon: {
 				Count: 1b
@@ -693,8 +693,8 @@
 				type: "item"
 			}]
 			title: "&9Infiniter Water"
-			x: 1.0357142857142563d
-			y: -0.4761904761904816d
+			x: 8.5d
+			y: -0.5d
 		}
 		{
 			dependencies: ["29A487F0BC43AAF9"]

--- a/config/ftbquests/quests/chapters/early_game.snbt
+++ b/config/ftbquests/quests/chapters/early_game.snbt
@@ -44,12 +44,6 @@
 			y: 8.5d
 		}
 		{
-			id: "27DFA4CC3F039428"
-			linked_quest: "26C9F1514FD08C81"
-			x: 5.25d
-			y: 18.5d
-		}
-		{
 			id: "4065DEBE89F8D723"
 			linked_quest: "3650EF39B5AB4A7D"
 			shape: "hexagon"

--- a/config/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config/ftbquests/quests/chapters/the_beginning.snbt
@@ -670,7 +670,7 @@
 			y: -0.5d
 		}
 		{
-			dependencies: ["29A487F0BC43AAF9"]
+			dependencies: ["025543EDB0A4AC22"]
 			description: ["Needs 2 &6Water Source Blocks&r around it to generate water. You will also need a way to pull the water out of the accumulator, such as using the &5LV water pump&f as a &acover&f."]
 			icon: {
 				Count: 1b
@@ -693,8 +693,8 @@
 				type: "item"
 			}]
 			title: "&9Infiniter Water"
-			x: 1.0357142857142563d
-			y: -0.4761904761904816d
+			x: 8.5d
+			y: -0.5d
 		}
 		{
 			dependencies: ["29A487F0BC43AAF9"]

--- a/kubejs/server_scripts/_hardmode/hardmode.js
+++ b/kubejs/server_scripts/_hardmode/hardmode.js
@@ -57,8 +57,6 @@ ServerEvents.recipes(event => {
         .itemOutputs('kubejs:omnic_data')
         .duration(1000).EUt(180000)
 
-        event.remove({ id: "watercollector:watercollector" })
-        event.remove({ id: "thermal:device_rock_gen" })
         event.remove({ output: 'systeams:stirling_boiler' })
         event.remove({ id: "bountiful:crafting/bountyboard" })
 
@@ -107,35 +105,7 @@ ServerEvents.recipes(event => {
             .itemOutputs('8x kubejs:ender_spore')
             .duration(640)
             .EUt(120)
-
-// Anything that shouldn't apply to hardermode
-        if (!isHarderMode) {
-            event.shaped(
-                "watercollector:watercollector", [
-                    "AAA",
-                    "B B",
-                    "AAA"
-                ], {
-                    A: "gtceu:double_steel_plate",
-                    B: "minecraft:water_bucket"
-                }
-            )
-
-            event.remove({ id: "thermal:device_rock_gen" })
-            event.shaped(
-                "thermal:device_rock_gen", [
-                'PPP',
-                'B B',
-                'PPP'
-            ], {
-                P: "gtceu:black_steel_plate",
-                B: "minecraft:bucket"
-            }
-            )
-}}
-
-
-})
+}})
 
 // HM Ore Gen
 

--- a/kubejs/server_scripts/infinite_sources.js
+++ b/kubejs/server_scripts/infinite_sources.js
@@ -67,4 +67,20 @@ ServerEvents.recipes(event => {
             }
         ).id('kubejs:device_rock_gen');
     }
+
+    //Infinite Cobble/Water cells
+    event.remove({ id: 'expatternprovider:water_cell' })
+    event.recipes.gtceu.assembler("kubejs:infinite_water_cell")
+            .itemInputs("3x #forge:plates/mythril", "3x minecraft:water_bucket", "ae2:cell_component_16k", "2x ae2:quartz_vibrant_glass")
+            .itemOutputs(Item.of('expatternprovider:infinity_cell', '{record:{"#c":"ae2:f",id:"minecraft:water"}}'))
+            .duration(800)
+            .EUt(512)
+
+    event.remove({ id: 'expatternprovider:cobblestone_cell' })
+    event.recipes.gtceu.assembler("kubejs:infinite_cobblestone_cell")
+            .itemInputs("3x #forge:plates/mythril", "2x minecraft:water_bucket", "1x minecraft:lava_bucket", "ae2:cell_component_16k", "2x ae2:quartz_vibrant_glass")
+            .itemOutputs(Item.of('expatternprovider:infinity_cell', '{record:{"#c":"ae2:i",id:"minecraft:cobblestone"}}'))
+            .duration(800)
+            .EUt(512)
+
 })

--- a/kubejs/server_scripts/infinite_sources.js
+++ b/kubejs/server_scripts/infinite_sources.js
@@ -1,0 +1,70 @@
+ServerEvents.recipes(event => {
+    event.remove({ id: "watercollector:watercollector" })
+    event.remove({ id: "thermal:device_water_gen" })
+    event.remove({ id: "thermal:device_rock_gen" })
+
+    if (isNormalMode) {
+        event.shaped(
+            "watercollector:watercollector", [
+                "AAA",
+                "B B",
+                "AAA"
+            ], {
+                A: "gtceu:wrought_iron_plate",
+                B: "minecraft:water_bucket"
+            }
+        )
+        event.shaped(
+            "thermal:device_water_gen", [
+                ' B ',
+                'CWC',
+                'GSG'
+            ], {
+                G: "#forge:gears/iron",
+                B: "minecraft:bucket",
+                W: "watercollector:watercollector",
+                S: "thermal:redstone_servo",
+                C: "#forge:ingots/copper"
+            }
+        ).id('kubejs:device_water_gen');
+        event.shaped(
+            "thermal:device_rock_gen", [
+                ' P ',
+                'PNP',
+                'GHG'
+            ], {
+                G: "#forge:gears/iron",
+                P: "#forge:plates/steel",
+                N: "#forge:pistons",
+                H: "minecraft:hopper"
+            }
+        ).id('kubejs:device_rock_gen');
+    } else {
+        event.shaped(
+            "thermal:device_water_gen", [
+                ' B ',
+                'CWC',
+                'GSG'
+            ], {
+                G: "#forge:gears/iron",
+                B: "minecraft:bucket",
+                W: "#enderio:fused_quartz",
+                S: "thermal:redstone_servo",
+                C: "#forge:ingots/copper"
+            }
+        ).id('kubejs:device_water_gen');
+        event.shaped(
+            "thermal:device_rock_gen", [
+                ' P ',
+                'INI',
+                'GSG'
+            ], {
+                G: "#forge:gears/iron",
+                S: "thermal:redstone_servo",
+                P: "#forge:plates/steel",
+                I: "#forge:plates/invar",
+                N: "#forge:pistons"
+            }
+        ).id('kubejs:device_rock_gen');
+    }
+})

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -1175,12 +1175,6 @@ ServerEvents.recipes(event => {
         .duration(240)
         .EUt(512)
 
-    //Infinite Cobble/Water cell
-    event.replaceInput({ id: 'expatternprovider:water_cell' }, 'minecraft:water_bucket', 'gtceu:infinite_water_cover')
-    event.replaceInput({ id: 'expatternprovider:cobblestone_cell' }, 'minecraft:water_bucket', 'gtceu:infinite_water_cover')
-    event.replaceInput({ id: 'expatternprovider:water_cell' }, 'minecraft:diamond', 'gtceu:diamond_plate')
-    event.replaceInput({ id: 'expatternprovider:cobblestone_cell' }, 'minecraft:diamond', 'gtceu:diamond_plate')
-
     //Misc stuff
     event.replaceInput({ id: 'expatternprovider:ingredient_buffer' }, 'minecraft:iron_ingot', 'gtceu:iron_plate')
     event.replaceInput({ id: 'expatternprovider:crystal_fixer' }, 'minecraft:iron_ingot', 'gtceu:iron_plate')

--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -502,18 +502,6 @@ ServerEvents.recipes(event => {
         .EUt(16);
 
     // Devices
-    event.remove({ id: "thermal:device_water_gen" }) // aqua accumulator
-    event.shaped(
-        "thermal:device_water_gen", [
-            'BBB',
-            'BCB',
-            'BBB'
-        ], {
-            B: "enderio:fused_quartz",
-            C: "watercollector:watercollector"
-        }
-    ).id('kubejs:device_water_gen');
-
     event.remove({ type: "thermal:rock_gen", not: { output: "minecraft:cobblestone" } })
 
     event.remove({ id: 'thermal:device_nullifier' });

--- a/kubejs/server_scripts/normal_mode.js
+++ b/kubejs/server_scripts/normal_mode.js
@@ -131,17 +131,6 @@ ServerEvents.recipes(event => {
         }
         )
 
-        event.remove({ id: "watercollector:watercollector" })
-        event.shaped(
-            "watercollector:watercollector", [
-            "AAA",
-            "B B",
-            "AAA"
-        ], {
-            A: "gtceu:wrought_iron_plate",
-            B: "minecraft:water_bucket"
-        }
-        )
         event.recipes.gtceu.assembler("lv_motor")
             .itemInputs("2x gtceu:tin_single_cable", "2x gtceu:iron_rod", "gtceu:magnetic_iron_rod", "4x gtceu:fine_copper_wire")
             .itemOutputs("gtceu:lv_electric_motor")
@@ -173,14 +162,6 @@ ServerEvents.recipes(event => {
         }
         ).id('gtceu:shaped/distillation_tower')
 
-
-        event.remove({ id: 'gtceu:assembler/cover_infinite_water' })
-        event.recipes.gtceu.assembler("kubejs:infinite_water_cover")
-            .itemInputs("2x gtceu:mv_electric_pump", "thermal:device_water_gen", "#gtceu:circuits/mv")
-            .itemOutputs('gtceu:infinite_water_cover')
-            .duration(100)
-            .EUt(128)
-
         //GT Steam Age
         gtMachines.forEach(machine => {
             event.remove({ output: ['gtceu:lp_steam_' + machine, 'gtceu:hp_steam_' + machine] })
@@ -197,18 +178,6 @@ ServerEvents.recipes(event => {
         C: 'ironfurnaces:diamond_furnace',
         D: 'enderio:vibrant_gear',
         E: 'kubejs:redstone_transmission_coil'
-    }
-    )
-
-    event.remove({ id: "thermal:device_rock_gen" })
-    event.shaped(
-        "thermal:device_rock_gen", [
-        'PPP',
-        'B B',
-        'PPP'
-    ], {
-        P: "gtceu:steel_plate",
-        B: "minecraft:bucket"
     }
     )
     


### PR DESCRIPTION
Reworks Water Collector, Igneous Extruder, Aquaeous Accumulator, GT Infinite Water Cover, and ExAE2 Infinity Water/Cobble Cells.

Water Collector is NM only now, HM has Primitive Water Pump so it's fine

Aquaeous Accumulator, Igneous Extruder recipes are changed to be more like other TE recipes, but have similar gating/costs when compared to the previous recipes

Infinite Water Cover recipe reset to GT default. Now gated to HV for all modes, no longer requires Aquaeous Accumulator + Water Collector nested recipes.

ExAE2 Infinite cell made obtainable once again (or, at the very least, the recipe is now visible in JEI) Recipe was also moved to Assembler and some ingredients switched out for _slightly_ more expensive variants that are still obtainable in the same voltage tier since you only need one of each for each AE2 network.

Because Mana Infused Metal is used in their new recipe, however, the quest link from HV circuits is removed since it's not the last hurdle people will have to overcome to make one.