### PR TITLE
Gregified recipes for Building Gadgets attempt 2

### DIFF
--- a/kubejs/server_scripts/_hardmode/hardmode.js
+++ b/kubejs/server_scripts/_hardmode/hardmode.js
@@ -49,8 +49,6 @@ ServerEvents.recipes(event => {
             .duration(100)
         }
 
-        event.replaceInput({ output: 'buildinggadgets2:gadget_exchanging' }, 'minecraft:redstone', 'gtceu:iv_emitter')
-
         event.remove({ output: 'gtceu:extractor/tank_data' })
         event.recipes.gtceu.extractor('omnicdata')
         .itemInputs('kubejs:heart_of_a_universe')

--- a/kubejs/server_scripts/mods/buildinggadgets2.js
+++ b/kubejs/server_scripts/mods/buildinggadgets2.js
@@ -1,0 +1,109 @@
+ServerEvents.recipes( event => {
+    event.remove({id: 'buildinggadgets2:template_manager'})
+    event.shaped(
+        'buildinggadgets2:template_manager', [
+            'PMP',
+            'CGC',
+            'PLP'
+        ], {
+            M: 'minecraft:paper',
+            P: 'gtceu:iron_plate',
+            G: 'gtceu:restonia_gear',
+            C: '#gtceu:circuits/lv',
+            L: '#forge:plates/lapis'
+        }
+    )
+
+    event.remove({id: 'buildinggadgets2:gadget_building'})
+    event.shaped(
+        'buildinggadgets2:gadget_building', [
+            'PE',
+            'CM',
+            'PB'
+        ], {
+            M: 'gtceu:computer_monitor_cover',
+            P: 'gtceu:iron_plate',
+            E: 'gtceu:lv_emitter',
+            C: '#gtceu:circuits/lv',
+            B: '#gtceu:batteries/lv'
+        }
+    )
+
+    event.remove({id: 'buildinggadgets2:gadget_exchanging'})
+    if (isHardMode) {
+        event.shaped(
+            'buildinggadgets2:gadget_exchanging', [
+                'PE',
+                'CM',
+                'PB'
+            ], {
+                M: 'gtceu:computer_monitor_cover',
+                P: 'gtceu:iron_plate',
+                E: 'gtceu:iv_emitter',
+                C: '#gtceu:circuits/mv',
+                B: '#gtceu:batteries/lv'
+            }
+        )
+    } else {
+        event.shaped(
+            'buildinggadgets2:gadget_exchanging', [
+                'PE',
+                'CM',
+                'PB'
+            ], {
+                M: 'gtceu:computer_monitor_cover',
+                P: 'gtceu:iron_plate',
+                E: 'gtceu:mv_emitter',
+                C: '#gtceu:circuits/mv',
+                B: '#gtceu:batteries/lv'
+            }
+        )
+    }
+
+    event.remove({id: 'buildinggadgets2:gadget_copy_paste'})
+    event.shaped(
+        'buildinggadgets2:gadget_copy_paste', [
+            'SE',
+            'CM',
+            'PB'
+        ], {
+            M: 'gtceu:computer_monitor_cover',
+            P: 'gtceu:iron_plate',
+            E: 'gtceu:lv_emitter',
+            S: 'gtceu:lv_sensor',
+            C: '#gtceu:circuits/mv',
+            B: '#gtceu:batteries/mv'
+        }
+    )
+
+    event.remove({id: 'buildinggadgets2:gadget_cut_paste'})
+    event.shaped(
+        'buildinggadgets2:gadget_cut_paste', [
+            'SE',
+            'CM',
+            'PB'
+        ], {
+            M: 'gtceu:computer_monitor_cover',
+            P: 'gtceu:steel_plate',
+            E: 'gtceu:lv_emitter',
+            S: 'gtceu:lv_sensor',
+            C: '#gtceu:circuits/lv',
+            B: '#gtceu:batteries/hv'
+        }
+    )
+
+    event.remove({id: 'buildinggadgets2:gadget_destruction'})
+    event.shaped(
+        'buildinggadgets2:gadget_destruction', [
+            'PE',
+            'CM',
+            'PB'
+        ], {
+            M: 'gtceu:computer_monitor_cover',
+            P: 'gtceu:steel_plate',
+            E: 'gtceu:lv_emitter',
+            C: '#gtceu:circuits/lv',
+            B: '#gtceu:batteries/mv'
+        }
+    )
+})


### PR DESCRIPTION
Taking a second try now that Effortless Building's been removed.

Same as #450, but with a few changes.
- With the addition of the Template Manager, Every Building Gadgets 2 recipe has been Gregified.
- Gadget Recipes are somewhat cheaper.
- Everything gets unlocked after Aluminium (to make the computer monitor covers) except:
    Exchanging gadget (Requires MV emitter in NM, IV in HM/EM)
    Copy/paste gadget (Requires one MV circuit)
    Template Manager (Requires 2 MV circuits & 1 Restonia gear)