### PR TITLE
Increase maximum force-loaded chunk limit to 100

### DIFF
--- a/defaultconfigs/ftbchunks/ftbchunks-world.snbt
+++ b/defaultconfigs/ftbchunks/ftbchunks-world.snbt
@@ -3,4 +3,5 @@
 
 {
     force_load_mode: "always"
+    max_force_loaded_chunks: 100
 }


### PR DESCRIPTION
Only applies to worlds created after this update.