### PR TITLE
Buff GT boilers to be almost reasonable compared to the Systeams stirling boiler

### DIFF
--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -280,7 +280,7 @@ machines:
 
     # The amount of steam a High Pressure Steam Solid Boiler produces per second at max temperature.
     # Default: 300
-    hpSolidBoilerBaseOutput: 1800
+    hpSolidBoilerBaseOutput: 900
 
     # The amount of steam a Steam Liquid Boiler produces per second at max temperature.
     # Default: 240

--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -276,27 +276,27 @@ machines:
   smallBoilers:
     # The amount of steam a Steam Solid Boiler produces per second at max temperature.
     # Default: 120
-    solidBoilerBaseOutput: 120
+    solidBoilerBaseOutput: 240
 
     # The amount of steam a High Pressure Steam Solid Boiler produces per second at max temperature.
     # Default: 300
-    hpSolidBoilerBaseOutput: 300
+    hpSolidBoilerBaseOutput: 600
 
     # The amount of steam a Steam Liquid Boiler produces per second at max temperature.
     # Default: 240
-    liquidBoilerBaseOutput: 240
+    liquidBoilerBaseOutput: 480
 
     # The amount of steam a High Pressure Steam Liquid Boiler produces per second at max temperature.
     # Default: 600
-    hpLiquidBoilerBaseOutput: 600
+    hpLiquidBoilerBaseOutput: 1200
 
     # The amount of steam a Steam Solar Boiler produces per second at max temperature.
     # Default: 120
-    solarBoilerBaseOutput: 120
+    solarBoilerBaseOutput: 160
 
     # The amount of steam a High Pressure Steam Solar Boiler produces per second at max temperature.
     # Default: 360
-    hpSolarBoilerBaseOutput: 360
+    hpSolarBoilerBaseOutput: 480
 
   # Large Steam Boiler Options
   largeBoilers:

--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -276,27 +276,27 @@ machines:
   smallBoilers:
     # The amount of steam a Steam Solid Boiler produces per second at max temperature.
     # Default: 120
-    solidBoilerBaseOutput: 240
+    solidBoilerBaseOutput: 360
 
     # The amount of steam a High Pressure Steam Solid Boiler produces per second at max temperature.
     # Default: 300
-    hpSolidBoilerBaseOutput: 600
+    hpSolidBoilerBaseOutput: 1800
 
     # The amount of steam a Steam Liquid Boiler produces per second at max temperature.
     # Default: 240
-    liquidBoilerBaseOutput: 480
+    liquidBoilerBaseOutput: 720
 
     # The amount of steam a High Pressure Steam Liquid Boiler produces per second at max temperature.
     # Default: 600
-    hpLiquidBoilerBaseOutput: 1200
+    hpLiquidBoilerBaseOutput: 1800
 
     # The amount of steam a Steam Solar Boiler produces per second at max temperature.
     # Default: 120
-    solarBoilerBaseOutput: 160
+    solarBoilerBaseOutput: 240
 
     # The amount of steam a High Pressure Steam Solar Boiler produces per second at max temperature.
     # Default: 360
-    hpSolarBoilerBaseOutput: 480
+    hpSolarBoilerBaseOutput: 720
 
   # Large Steam Boiler Options
   largeBoilers:

--- a/config/thermal-common.toml
+++ b/config/thermal-common.toml
@@ -39,7 +39,3 @@
 			#Whether this feature should naturally spawn in the world.
 			Enable = false
 
-		[World.Features.Apatite]
-			#Whether this feature should naturally spawn in the world.
-			Enable = false
-

--- a/defaultconfigs/systeams-server.toml
+++ b/defaultconfigs/systeams-server.toml
@@ -6,6 +6,9 @@ water_to_steam_ratio = 10
 #The multiplier on the steam dynamo's RF/t
 #Range: 0.05 ~ 8.0
 steam_dynamo_output_multiplier = 4.0
+#If the Dynamo in dynamo augment tooltips should be replaced with Dynamo & Boiler
+#This doesn't have as much support for translations (it can still be translated with the key info.systeams.augment.type.DynamoBoiler)
+replace_dynamo_augment_tooltips = true
 
 ["Steam Values"]
 	#The number of mb of steam produced per RF of energy usually produced by the same fuel in a dynamo


### PR DESCRIPTION
Fun fact: GT boilers burn fuel at a rate that's 12 (HP) or 24 (LP) times slower than TE Stirling boilers.
However, they also produce steam 10 (HP) or 26 (LP) times slower.
Tripling their steam output will result in GT boilers that produce steam 3 (HP) or 8 (LP) times slower, but are about 3x as efficient on fuel and 16x more efficient on water. Neat.

This PR also has some config updates for Thermal-related stuff lumped in.