### PR TITLE
Update Create configs to remove the button in the way of the Main Menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ kubejs/assets/gtceu/textures/item/material_sets/infinity/infinity_plate.xcf
 config/packmode.json
 config/gtceu.yaml
 config/darkmodeeverywhereshaders.json
+
+#Don't ignore the Create client config so we can remove the Main Menu config button
+#it gets in the way of the beautiful FancyMenu
+!/config/create-client.toml

--- a/config/create-client.toml
+++ b/config/create-client.toml
@@ -1,0 +1,149 @@
+
+#.
+#Client-only settings - If you're looking for general settings, look inside your worlds serverconfig folder!
+[client]
+	#.
+	#Show item descriptions on Shift and controls on Ctrl.
+	enableTooltips = true
+	#.
+	#Display a tooltip when looking at overstressed components.
+	enableOverstressedTooltip = true
+	#.
+	#Log a stack-trace when rendering issues happen within a moving contraption.
+	explainRenderErrors = false
+	#.
+	#Higher density means more spawned particles.
+	#Range: 0.0 ~ 1.0
+	fanParticleDensity = 0.5
+	#.
+	#[in Blocks]
+	#Maximum Distance to the player at which items in Blocks' filter slots will be displayed
+	#Range: 1.0 ~ 3.4028234663852886E38
+	filterItemRenderDistance = 10.0
+	#.
+	#Show kinetic debug information on blocks while the F3-Menu is open.
+	enableRainbowDebug = false
+	#.
+	#The maximum amount of blocks for which to try and calculate dynamic contraption lighting. Decrease if large contraption cause too much lag
+	#Range: > 0
+	maximumContraptionLightVolume = 16384
+	#.
+	#Choose the menu row that the Create config button appears on in the main menu
+	#Set to 0 to disable the button altogether
+	#Range: 0 ~ 4
+	mainMenuConfigButtonRow = 0
+	#.
+	#Offset the Create config button in the main menu by this many pixels on the X axis
+	#The sign (-/+) of this value determines what side of the row the button appears on (left/right)
+	#Range: > -2147483648
+	mainMenuConfigButtonOffsetX = -4
+	#.
+	#Choose the menu row that the Create config button appears on in the in-game menu
+	#Set to 0 to disable the button altogether
+	#Range: 0 ~ 5
+	ingameMenuConfigButtonRow = 3
+	#.
+	#Offset the Create config button in the in-game menu by this many pixels on the X axis
+	#The sign (-/+) of this value determines what side of the row the button appears on (left/right)
+	#Range: > -2147483648
+	ingameMenuConfigButtonOffsetX = -4
+	#.
+	#Setting this to true will prevent Create from sending you a warning when playing with Fabulous graphics enabled
+	ignoreFabulousWarning = false
+	#.
+	#Disable to prevent being rotated while seated on a Moving Contraption
+	rotateWhenSeated = true
+
+	#.
+	#Configure your vision range when submerged in Create's custom fluids
+	[client.fluidFogSettings]
+		#.
+		#The vision range through honey will be multiplied by this factor
+		#Range: 0.125 ~ 256.0
+		honey = 1.0
+		#.
+		#The vision range though chocolate will be multiplied by this factor
+		#Range: 0.125 ~ 256.0
+		chocolate = 1.0
+
+	#.
+	#Settings for the Goggle Overlay
+	[client.goggleOverlay]
+		#.
+		#Offset the overlay from goggle- and hover- information by this many pixels on the respective axis; Use /create overlay
+		#Range: > -2147483648
+		overlayOffsetX = 20
+		#.
+		#Offset the overlay from goggle- and hover- information by this many pixels on the respective axis; Use /create overlay
+		#Range: > -2147483648
+		overlayOffsetY = 0
+		#.
+		#Enable this to use your custom colors for the Goggle- and Hover- Overlay
+		customColorsOverlay = false
+		#.
+		#The custom background color to use for the Goggle- and Hover- Overlays, if enabled
+		#[in Hex: #AaRrGgBb]
+		#[@cui:IntDisplay:#]
+		#Range: > -2147483648
+		customBackgroundOverlay = -267386864
+		#.
+		#The custom top color of the border gradient to use for the Goggle- and Hover- Overlays, if enabled
+		#[in Hex: #AaRrGgBb]
+		#[@cui:IntDisplay:#]
+		#Range: > -2147483648
+		customBorderTopOverlay = 1347420415
+		#.
+		#The custom bot color of the border gradient to use for the Goggle- and Hover- Overlays, if enabled
+		#[in Hex: #AaRrGgBb]
+		#[@cui:IntDisplay:#]
+		#Range: > -2147483648
+		customBorderBotOverlay = 1344798847
+
+	#.
+	#Settings for the Placement Assist
+	[client.placementAssist]
+		#.
+		#What indicator should be used when showing where the assisted placement ends up relative to your crosshair
+		#Choose 'NONE' to disable the Indicator altogether
+		#Allowed Values: TEXTURE, TRIANGLE, NONE
+		indicatorType = "TEXTURE"
+		#.
+		#Change the size of the Indicator by this multiplier
+		#Range: 0.0 ~ 3.4028234663852886E38
+		indicatorScale = 1.0
+
+	#.
+	#Ponder settings
+	[client.ponder]
+		#.
+		#Slow down a ponder scene whenever there is text on screen.
+		comfyReading = false
+		#.
+		#Show additional info in the ponder view and reload scene scripts more frequently.
+		editingMode = false
+
+	#.
+	#Sound settings
+	[client.sound]
+		#.
+		#Make cogs rumble and machines clatter.
+		enableAmbientSounds = true
+		#.
+		#Maximum volume modifier of Ambient noise
+		#Range: 0.0 ~ 1.0
+		ambientVolumeCap = 0.10000000149011612
+
+	#.
+	#Railway related settings
+	[client.trains]
+		#.
+		#How far away the Camera should zoom when seated on a train
+		#Range: 0.0 ~ 3.4028234663852886E38
+		mountedZoomMultiplier = 3.0
+		#.
+		#Display nodes and edges of a Railway Network while f3 debug mode is active
+		showTrackGraphOnF3 = false
+		#.
+		#Additionally display materials of a Rail Network while f3 debug mode is active
+		showExtendedTrackGraphOnF3 = false
+

--- a/config/create-common.toml
+++ b/config/create-common.toml
@@ -1,64 +1,9 @@
 
+#.
+#Modify Create's impact on your terrain
 [worldgen]
-
 	#.
-	#Modify Create's impact on your terrain
-	[worldgen.v2]
-		#.
-		#Prevents all worldgen added by Create from taking effect
-		disableWorldGen = true
-
-		[worldgen.v2.striated_ores_nether]
-			#.
-			#Range: > 0
-			clusterSize = 32
-			#.
-			#Amount of clusters generated per Chunk.
-			#  >1 to spawn multiple.
-			#  <1 to make it a chance.
-			#  0 to disable.
-			#Range: 0.0 ~ 512.0
-			frequency = 0
-			#.
-			#Range: > -2147483648
-			minHeight = 40
-			#.
-			#Range: > -2147483648
-			maxHeight = 90
-
-		[worldgen.v2.striated_ores_overworld]
-			#.
-			#Range: > 0
-			clusterSize = 32
-			#.
-			#Amount of clusters generated per Chunk.
-			#  >1 to spawn multiple.
-			#  <1 to make it a chance.
-			#  0 to disable.
-			#Range: 0.0 ~ 512.0
-			frequency = 0
-			#.
-			#Range: > -2147483648
-			minHeight = -30
-			#.
-			#Range: > -2147483648
-			maxHeight = 70
-
-		[worldgen.v2.zinc_ore]
-			#.
-			#Range: > 0
-			clusterSize = 12
-			#.
-			#Amount of clusters generated per Chunk.
-			#  >1 to spawn multiple.
-			#  <1 to make it a chance.
-			#  0 to disable.
-			#Range: 0.0 ~ 512.0
-			frequency = 0
-			#.
-			#Range: > -2147483648
-			minHeight = -63
-			#.
-			#Range: > -2147483648
-			maxHeight = 70
+	#.
+	#Prevents all worldgen added by Create from taking effect
+	disableWorldGen = true
 


### PR DESCRIPTION
Before this PR, Create adds a button to the Main Menu that directs the player to the config. This button got in the way.
This PR removes that button from the menu at the cost of adding the client script to the repo.

![eww](https://github.com/user-attachments/assets/c2d13351-d2c2-4578-97c9-e367d82fb5d2)