### PR TITLE
Alternative recipes + Diamond Lattice rebalancing

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -136,6 +136,11 @@ ServerEvents.recipes(event => {
             P: 'gtceu:electrum_flux_plate'
         }
     ).id('redstone_arsenal:materials/flux_plating')
+    event.recipes.gtceu.omnic_forge('kubejs:flux_plating_assembly')
+        .itemInputs('redstone_arsenal:flux_gem', '4x gtceu:electrum_flux_plate')
+        .itemOutputs('redstone_arsenal:flux_plating')
+        .duration(60)
+        .EUt(7680)
 
 	// Vacuum Freezer
 	// kubejs Superconductor Wire

--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -215,11 +215,16 @@ ServerEvents.recipes(event => {
             'BGB',
             'PBP'
         ], {
-            B: 'minecraft:diamond_block',
+            P: 'minecraft:diamond',
             G: 'gtceu:diamond_perfect',
-            P: 'gtceu:diamond_plate'
+            B: 'gtceu:diamond_screw'
         }
     ).id('kubejs:diamond_lattice')
+    event.recipes.gtceu.assembler('kubejs:diamond_lattice')
+        .itemInputs('gtceu:diamond_perfect', '2x gtceu:diamond_plate', '4x gtceu:diamond_screw')
+        .itemOutputs('kubejs:diamond_lattice')
+        .duration(100)
+        .EUt(491520)
 
     event.recipes.extendedcrafting.shaped_table(
         'gtceu:crystal_matrix_ingot', [

--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -61,6 +61,7 @@ ServerEvents.recipes(event => {
         }
     )
 
+    //Coil Ingredients
     event.shaped(
         'thermal:rf_coil', [
             ' BA',
@@ -71,6 +72,11 @@ ServerEvents.recipes(event => {
             B: 'minecraft:redstone'
         }
     )
+    event.recipes.gtceu.assembler('thermal:rf_coil_assembly')
+        .itemInputs('#forge:rods/gold', '2x #forge:rings/gold', '3x #forge:dusts/redstone')
+        .itemOutputs('thermal:rf_coil')
+        .duration(200)
+        .EUt(30)
 
     event.shaped(
         'kubejs:redstone_transmission_coil', [
@@ -82,6 +88,11 @@ ServerEvents.recipes(event => {
             B: 'minecraft:redstone'
         }
     )
+    event.recipes.gtceu.assembler('kubejs:rf_transmission_coil_assembly')
+        .itemInputs('#forge:rods/silver', '2x #forge:rings/silver', '3x #forge:dusts/redstone')
+        .itemOutputs('kubejs:redstone_transmission_coil')
+        .duration(200)
+        .EUt(30)
 
     /*=== AUGMENTS/UPGRADES ===*/
     event.shaped(
@@ -187,6 +198,11 @@ ServerEvents.recipes(event => {
             B: 'gtceu:red_alloy_plate'
         }
     )
+    event.recipes.gtceu.assembler('kubejs:excitationcoil_assembly')
+        .itemInputs('thermal:rf_coil', '2x gtceu:red_alloy_plate')
+        .itemOutputs('kubejs:excitationcoil')
+        .duration(180)
+        .EUt(30)
 
     event.shaped(
         'steamdynamo:steam_dynamo', [

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -593,7 +593,13 @@ ServerEvents.recipes(event => {
         .duration(900)
         .EUt(480)
 
+    //Ender Shard
     event.shapeless('8x kubejs:ender_shard', ['minecraft:ender_pearl']).id('kubejs:ender_pearl')
+    event.recipes.gtceu.forge_hammer('kubejs:ender_pearl_shattering')
+        .itemInputs('minecraft:ender_pearl')
+        .itemOutputs('8x kubejs:ender_shard')
+        .duration(40)
+        .EUt(12)
 
     // Waterframes
     event.shaped(


### PR DESCRIPTION
Adds some alternative recipes for intermediate products that don't have any.

Also includes some re-balancing for Diamond Lattices, making them significantly cheaper with regular crafting - to around 2 T6MM's worth of diamonds per T8MM's worth of Crystal Matrix double plates. There is also a UV Assembler recipe that brings their cost down another 30-ish percent.
This hasn't come into play very much for our testers since NM players get tank shortly after Discharger (And as such they don't need to make very many T10s) but it importantly makes Crystal Matrix ingots cheaper for HM/EM players who won't get tank's creative properties.