### PR TITLE
Update required items for NuclearCraft fission reactor quest + wording

### DIFF
--- a/config/ftbquests/quests/chapters/mid_game.snbt
+++ b/config/ftbquests/quests/chapters/mid_game.snbt
@@ -3201,7 +3201,7 @@
 				{
 					count: 2L
 					id: "31B29F8245043671"
-					item: "gtceu:steel_gearbox"
+					item: { Count: 2, id: "gtceu:steel_gearbox" }
 					type: "item"
 				}
 			]

--- a/config/ftbquests/quests/chapters/mid_game.snbt
+++ b/config/ftbquests/quests/chapters/mid_game.snbt
@@ -3020,7 +3020,8 @@
 				""
 				"This reactor is capable of running any Low-Enriched fuel, such as TBU and LEU-235. This is a basic reactor and can be expanded, following the same pattern, to run faster. Alternatively, reactors can be designed to produce a decent amount of power for the mid game of the pack."
 				""
-				"First, set up your 150 &6Fission Reactor Casings&r to encase a 5x5x5 cube shape of empty air. Any of these reactor casings can be changed to &6Transparent Fission Reactor Casings&r. The Casings should  cover the faces of the interior cube, as well as the edges or corners. You should have exactly the right number of Casings to encase a 5x5x5 space."
+				"First, set up your 215 &6Fission Reactor Casings&r to encase a 5x5x5 cube shape of empty air. Any of these reactor casings can be changed to &6Transparent Fission Reactor Casings&r. The Casings should  cover the faces of the interior cube, as well as the edges or corners. You should have exactly the right number of Casings to encase a 5x5x5 space (with space for the controller and ports)."
+				""
 				"{@pagebreak}"
 				""
 				"Next, create a hole so you can get inside the cube. Place the &6Reactor Cells&r in an alternating pattern, with the reactor cells at the corners, and spaces between each one. Alternate between each row, creating a grid pattern. Fill in the &6Cryotheum Coolers&r between, in the empty holes. Do this for every layer, alternating between &6Cryotheum Coolers&r on the corners and &6Reactor Cells&r on the corners. You should have the perfect amount of &6Reactor Cells&r and &6Cryotheum Coolers&r for this, and the third and final layers should be the same as the first one. The reactor will now be complete when you reseal it up with the Casings you removed to access the interior."
@@ -3033,6 +3034,7 @@
 				"Info on what exactly you are going to be doing with you fancy new reactor can be found in the &bFission and Fusion&r Chapter."
 			]
 			disable_toast: true
+			icon: "nuclearcraft:fission_reactor_controller"
 			id: "745628397790ED7A"
 			rewards: [{
 				id: "0F6CC38788229FC4"
@@ -3041,11 +3043,37 @@
 			}]
 			shape: "hexagon"
 			size: 2.0d
-			tasks: [{
-				id: "374FBDF56D3B9E22"
-				item: "nuclearcraft:fission_reactor_controller"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "374FBDF56D3B9E22"
+					item: "nuclearcraft:fission_reactor_controller"
+					type: "item"
+				}
+				{
+					count: 215L
+					id: "09B080275946957D"
+					item: "nuclearcraft:fission_reactor_casing"
+					type: "item"
+				}
+				{
+					count: 2L
+					id: "1FE61627CF275B87"
+					item: "nuclearcraft:fission_reactor_port"
+					type: "item"
+				}
+				{
+					count: 62L
+					id: "39B4F53A8DDFD446"
+					item: "nuclearcraft:cryotheum_heat_sink"
+					type: "item"
+				}
+				{
+					count: 63L
+					id: "3759DFA116F90838"
+					item: "nuclearcraft:fission_reactor_solid_fuel_cell"
+					type: "item"
+				}
+			]
 			title: "Fission Reactor"
 			x: 47.0d
 			y: 11.0d
@@ -3173,7 +3201,7 @@
 				{
 					count: 2L
 					id: "31B29F8245043671"
-					item: { Count: 2, id: "gtceu:steel_gearbox" }
+					item: "gtceu:steel_gearbox"
 					type: "item"
 				}
 			]


### PR DESCRIPTION
The amount of required casing is incorrect for 5x5x5 internal (7x7x7 external)

(7^3) - (5^3) = 218

- Subtract 1 for controller
- Subtract 2 for ports
- = 215

Also update the required items needed to build a complete reactor as described by the quest