### PR TITLE
Disable model attuning & add an informational tooltip

### DIFF
--- a/config/hostilenetworks.cfg
+++ b/config/hostilenetworks.cfg
@@ -23,7 +23,7 @@ power {
 models {
     # If true, right clicking a blank data model on a mob will attune it to that mob. If disabled, you will need to provide players with a way to get attuned models!
     # Default: true
-    B:"Right Click To Attune"=true
+    B:"Right Click To Attune"=false
 
     # Whether the Simulation Chamber will upgrade the data on a model. (0 = No, 1 = Yes, 2 = Only up to tier boundaries)
     # Default: 1; Range: [0 ~ 2]
@@ -31,7 +31,7 @@ models {
 
     # Whether killing mobs will upgrade the data on a model. Note: If you disable this, be sure to add a way for players to get non-Faulty models!
     # Default: true
-    B:"Killing Upgrades Model"=true
+    B:"Killing Upgrades Model"=false
 
     # If true, the accuracy of the model increases as it gains progress towards the next tier. If false, always uses the base accuracy of the current tier.
     # Default: true

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -26,6 +26,9 @@ ItemEvents.tooltip(tooltip => {
     //Endgame Items
     tooltip.add('kubejs:ultimate_gem', '§eRecipe is shapeless.')
 
+    //DML Data Model
+    tooltip.add('hostilenetworks:blank_data_model', '§7use it in the crafting table instead!')
+    
     //DML Matters
     tooltip.add('hostilenetworks:overworld_prediction', '§7Experience per item: 10')
     tooltip.add('hostilenetworks:nether_prediction', '§7Experience per item: 20')


### PR DESCRIPTION
All of this to more clearly indicate to the Player that crafting is the intended way of using Blank models.