### PR TITLE
Redo Atomic Reconstructor v2

### DIFF
--- a/kubejs/server_scripts/gregtech/Actually_Additions.js
+++ b/kubejs/server_scripts/gregtech/Actually_Additions.js
@@ -76,13 +76,14 @@ ServerEvents.recipes(event => {
     reconstructorrecipe.forEach(([tier, plate]) => {
     event.shaped(
         `gtceu:${tier}_atomic_reconstructor`, [
-        'PPP',
+        'CPC',
         'EHE',
         'PPP'
     ], {
         P: `gtceu:${plate}_plate`,
         E: `gtceu:${tier}_emitter`,
-        H: `gtceu:${tier}_machine_hull`
+        H: `gtceu:${tier}_machine_hull`,
+        C: `#gtceu:circuits/${tier}`
     }).id(`kubejs:shaped/${tier}_atomic_reconstructor`)
     })
 

--- a/kubejs/server_scripts/gregtech/Actually_Additions.js
+++ b/kubejs/server_scripts/gregtech/Actually_Additions.js
@@ -62,29 +62,30 @@ ServerEvents.recipes(event => {
 
     const reconstructorrecipe = [
         ['lv', 'lead'],
-        ['mv', 'lead'],
-        ['hv', 'lead'],
-        ['ev', 'beryllium'],
-        ['iv', 'beryllium'],
+        ['mv', 'rose_gold'],
+        ['hv', 'beryllium'],
+        ['ev', 'rhodium'],
+        ['iv', 'platinum'],
         ['luv', 'osmiridium'],
-        ['zpm', 'osmiridium'],
+        ['zpm', 'naquadah'],
         ['uv', 'duranium'],
-        ['uhv', 'duranium'],
-        ['uev', 'holmium'],
+        ['uhv', 'tritanium'],
+        ['uev', 'omnium'],
         ['uiv', 'holmium']
     ]
     reconstructorrecipe.forEach(([tier, plate]) => {
     event.shaped(
         `gtceu:${tier}_atomic_reconstructor`, [
-        'PCE',
-        'CHL',
-        'PPE'
+        'CPC',
+        'FHE',
+        'PPM'
     ], {
         P: `gtceu:${plate}_plate`,
         E: `gtceu:${tier}_emitter`,
         H: `gtceu:${tier}_machine_hull`,
         C: `#gtceu:circuits/${tier}`,
-        L: `#forge:lenses`
+        F: `gtceu:${tier}_field_generator`,
+        M: `gtceu:${tier}_electric_motor`
     }).id(`kubejs:shaped/${tier}_atomic_reconstructor`)
     })
 

--- a/kubejs/server_scripts/gregtech/Actually_Additions.js
+++ b/kubejs/server_scripts/gregtech/Actually_Additions.js
@@ -77,14 +77,13 @@ ServerEvents.recipes(event => {
     event.shaped(
         `gtceu:${tier}_atomic_reconstructor`, [
         'CPC',
-        'FHE',
+        'EHE',
         'PPM'
     ], {
         P: `gtceu:${plate}_plate`,
         E: `gtceu:${tier}_emitter`,
         H: `gtceu:${tier}_machine_hull`,
         C: `#gtceu:circuits/${tier}`,
-        F: `gtceu:${tier}_field_generator`,
         M: `gtceu:${tier}_electric_motor`
     }).id(`kubejs:shaped/${tier}_atomic_reconstructor`)
     })

--- a/kubejs/server_scripts/gregtech/Actually_Additions.js
+++ b/kubejs/server_scripts/gregtech/Actually_Additions.js
@@ -76,14 +76,15 @@ ServerEvents.recipes(event => {
     reconstructorrecipe.forEach(([tier, plate]) => {
     event.shaped(
         `gtceu:${tier}_atomic_reconstructor`, [
-        'CPC',
-        'EHE',
-        'PPP'
+        'PCE',
+        'CHL',
+        'PPE'
     ], {
         P: `gtceu:${plate}_plate`,
         E: `gtceu:${tier}_emitter`,
         H: `gtceu:${tier}_machine_hull`,
-        C: `#gtceu:circuits/${tier}`
+        C: `#gtceu:circuits/${tier}`,
+        L: `#forge:lenses`
     }).id(`kubejs:shaped/${tier}_atomic_reconstructor`)
     })
 


### PR DESCRIPTION
This time, with field generators instead of lenses!

If there is a reason other than the lenses that this was denied last time, I would like to mention that all other machine recipes (except for this one) have circuits, so please integrate a circuit into the Atomic Reconstructor recipe somehow.