### PR TITLE
[Urgent] Fix broken Sculk Core crafting

### DIFF
--- a/config/extendedcrafting-common.toml
+++ b/config/extendedcrafting-common.toml
@@ -100,7 +100,7 @@
 	#Range: > 0
 	autoCrafterInsertPowerRate = 100
 	#Should the Flux Crafter be enabled?
-	enabled = false
+	enabled = true
 	#Should the Auto Flux Crafter be enabled?
 	autoCrafterEnabled = true
 


### PR DESCRIPTION
I screwed up progression!
quite the fucky-wucky
a real fucko boingo!

I blame ExtendedCrafting's for removing Flux Crafting entirely when I
disable the config option labelled "Should the Flux Crafter be enabled?"
but enable the config option labelled "Should the Auto Flux Crafter be enabled?"