### PR TITLE
Remove some duplicate fluids

### DIFF
--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -34,7 +34,7 @@ JEIEvents.hideItems(event => {
     event.hide(['thermal:dynamo_stirling', 'thermal:dynamo_gourmand', 'thermal:dynamo_disenchantment', 'thermal:dynamo_lapidary', 'systeams:numismatic_boiler', 'systeams:magmatic_boiler', 'systeams:compression_boiler', 'systeams:gourmand_boiler', 'systeams:lapidary_boiler', 'systeams:disenchantment_boiler'])
     //event.hide(['thermal:upgrade_augment_1', 'thermal:upgrade_augment_2', 'thermal:upgrade_augment_3', 'thermal:upgrade_augment_4', 'thermal:dynamo_output_augment'])
     event.hide(['thermal:coal_coke', 'thermal:coal_coke_block'])
-    event.hide(['thermal:machine_furnace', 'thermal:machine_sawmill', 'thermal:machine_pulverizer', 'thermal:machine_smelter', 'thermal:machine_centrifuge', 'thermal:machine_crucible', 'thermal:machine_chiller', 'thermal:machine_refinery', 'thermal:machine_pyrolyzer', 'thermal:machine_bottler', 'thermal:machine_brewer', 'thermal:machine_crystallizer', 'thermal:machine_crafter'])
+    event.hide(['thermal:machine_furnace', 'thermal:machine_sawmill', 'thermal:machine_pulverizer', 'thermal:machine_smelter', 'thermal:machine_centrifuge', 'thermal:machine_crucible', 'thermal:machine_chiller', 'thermal:machine_refinery', 'thermal:machine_pyrolyzer', 'thermal:machine_bottler', 'thermal:machine_brewer', 'thermal:machine_crystallizer', 'thermal:machine_crafter', 'thermal:device_xp_condenser'])
     //Thermal unused items
     event.hide(/thermal:.*_block/)
     event.hide(/thermal:.*_ingot/)
@@ -43,6 +43,7 @@ JEIEvents.hideItems(event => {
     event.hide(/thermal:.*_nugget/)
     event.hide(/thermal:.*_glass/)
     event.hide(/thermal:.*_gear/)
+    event.hide('thermal:creosote_bucket')
 
     //EnderIO
     event.hide(['enderio:conduit', 'enderio:energy_conduit', 'enderio:plant_matter_green', 'enderio:plant_matter_brown', 'enderio:clayed_glowstone', 'enderio:flour', 'enderio:organic_green_dye', 'enderio:organic_brown_dye', 'enderio:industrial_insulation_block', "enderio:primitive_alloy_smelter", "enderio:alloy_smelter", "enderio:sag_mill", "enderio:stirling_generator"])
@@ -155,7 +156,14 @@ JEIEvents.hideItems(event => {
 
     //Sophisticated tier upgrades
     event.hide(/^sophisticatedstorage:.+tier_upgrade$/)
+    
+    //Unused Sophisticated stack upgrades
+    event.hide("sophisticatedstorage:stack_upgrade_tier_1_plus")
+    event.hide("sophisticatedbackpacks:stack_upgrade_starter_tier")
 
+    //Sophisticated Experience
+    event.hide(/xp_pump_upgrade/)
+    
     // Chipped
     // Adding this in case chipped is okay to be hidden since it adds a ton of items
     //event.hide(/chipped:*/)
@@ -233,4 +241,11 @@ JEIEvents.hideFluids(event => {
     ncFluids.forEach(element => {
         event.hide(element)
     })
+
+    //Hide Thermal fluids
+    event.hide("thermal:creosote")
+    event.hide("cofh_core:experience")
+
+    //Hide Soph Core fluids
+    event.hide("sophisticatedcore:xp_still")
 })

--- a/kubejs/server_scripts/Remove_Recipes.js
+++ b/kubejs/server_scripts/Remove_Recipes.js
@@ -26,6 +26,8 @@ ServerEvents.recipes(event => {
     event.remove({ output: 'thermal:cured_rubber' })
     event.remove({ input: 'forge:nuggets/netherite'})
     event.remove({ id: 'thermal:gunpowder_4' })
+    event.remove({ id: 'thermal:device_xp_condenser'})
+
     //Redstone arsenal
     event.remove({ id: 'redstone_arsenal:smelting/flux_ingot_from_dust_smelting' })
     event.remove({ id: 'redstone_arsenal:smelting/flux_ingot_from_dust_blasting' })

--- a/kubejs/server_scripts/mods/Sophisticated_Storage.js
+++ b/kubejs/server_scripts/mods/Sophisticated_Storage.js
@@ -13,6 +13,8 @@ ServerEvents.recipes(event => {
     event.remove({ output: /sophisticatedstorage:[A-Za-z]+_shulker_box/ })
     event.remove(/^sophisticatedstorage:limited.+barrel.+/)
     event.remove({ output: /sophisticatedstorage:[A-Za-z]+_to_[A-Za-z]+_tier_upgrade/ })
+    event.remove({ id: "sophisticatedstorage:xp_pump_upgrade"})
+    event.remove({ id: "sophisticatedbackpacks:xp_pump_upgrade"})
     event.remove({ input: 'minecraft:redstone_torch', mod: 'sophisticatedstorage'})
     
     var barrelupgrade = [

--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -542,19 +542,6 @@ ServerEvents.recipes(event => {
         E: 'thermal:redstone_servo'
     }).id('kubejs:device_fisher');
 
-    event.remove({ id: 'thermal:device_xp_condenser' });
-    event.shaped('thermal:device_xp_condenser', [
-        ' A ',
-        'BCB',
-        'DED'
-    ], {
-        A: 'thermal:xp_crystal',
-        B: '#forge:ingots/gold',
-        C: 'thermal:machine_frame', // casing
-        D: '#forge:gears/iron',
-        E: 'thermal:redstone_servo'
-    }).id('kubejs:device_xp_condenser');
-
     event.remove({ id: 'thermal:device_collector' });
     event.shaped('thermal:device_collector', [
         ' A ',

--- a/kubejs/server_scripts/unification/tags.js
+++ b/kubejs/server_scripts/unification/tags.js
@@ -108,6 +108,11 @@ ServerEvents.tags('fluid', event => {
     ncFluids.forEach(element => {
         event.removeAllTagsFrom(element)
     })
+
+    //Remove tags from other unused non-GT fluids
+    event.removeAllTagsFrom('thermal:creosote')
+    event.removeAllTagsFrom('thermal:experience')
+    event.removeAllTagsFrom('sophisticatedcore:xp_still')
 })
 
 // Unification regexes are definited in startup script _initial.js


### PR DESCRIPTION
- Remove & hide items that make Soph Storage & COFH experience fluids
Essentially, these experience fluids have no other use except as a means of _storing_ experience, and are a pain to recover since it can only be done by piping into a Sophisticated Storage block with an XP pump upgrade. Thus, these fluids and the means to produce them are made unobtainable.
- Hide COFH Creosote
These are unobtainable & useless.