### PR TITLE
[Bug Fix] Fixed "Ironman 2" and "Ironman 3" not completing because of bad NBT data in quest

### DIFF
--- a/config/ftbquests/quests/chapters/early_game.snbt
+++ b/config/ftbquests/quests/chapters/early_game.snbt
@@ -2047,7 +2047,6 @@
 					id: "ironjetpacks:jetpack"
 					tag: {
 						Id: "ironjetpacks:energetic"
-						Throttle: 1.0d
 					}
 				}
 				match_nbt: true
@@ -2095,7 +2094,6 @@
 					id: "ironjetpacks:jetpack"
 					tag: {
 						Id: "ironjetpacks:electrical_steel"
-						Throttle: 1.0d
 					}
 				}
 				match_nbt: true


### PR DESCRIPTION
Jetpacks are initialized in inventory with no throttle data.