### PR TITLE
Touched up `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*]
 indent_style = space
 indent_size = 4
@@ -16,3 +18,6 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = false
+
+[*.snbt]
+indent_style = tab


### PR DESCRIPTION
Just a small pull request to:

* Set the `root` flag in the top-level `.editorconfig` file (it's good practice).
* Add a rule for `*.snbt` files (they should all be tab-indented).