### PR TITLE
[Bug Fix] Remove FTB Quest Optimizer

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -116,11 +116,6 @@
       "required": true
     },
     {
-      "projectID": 912469,
-      "fileID": 5189155,
-      "required": true
-    },
-    {
       "projectID": 299540,
       "fileID": 5181098,
       "required": true


### PR DESCRIPTION
It causes quests to take FOREVER to register on servers. Sometimes minutes, even after tweaking the config file as recommended in bigenergy/ftb-quests-optimizer#11 (adjusting delay, disabling entirely, etc). Only removing the mod seems to fix the issue.