### PR TITLE
Super tank quest typo

### DIFF
--- a/config/ftbquests/quests/chapters/early_game.snbt
+++ b/config/ftbquests/quests/chapters/early_game.snbt
@@ -1832,7 +1832,7 @@
 				""
 				"&2Super and Quantum Tanks are the high-tier GT Fluid storage solution.&r"
 				""
-				"The first tier holds &64,000 buckets&r, and higher tiers hold more. They can also be used like Drums to put fluids in and out of machines."
+				"The first tier holds &68,000 buckets&r, and higher tiers hold more. They can also be used like Drums to put fluids in and out of machines."
 				""
 				"You can conveniently configure &cvoiding&r for them to always void, start voiding at 95%% capacity, or never void."
 				""


### PR DESCRIPTION
The quest description says the capacity of the tier 1 super tank is 4,000 buckets when it is 8,000