### PR TITLE
Nerf the fuel efficiency of Thermal's Steam Boiler

### DIFF
--- a/defaultconfigs/systeams-server.toml
+++ b/defaultconfigs/systeams-server.toml
@@ -12,14 +12,14 @@ replace_dynamo_augment_tooltips = true
 
 #For future reference: Boilers are 16x as efficient as Dynamos by default.
 #This means that Numismatic Boilers are 16 * 0.5 = 8x as efficient as Numismatic Dynamos,
-#While Stirling Boilers are 16 * 0.125 = 2x as efficient as Stirling Dynamos.
+#While Stirling Boilers are 16 * 0.25 = 4x as efficient as Stirling Dynamos.
 # -Xefyr
 
 ["Steam Values"]
 	#The number of mb of steam produced per RF of energy usually produced by the same fuel in a dynamo
 	#Note that this does not affect the steam dynamo's rates. That needs to be adjusted with a datapack
 	#Range: 0.05 ~ 100.0
-	stirling = 0.125
+	stirling = 0.25
 	#Range: 0.05 ~ 100.0
 	magmatic = 0.5
 	#Range: 0.05 ~ 100.0

--- a/defaultconfigs/systeams-server.toml
+++ b/defaultconfigs/systeams-server.toml
@@ -4,14 +4,22 @@
 #Range: 0.1 ~ 10.0
 water_to_steam_ratio = 10
 #The multiplier on the steam dynamo's RF/t
-#Range: 0.05 ~ 8.0
-steam_dynamo_output_multiplier = 4.0
+#Range: 0.05 ~ 10.0
+steam_dynamo_output_multiplier = 1.0
+#If the Dynamo in dynamo augment tooltips should be replaced with Dynamo & Boiler
+#This doesn't have as much support for translations (it can still be translated with the key info.systeams.augment.type.DynamoBoiler)
+replace_dynamo_augment_tooltips = true
+
+#For future reference: Boilers are 16x as efficient as Dynamos by default.
+#This means that Numismatic Boilers are 16 * 0.5 = 8x as efficient as Numismatic Dynamos,
+#While Stirling Boilers are 16 * 0.125 = 2x as efficient as Stirling Dynamos.
+# -Xefyr
 
 ["Steam Values"]
 	#The number of mb of steam produced per RF of energy usually produced by the same fuel in a dynamo
 	#Note that this does not affect the steam dynamo's rates. That needs to be adjusted with a datapack
 	#Range: 0.05 ~ 100.0
-	stirling = 1
+	stirling = 0.125
 	#Range: 0.05 ~ 100.0
 	magmatic = 0.5
 	#Range: 0.05 ~ 100.0
@@ -26,25 +34,29 @@ steam_dynamo_output_multiplier = 4.0
 	gourmand = 0.5
 	#Range: 0.05 ~ 100.0
 	pneumatic = 0.5
+	#Range: 0.05 ~ 100.0
+	frost = 0.5
 
 ["Boiler Speed Multipliers"]
 	#The speed multiplier on each boiler's mB/t
 	#Range: 0.05 ~ 20.0
 	stirling = 8.0
 	#Range: 0.05 ~ 20.0
-	magmatic = 2.0
+	magmatic = 8.0
 	#Range: 0.05 ~ 20.0
-	compression = 2.0
+	compression = 8.0
 	#Range: 0.05 ~ 20.0
-	numismatic = 2.0
+	numismatic = 8.0
 	#Range: 0.05 ~ 20.0
-	lapidary = 2.0
+	lapidary = 8.0
 	#Range: 0.05 ~ 20.0
-	disenchantment = 2.0
+	disenchantment = 8.0
 	#Range: 0.05 ~ 20.0
-	gourmand = 2.0
+	gourmand = 8.0
 	#Range: 0.05 ~ 20.0
-	pneumatic = 2.0
+	pneumatic = 8.0
+	#Range: 0.05 ~ 20.0
+	frost = 8.0
 
 ["Integration settings"]
 	#If you can shift right click a Pneumatic Boiler with an Advanced Pneumatic Tube to convert it to a Pneumatic Dynamo

--- a/defaultconfigs/systeams-server.toml
+++ b/defaultconfigs/systeams-server.toml
@@ -19,7 +19,7 @@ replace_dynamo_augment_tooltips = true
 	#The number of mb of steam produced per RF of energy usually produced by the same fuel in a dynamo
 	#Note that this does not affect the steam dynamo's rates. That needs to be adjusted with a datapack
 	#Range: 0.05 ~ 100.0
-	stirling = 0.25
+	stirling = 0.5
 	#Range: 0.05 ~ 100.0
 	magmatic = 0.5
 	#Range: 0.05 ~ 100.0


### PR DESCRIPTION
After a long night of work, this PR would make Steam Boilers 4x as fuel-hungry without changing their steam output.
It also buffs the speed of other Systeams boiler types, since they were pretty slow & underused anyways.

Why do this? See:
https://discord.com/channels/914926812948234260/1229929078547550238/1286931800207261749
https://discord.com/channels/914926812948234260/1229929078547550238/1286941927895339039

(If you don't feel like looking, the tl;dr is that TE Steam Boilers completely outclass any GT alternative and tended to make earlygame power too easy. Also buffing GT steam boilers had some weird consequences)