### PR TITLE
Monicoin tweaks

### DIFF
--- a/kubejs/server_scripts/normal_mode.js
+++ b/kubejs/server_scripts/normal_mode.js
@@ -187,6 +187,8 @@ ServerEvents.recipes(event => {
     //Bounty board recipes only accept oak. The dev has stated this is intended. https://github.com/ejektaflex/Bountiful/issues/271
     event.replaceInput({ id: "bountiful:crafting/bountyboard" }, "minecraft:oak_log", "#minecraft:logs")
     event.replaceInput({ id: "bountiful:crafting/bountyboard" }, "minecraft:oak_planks", "#minecraft:planks")
+
+    event.shapeless('kubejs:monipenny', 'gtceu:ancient_gold_coin')
 }
 
 

--- a/kubejs/server_scripts/normal_mode.js
+++ b/kubejs/server_scripts/normal_mode.js
@@ -188,7 +188,7 @@ ServerEvents.recipes(event => {
     event.replaceInput({ id: "bountiful:crafting/bountyboard" }, "minecraft:oak_log", "#minecraft:logs")
     event.replaceInput({ id: "bountiful:crafting/bountyboard" }, "minecraft:oak_planks", "#minecraft:planks")
 
-    event.shapeless('kubejs:monipenny', 'gtceu:ancient_gold_coin')
+    event.shapeless('kubejs:moni_penny', 'gtceu:ancient_gold_coin')
 }
 
 

--- a/kubejs/server_scripts/normal_mode.js
+++ b/kubejs/server_scripts/normal_mode.js
@@ -189,6 +189,14 @@ ServerEvents.recipes(event => {
     event.replaceInput({ id: "bountiful:crafting/bountyboard" }, "minecraft:oak_planks", "#minecraft:planks")
 
     event.shapeless('kubejs:moni_penny', 'gtceu:ancient_gold_coin')
+    event.shaped(
+        Item.of('gtceu:sticky_resin', 32), [
+        '   ',
+        'P  ',
+        'PPP'
+    ], {
+        P: 'kubejs:moni_penny'
+    }).noMirror().noShrink()
 }
 
 


### PR DESCRIPTION
- Ancient gold coins can be found in rare MC structures, but are completely useless. This adds a use for them by letting them be converted into Monipennies
- Sticky resin is horrible to farm in the early game, adds a trade for 4 monipennies -> 32 sticky resin. Feel free to change this to moninickels instead