### PR TITLE
Functionally swap the Shattered & Corrupted universe datas

### DIFF
--- a/config/ftbquests/quests/chapters/end_game.snbt
+++ b/config/ftbquests/quests/chapters/end_game.snbt
@@ -744,9 +744,9 @@
 		{
 			dependencies: ["4261BDA34D716EC8"]
 			description: [
-				"&7&oUh boss? I think putting the Universe Creation Data in the Subatomic Digital Assembler was a bad idea.&r"
+				"&7&oUh boss? I think putting the &6Universe Creation Data&r in the Subatomic Digital Assembler was a bad idea.&r"
 				""
-				"Attempting to replicate Universe Creation Data will instead corrupt the data, giving you this unsightly mess."
+				"Attempting to replicate Universe Creation Data will instead &eshatter the universe inside&r, giving you this unsightly mess."
 				""
 				"Not all may be lost, though..."
 			]
@@ -754,10 +754,10 @@
 			shape: "hexagon"
 			tasks: [{
 				id: "3F79F8E984CF6A2A"
-				item: "kubejs:corrupted_universe_data"
+				item: "kubejs:shattered_universe_data"
 				type: "item"
 			}]
-			title: "&9Corrupted Universe Data"
+			title: "&9Shattered Universe Data"
 			x: 31.0d
 			y: -18.0d
 		}
@@ -897,19 +897,19 @@
 				"1D00150456DEF379"
 			]
 			description: [
-				"Sending out this corrupted data with some shattered star data will return &9Shattered Universe Data&r.  "
+				"Forcefully combining this shattered universe data with some shattered star data will return &6Corrupted Universe Data&r - a realm with &eglitched duplicates of assorted valuable resources.&r"
 				""
-				"Using this data alongside some infinity catalysts will return multiple Hearts of The Universe, making a nice net profit."
+				"Using this data alongside some infinity catalysts will return multiple &6Hearts of The Universe&r, making a nice net profit."
 			]
 			id: "769047385AAC71B2"
 			shape: "hexagon"
 			subtitle: "Sometimes you gotta spend money to make money"
 			tasks: [{
 				id: "45C0AD6F1EC8334B"
-				item: "kubejs:shattered_universe_data"
+				item: "kubejs:corrupted_universe_data"
 				type: "item"
 			}]
-			title: "&9Shattered Universe Data"
+			title: "&9Corrupted Universe Data"
 			x: 28.5d
 			y: -18.0d
 		}

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -542,7 +542,7 @@ ServerEvents.recipes(event => {
                 '64x kubejs:dilithium_crystal', 
                 '64x kubejs:dilithium_crystal', 
                 '64x minecraft:sculk_catalyst', 
-                'kubejs:shattered_universe_data',
+                'kubejs:corrupted_universe_data',
                 'kubejs:lair_of_the_warden_data')
     .itemOutputs('64x kubejs:hadal_shard',
                  '64x kubejs:warden_heart',
@@ -555,30 +555,30 @@ ServerEvents.recipes(event => {
         event.recipes.gtceu.advanced_microverse_iii('kubejs:t_nine_forth')
         .itemInputs(
             'kubejs:microminer_t9', 
-            'kubejs:corrupted_universe_data', 
+            'kubejs:shattered_universe_data', 
             '64x kubejs:shattered_star_data', 
             '64x kubejs:shattered_star_data', 
             '64x kubejs:shattered_star_data', 
             '64x kubejs:shattered_star_data'
         )
-        .itemOutputs('kubejs:shattered_universe_data')
+        .itemOutputs('kubejs:corrupted_universe_data')
         .duration(1000)
         .EUt(194387)
 
         event.recipes.gtceu.advanced_microverse_iii('kubejs:t_ten_second')
-        .itemInputs('kubejs:microminer_t10', '8x kubejs:infinity_catalyst', 'kubejs:shattered_universe_data')
+        .itemInputs('kubejs:microminer_t10', '8x kubejs:infinity_catalyst', 'kubejs:corrupted_universe_data')
         .itemOutputs('16x kubejs:heart_of_a_universe')
         .duration(3000)
         .EUt(2000000)
 
     event.recipes.gtceu.advanced_microverse_iii('kubejs:t_ten_third')
-        .itemInputs('kubejs:microminer_t10', '64x kubejs:singularity_containment_unit', 'kubejs:corrupted_universe_data', ) // could be increased 
+        .itemInputs('kubejs:microminer_t10', '64x kubejs:singularity_containment_unit', 'kubejs:shattered_universe_data', ) // could be increased 
         .itemOutputs('64x kubejs:contained_singularity')
         .duration(400)
         .EUt(2000000)
 
         event.recipes.gtceu.advanced_microverse_iii('kubejs:t_eleven_first')
-        .itemInputs('kubejs:microminer_t11', 'kubejs:infinity_catalyst', 'kubejs:corrupted_universe_data', )
+        .itemInputs('kubejs:microminer_t11', 'kubejs:infinity_catalyst', 'kubejs:shattered_universe_data', )
         .itemOutputs('64x kubejs:alien_scrap', '64x kubejs:alien_scrap', '64x kubejs:alien_scrap', '64x kubejs:alien_scrap')
         .duration(600)
         .EUt(2000000)
@@ -601,7 +601,7 @@ ServerEvents.recipes(event => {
             '64x gtceu:gravi_star',
             '64x gtceu:gravi_star',
             '64x gtceu:gravi_star',
-            'kubejs:shattered_universe_data')
+            'kubejs:corrupted_universe_data')
         .itemOutputs('64x kubejs:quasi_stable_neutron_star', 
             '64x kubejs:quasi_stable_neutron_star', 
             '64x kubejs:quasi_stable_neutron_star', 
@@ -620,7 +620,7 @@ ServerEvents.recipes(event => {
         .EUt(32000000)
 
     event.recipes.gtceu.advanced_microverse_iii('kubejs:t_twelve_second')
-        .itemInputs('kubejs:microminer_t12', '8x kubejs:timeless_monic_heavy_plating', '4x kubejs:universe_creation_data', '2x kubejs:corrupted_universe_data', '2x kubejs:shattered_universe_data')
+        .itemInputs('kubejs:microminer_t12', '8x kubejs:timeless_monic_heavy_plating', '4x kubejs:universe_creation_data', '2x kubejs:shattered_universe_data', '2x kubejs:corrupted_universe_data')
         .itemOutputs('4x kubejs:causality_exempt_monic_heavy_plating')
         .duration(800)
         .EUt(128000000)

--- a/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
+++ b/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
@@ -40,7 +40,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.subatomic_digital_assembly('kubejs:corrupted_data')
         .itemInputs('kubejs:universe_creation_data')
-        .itemOutputs('kubejs:corrupted_universe_data')
+        .itemOutputs('kubejs:shattered_universe_data')
         .circuit(1)
         .CWUt(32)
         .duration(200)


### PR DESCRIPTION
We are at a golden hour at this point in time where nobody (AFAIK) seems to be actively playing in the endgame. This enables us to make minor tweaks such as this one, so that the SDA _shatters both star and universe data_, instead of shattering one and corrupting the other for some reason.

Additionally, this includes additional lore explaining why the (now Corrupted instead of Shattered) universe data can accomplish the unique purpose of duplicating valuable resources in the endgame.