### PR TITLE
[Bug Fix] Switch "Oak Iron Barrel" to "Spruce Iron Barrel" in Genesis quest "Sophisticated Storage Shenanigans"

### DIFF
--- a/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
@@ -271,7 +271,7 @@
 						Count: 1b
 						id: "sophisticatedstorage:gold_barrel"
 						tag: {
-							woodType: "oak"
+							woodType: "spruce"
 						}
 					}
 					type: "item"

--- a/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
@@ -298,7 +298,7 @@
 						Count: 1b
 						id: "sophisticatedstorage:gold_barrel"
 						tag: {
-							woodType: "oak"
+							woodType: "spruce"
 						}
 					}
 					type: "item"

--- a/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
@@ -347,7 +347,7 @@
 						Count: 1b
 						id: "sophisticatedstorage:gold_barrel"
 						tag: {
-							woodType: "oak"
+							woodType: "spruce"
 						}
 					}
 					type: "item"

--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -347,7 +347,7 @@
 						Count: 1b
 						id: "sophisticatedstorage:gold_barrel"
 						tag: {
-							woodType: "oak"
+							woodType: "spruce"
 						}
 					}
 					type: "item"


### PR DESCRIPTION
Addresses half of #530.

Down the road this quest should probably be updated to accept "Any Sophisticated Storage Barrel" once the other barrels are added back in (as per the rest of the commit message in d9c2d5d).

Screenshots of it working on my private server:

![image](https://github.com/user-attachments/assets/99001558-71a9-40d3-b0b9-6366008d9f53)
