### PR TITLE
Fix all custom alloy recipes to be consistent

### DIFF
--- a/kubejs/server_scripts/gregtech/Alloys_Recipes.js
+++ b/kubejs/server_scripts/gregtech/Alloys_Recipes.js
@@ -77,7 +77,7 @@ ServerEvents.recipes(event => {
         .duration(50)
         .EUt(16)
 
-        event.recipes.gtceu.alloy_smelter('kubejs:netherite_ingot')
+    event.recipes.gtceu.alloy_smelter('kubejs:netherite_ingot')
         .itemInputs('4x #forge:ingots/gold', '4x minecraft:netherite_scrap') // was flipped
         .itemOutputs('1x minecraft:netherite_ingot')
         .duration(100)
@@ -136,14 +136,14 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.mixer("kubejs:lumium_dust")
         .itemInputs('4x #forge:dusts/tin_alloy', '2x #forge:dusts/sterling_silver', '2x extendedcrafting:luminessence', 'kubejs:energized_clathrate')
-        .itemOutputs('4x gtceu:lumium_dust')
+        .itemOutputs('8x gtceu:lumium_dust')
         .inputFluids(Fluid.of('kubejs:molten_primal_mana', 1000))
         .duration(300)
         .EUt(1920)
 
     event.recipes.gtceu.mixer("kubejs:signalum_dust")
         .itemInputs('4x #forge:dusts/annealed_copper', '2x #forge:dusts/ardite', '2x #forge:dusts/red_alloy', 'kubejs:destabilized_clathrate')
-        .itemOutputs('4x gtceu:signalum_dust')
+        .itemOutputs('8x gtceu:signalum_dust')
         .inputFluids(Fluid.of('kubejs:molten_primal_mana', 1000))
         .duration(300)
         .EUt(1920)
@@ -159,7 +159,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.mixer("kubejs:enderium_dust")
         .itemInputs('4x gtceu:lead_dust', '2x gtceu:platinum_dust', 'gtceu:blue_steel_dust', 'gtceu:osmium_dust', 'gtceu:tantalum_dust', 'kubejs:resonant_clathrate')
-        .itemOutputs('4x gtceu:enderium_dust')
+        .itemOutputs('9x gtceu:enderium_dust')
         .inputFluids(Fluid.of('kubejs:molten_primal_mana', 1000))
         .duration(300)
         .EUt(1920)
@@ -207,14 +207,6 @@ ServerEvents.recipes(event => {
 })
 
 ServerEvents.recipes(event => {
-    event.remove('gtceu:alloy_blast_smelter/red_alloy')
-    event.recipes.gtceu.alloy_blast_smelter("kubejs:red_alloy_fluid")
-        .itemInputs('2x gtceu:copper_dust', '3x #forge:dusts/redstone')
-        .outputFluids(Fluid.of('gtceu:red_alloy', 288))
-        .duration(75)
-        .EUt(16)
-        .circuit(5)
-        .blastFurnaceTemp(1400)
     event.recipes.gtceu.alloy_blast_smelter("kubejs:conductive_alloy_fluid")
         .itemInputs('#forge:dusts/iron', '#forge:dusts/redstone')
         .outputFluids(Fluid.of('gtceu:conductive_alloy', 144))
@@ -292,57 +284,57 @@ ServerEvents.recipes(event => {
     event.remove ({ id: 'gtceu:alloy_blast_smelter/enderium_gas' })
 
     event.recipes.gtceu.alloy_blast_smelter('signalum_mana')
-    .itemInputs('4x gtceu:annealed_copper_dust', '2x gtceu:ardite_dust', '2x gtceu:red_alloy_dust', 'kubejs:destabilized_clathrate')
-    .inputFluids(Fluid.of('kubejs:molten_primal_mana', 1000))
-    .circuit(4)
-    .outputFluids(Fluid.of('gtceu:molten_signalum', 1152))
-    .duration(8400) // 420s
-    .EUt(7680)
-    .blastFurnaceTemp(4000)
+        .itemInputs('4x gtceu:annealed_copper_dust', '2x gtceu:ardite_dust', '2x gtceu:copper_dust', '8x minecraft:redstone', 'kubejs:destabilized_clathrate')
+        .inputFluids(Fluid.of('kubejs:molten_primal_mana', 1000))
+        .circuit(4)
+        .outputFluids(Fluid.of('gtceu:molten_signalum', 1152))
+        .duration(8400) // 420s
+        .EUt(7680)
+        .blastFurnaceTemp(4000)
 
     event.recipes.gtceu.alloy_blast_smelter('signalum_mana_gas')
-    .itemInputs('4x gtceu:annealed_copper_dust', '2x gtceu:ardite_dust', '2x gtceu:red_alloy_dust', 'kubejs:destabilized_clathrate')
-    .inputFluids('kubejs:molten_primal_mana 1000', 'gtceu:helium 800')
-    .circuit(14)
-    .outputFluids(Fluid.of('gtceu:molten_signalum', 1152))
-    .duration(5620) // 281s
-    .EUt(7680)
-    .blastFurnaceTemp(4000)
+        .itemInputs('4x gtceu:annealed_copper_dust', '2x gtceu:ardite_dust', '2x gtceu:copper_dust', '8x minecraft:redstone', 'kubejs:destabilized_clathrate')
+        .inputFluids('kubejs:molten_primal_mana 1000', 'gtceu:helium 800')
+        .circuit(14)
+        .outputFluids(Fluid.of('gtceu:molten_signalum', 1152))
+        .duration(5620) // 281s
+        .EUt(7680)
+        .blastFurnaceTemp(4000)
 
     event.recipes.gtceu.alloy_blast_smelter('lumium_mana')
-    .itemInputs('4x gtceu:tin_alloy_dust', '2x gtceu:sterling_silver_dust', '2x extendedcrafting:luminessence', 'kubejs:energized_clathrate')
-    .inputFluids(Fluid.of('kubejs:molten_primal_mana', 1000))
-    .circuit(4)
-    .outputFluids(Fluid.of('gtceu:molten_lumium', 864))
-    .duration(7200) // 360s
-    .EUt(7680)
-    .blastFurnaceTemp(4500)
+        .itemInputs('2x gtceu:tin_dust', '2x gtceu:iron_dust', '2x gtceu:sterling_silver_dust', '2x extendedcrafting:luminessence', 'kubejs:energized_clathrate')
+        .inputFluids(Fluid.of('kubejs:molten_primal_mana', 1000))
+        .circuit(4)
+        .outputFluids(Fluid.of('gtceu:molten_lumium', 1152))
+        .duration(7200) // 360s
+        .EUt(4800)
+        .blastFurnaceTemp(4500)
 
     event.recipes.gtceu.alloy_blast_smelter('lumium_mana_gas')
-    .itemInputs('4x gtceu:tin_alloy_dust', '2x gtceu:sterling_silver_dust', '2x extendedcrafting:luminessence', 'kubejs:energized_clathrate')
-    .inputFluids('kubejs:molten_primal_mana 1000', 'gtceu:helium 800')
-    .circuit(14)
-    .outputFluids(Fluid.of('gtceu:molten_lumium', 864))
-    .duration(4800) // 240s
-    .EUt(7680)
-    .blastFurnaceTemp(4500)
-
-    event.recipes.gtceu.alloy_blast_smelter('enderium_mana_gas')
-    .itemInputs('4x gtceu:lead_dust', '2x gtceu:platinum_dust', 'gtceu:blue_steel_dust', 'gtceu:osmium_dust', 'gtceu:tantalum_dust', 'kubejs:resonant_clathrate')
-    .inputFluids('kubejs:molten_primal_mana 1000', 'gtceu:krypton 80')
-    .circuit(14)
-    .outputFluids(Fluid.of('gtceu:molten_enderium', 1296))
-    .duration(7200) // 320s
-    .EUt(7680)
-    .blastFurnaceTemp(6400)
+        .itemInputs('2x gtceu:tin_dust', '2x gtceu:iron_dust', '2x gtceu:sterling_silver_dust', '2x extendedcrafting:luminessence', 'kubejs:energized_clathrate')
+        .inputFluids('kubejs:molten_primal_mana 1000', 'gtceu:helium 800')
+        .circuit(14)
+        .outputFluids(Fluid.of('gtceu:molten_lumium', 1152))
+        .duration(4800) // 240s
+        .EUt(4800)
+        .blastFurnaceTemp(4500)
 
     event.recipes.gtceu.alloy_blast_smelter('enderium_mana')
-    .itemInputs('4x gtceu:lead_dust', '2x gtceu:platinum_dust', 'gtceu:blue_steel_dust', 'gtceu:osmium_dust', 'gtceu:tantalum_dust', 'kubejs:resonant_clathrate')
-    .inputFluids(Fluid.of('kubejs:molten_primal_mana', 1000))
-    .circuit(4)
-    .outputFluids(Fluid.of('gtceu:molten_enderium', 1296))
-    .duration(8100) // 480S
-    .EUt(7680)
-    .blastFurnaceTemp(4500)
+        .itemInputs('4x gtceu:lead_dust', '2x gtceu:platinum_dust', 'gtceu:blue_steel_dust', 'gtceu:osmium_dust', 'gtceu:tantalum_dust', 'kubejs:resonant_clathrate')
+        .inputFluids(Fluid.of('kubejs:molten_primal_mana', 1000))
+        .circuit(4)
+        .outputFluids(Fluid.of('gtceu:molten_enderium', 1296))
+        .duration(8100) // 480S
+        .EUt(30720)
+        .blastFurnaceTemp(6400)
+    
+    event.recipes.gtceu.alloy_blast_smelter('enderium_mana_gas')
+        .itemInputs('4x gtceu:lead_dust', '2x gtceu:platinum_dust', 'gtceu:blue_steel_dust', 'gtceu:osmium_dust', 'gtceu:tantalum_dust', 'kubejs:resonant_clathrate')
+        .inputFluids('kubejs:molten_primal_mana 1000', 'gtceu:krypton 90')
+        .circuit(14)
+        .outputFluids(Fluid.of('gtceu:molten_enderium', 1296))
+        .duration(7200) // 320s
+        .EUt(30720)
+        .blastFurnaceTemp(6400)
 
 }) 

--- a/kubejs/server_scripts/gregtech/Alloys_Recipes.js
+++ b/kubejs/server_scripts/gregtech/Alloys_Recipes.js
@@ -34,7 +34,7 @@ ServerEvents.recipes(event => {
 	alloySmeltingVariant(
 		['#forge:ingots/iron', '#forge:dusts/iron'],
 		['#forge:dusts/redstone'],
-		'gtceu:conductive_alloy_ingot', 7.5, 16);
+		'2x gtceu:conductive_alloy_ingot', 7.5, 16);
 
 	alloySmeltingVariant(
 		['#forge:ingots/iron', '#forge:dusts/iron'],
@@ -95,6 +95,11 @@ ServerEvents.recipes(event => {
     event.remove({ id: "gtceu:mixer/black_steel" })
 
 	event.shapeless('gtceu:conductive_alloy_dust', ['#forge:dusts/iron', '#forge:dusts/redstone']).id('kubejs:conductive_alloy_dust_handcraft')
+    event.recipes.gtceu.mixer("kubejs:conductive_alloy_dust")
+        .itemInputs('#forge:dusts/iron', '#forge:dusts/redstone')
+        .itemOutputs('2x gtceu:conductive_alloy_dust')
+        .duration(40)
+        .EUt(30)
 
     event.recipes.gtceu.mixer("kubejs:black_steel_dust")
         .itemInputs('3x #forge:dusts/steel', '2x #forge:dusts/black_bronze', '2x gtceu:void_gem', '2x gtceu:coal_perfect')
@@ -110,13 +115,13 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.mixer("kubejs:vibrant_alloy_dust")
         .itemInputs('#forge:dusts/energetic_alloy', '#forge:dusts/ender_pearl')
-        .itemOutputs('gtceu:vibrant_alloy_dust')
+        .itemOutputs('2x gtceu:vibrant_alloy_dust')
         .duration(260)
         .EUt(30)
 
     event.recipes.gtceu.mixer("kubejs:energetic_alloy_dust")
         .itemInputs('2x #forge:dusts/gold', '#forge:dusts/redstone', '#forge:dusts/glowstone')
-        .itemOutputs('2x gtceu:energetic_alloy_dust')
+        .itemOutputs('4x gtceu:energetic_alloy_dust')
         .duration(140)
         .EUt(30)
 
@@ -209,47 +214,13 @@ ServerEvents.recipes(event => {
 ServerEvents.recipes(event => {
     event.recipes.gtceu.alloy_blast_smelter("kubejs:conductive_alloy_fluid")
         .itemInputs('#forge:dusts/iron', '#forge:dusts/redstone')
-        .outputFluids(Fluid.of('gtceu:conductive_alloy', 144))
+        .outputFluids(Fluid.of('gtceu:conductive_alloy', 288))
         .duration(112)
         .EUt(16)
         .circuit(2)
         .blastFurnaceTemp(1400)
 
-    event.recipes.gtceu.alloy_blast_smelter("kubejs:energetic_alloy_fluid")
-        .itemInputs('2x gtceu:gold_dust', '#forge:dusts/redstone', 'minecraft:glowstone_dust')
-        .outputFluids(Fluid.of('gtceu:energetic_alloy', 576))
-        .duration(1200)
-        .EUt(120)
-        .circuit(3)
-        .blastFurnaceTemp(1250)
-
-    event.recipes.gtceu.alloy_blast_smelter("kubejs:energetic_alloy_fluid_from_gold_dust")
-        .itemInputs('2x gtceu:gold_dust', '#forge:dusts/redstone', 'minecraft:glowstone_dust')
-        .inputFluids(Fluid.of('gtceu:nitrogen', 4000))
-        .outputFluids(Fluid.of('gtceu:energetic_alloy', 576))
-        .duration(804)
-        .EUt(120)
-        .circuit(13)
-        .blastFurnaceTemp(1250)
-
-    event.recipes.gtceu.alloy_blast_smelter("kubejs:vibrant_alloy_fluid")
-        .itemInputs('gtceu:energetic_alloy_dust', 'gtceu:ender_pearl_dust')
-        .outputFluids(Fluid.of('gtceu:vibrant_alloy', 288))
-        .duration(600) // 30s
-        .EUt(120)
-        .circuit(2)
-        .blastFurnaceTemp(1350)
-
-    event.recipes.gtceu.alloy_blast_smelter("kubejs:vibrant_alloy_fluid_from_energetic_dust")
-        .itemInputs('gtceu:energetic_alloy_dust', 'gtceu:ender_pearl_dust')
-        .inputFluids(Fluid.of('gtceu:nitrogen', 2000))
-        .outputFluids(Fluid.of('gtceu:vibrant_alloy', 288))
-        .duration(402) // 20.1s
-        .EUt(120)
-        .circuit(12)
-        .blastFurnaceTemp(1350)
-
-	// soularium
+    // soularium
     event.recipes.gtceu.alloy_blast_smelter('kubejs:soularium_fluid')
         .itemInputs('#forge:dusts/gold', 'soul_sand')
 		.circuit(2)

--- a/kubejs/server_scripts/gregtech/Alloys_Recipes.js
+++ b/kubejs/server_scripts/gregtech/Alloys_Recipes.js
@@ -212,7 +212,7 @@ ServerEvents.recipes(event => {
 })
 
 ServerEvents.recipes(event => {
-    event.recipes.gtceu.alloy_blast_smelter("kubejs:conductive_alloy_fluid")
+    event.recipes.gtceu.alloy_blast_smelter("kubejs:conductive_alloy_abs")
         .itemInputs('#forge:dusts/iron', '#forge:dusts/redstone')
         .outputFluids(Fluid.of('gtceu:conductive_alloy', 288))
         .duration(112)
@@ -220,13 +220,46 @@ ServerEvents.recipes(event => {
         .circuit(2)
         .blastFurnaceTemp(1400)
 
-    // soularium
-    event.recipes.gtceu.alloy_blast_smelter('kubejs:soularium_fluid')
+    event.recipes.gtceu.alloy_blast_smelter('kubejs:soularium_abs')
         .itemInputs('#forge:dusts/gold', 'soul_sand')
 		.circuit(2)
         .outputFluids(Fluid.of('gtceu:soularium', 144))
         .duration(90) // 4.5s
         .EUt(16)
+        .blastFurnaceTemp(1200)
+
+    //Black steel recipes. Has both regular & advanced recipe, each with a noble gas version.
+    event.remove({ id: 'gtceu:alloy_blast_smelter/black_steel'})
+    event.remove({ id: 'gtceu:alloy_blast_smelter/black_steel_gas'})
+    event.recipes.gtceu.alloy_blast_smelter('kubejs:black_steel')
+        .itemInputs('3x #forge:dusts/steel', '2x #forge:dusts/black_bronze', '2x gtceu:void_gem', '2x gtceu:coal_perfect')
+		.circuit(3)
+        .outputFluids(Fluid.of('gtceu:black_steel', 1296))
+        .duration(2880) // 144s
+        .EUt(120)
+        .blastFurnaceTemp(1200)
+    event.recipes.gtceu.alloy_blast_smelter('kubejs:black_steel_gas')
+        .itemInputs('3x #forge:dusts/steel', '2x #forge:dusts/black_bronze', '2x gtceu:void_gem', '2x gtceu:coal_perfect')
+		.inputFluids(Fluid.of('gtceu:nitrogen', 9000))
+        .circuit(13)
+        .outputFluids(Fluid.of('gtceu:black_steel', 1296))
+        .duration(1929) // 96.45s
+        .EUt(120)
+        .blastFurnaceTemp(1200)
+    event.recipes.gtceu.alloy_blast_smelter('kubejs:black_steel_alternate')
+    .itemInputs('15x #forge:dusts/steel', '6x #forge:dusts/copper', '2x #forge:dusts/gold', '2x #forge:dusts/silver', '10x #forge:gems/void', '10x gtceu:coal_perfect')
+		.circuit(3)
+        .outputFluids(Fluid.of('gtceu:black_steel', 6480))
+        .duration(14400) // 720s
+        .EUt(240)
+        .blastFurnaceTemp(1200)
+    event.recipes.gtceu.alloy_blast_smelter('kubejs:black_steel_alternate_gas')
+    .itemInputs('15x #forge:dusts/steel', '6x #forge:dusts/copper', '2x #forge:dusts/gold', '2x #forge:dusts/silver', '10x #forge:gems/void', '10x gtceu:coal_perfect')
+		.inputFluids(Fluid.of('gtceu:nitrogen', 9000))
+        .circuit(13)
+        .outputFluids(Fluid.of('gtceu:black_steel', 6480))
+        .duration(9645) // 482.25s
+        .EUt(240)
         .blastFurnaceTemp(1200)
 
     // End Steel
@@ -236,8 +269,7 @@ ServerEvents.recipes(event => {
         .duration(260)
         .EUt(120)
 
-
-	// moni ceu 1.7 normal
+	//Dark Soularium recipe (Requires Tritium!)
 	event.recipes.gtceu.electric_blast_furnace('kubejs:dark_soularium_ingot')
 		.itemInputs('#forge:ingots/soularium', '#forge:ingots/dark_steel')
 		.inputFluids(Fluid.of('gtceu:tritium', 1000))

--- a/kubejs/startup_scripts/material_registry/eio.js
+++ b/kubejs/startup_scripts/material_registry/eio.js
@@ -20,7 +20,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .ingot().fluid()
         .color(0xffb545).iconSet('shiny')
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR)
-        .blastTemp(1250, 'low', 128, 400)
+        .blastTemp(1250, 'low', 120, 400)
 		.components('2x gold', 'redstone', 'glowstone')
         .cableProperties(128, 1, 0, true)
 
@@ -28,7 +28,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .ingot().fluid()
         .color(0xa4ff70).iconSet('shiny')
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_BOLT_SCREW)
-        .blastTemp(1350, 'low', 128, 400)
+        .blastTemp(1350, 'low', 120, 400)
 		.components('energetic_alloy', 'ender_pearl')
         .cableProperties(512, 1, 0, true)
 


### PR DESCRIPTION
now more alloy recipes are consistent with:
- GT Conservation of mass (6 dust in => 6 dust out)
- ABS recipe ingredients match Mixer recipes (No more cheap Black Steel!)
- ABS coil & temperature tiers max EBF recipes (No more tier-skipping to Enderium!)
- Energetic and Vibrant alloy EBF recipes no longer use the full amp (to be consistent with other EBF recipes)

Consequences:
ABS now saves more time for all affected alloys than the EBF recipe
Conductive Alloy is about 2x cheaper on materials, and Lumium is 33% cheaper.