### PR TITLE
Update the_beginning.snbt

### DIFF
--- a/config/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config/ftbquests/quests/chapters/the_beginning.snbt
@@ -2,2106 +2,2087 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	disable_toast: true
-	filename: "the_beginning"
+	filename: "genesis"
 	group: ""
-	icon: "gtceu:electric_blast_furnace"
-	id: "2763DAD954E0EED8"
-	order_index: 2
-	quest_links: [ ]
-	quests: [
+	icon: "gtceu:vacuum_tube"
+	id: "0654B76C306712BE"
+	order_index: 1
+	quest_links: [
 		{
-			dependencies: ["2D31856F6EF1ED69"]
-			description: [
-				"The &3Wiremill&r is a major efficiency boost, giving you double yield of &6wires&r for your ingots. But first, you'll need to make some &6Motors&r."
-				""
-				"&bGregTech&r machines are built from a number of components, many of which are shared between the machines. Motors&r are used in a great number of recipes, even including other components."
-				""
-				"The Wiremill requires a &6Programmed Circuit&r to run. Each machine comes with a free one - click on the circuit slot in the &9bottom right &rof the GUI. For making single wires, leave the circuit at &econfiguration 1&r. Refer to &eEMI&r for which circuit config a recipe calls for, and refer to the adjacent quest for more information."
-				"{@pagebreak}"
-				"After you make the Wiremill, &econsider making a few stacks&r of LV motors. This might sound extreme, but &ebatch crafting&r in this manner is an important habit to pick up. This way you won't have to craft more for a while, and you &owill &ruse all those motors eventually, so you're not wasting materials."
-				""
-				"As you get access to more machinery you will no longer need to craft things manually. Instead, you will engineer factories to automate the production for you. It is useful to keep a stockpile of frequently used things like circuits and components crafted so you don't have to wait for them when you need them."
-				""
-				"&2If the machine sounds start to get on your nerves, you can mute GT machines with a GT Hammer, &9or mute the sound entirely in the ESM menu, accessable from your inventory."
-			]
-			icon: "gtceu:lv_electric_motor"
-			id: "62BBD1F6767A4D90"
-			rewards: [{
-				count: 2
-				id: "33683A0D0F389BD0"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			size: 2.0d
-			subtitle: "The factory begins"
-			tasks: [
-				{
-					id: "298288137C88DDFF"
-					item: "gtceu:lv_wiremill"
-					type: "item"
-				}
-				{
-					count: 4L
-					id: "7B350C87343A8A00"
-					item: "gtceu:lv_electric_motor"
-					type: "item"
-				}
-			]
-			title: "&2LV Wiremill"
-			x: 0.0d
-			y: 2.0d
+			id: "7FB8EA3900C4D89D"
+			linked_quest: "1A30472430354F1E"
+			shape: "gear"
+			size: 1.5d
+			x: 3.0d
+			y: 12.5d
 		}
 		{
-			dependencies: ["62BBD1F6767A4D90"]
-			description: [
-				"Although you could &emagnetize&r &6Iron Ingots&r by hand using &6Redstone&r, doing that consumes considerable amounts of dust and that's not an option for more advanced materials. This machine will let you magnetize &6Steel Rods&r, as well as even more advanced materials later."
-				""
-				"&2Polarizer recipes in GTCEu go up to UV."
-			]
-			id: "19233A97579E0BDD"
-			rewards: [{
-				id: "12A2FD239F76B646"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
+			id: "6DC914192E886D47"
+			linked_quest: "77670BF761084AA2"
 			shape: "hexagon"
-			subtitle: "Automatic magnetizers"
+			x: 1.5d
+			y: 11.0d
+		}
+	]
+	quests: [
+		{
+			description: [
+				"This pack is in &eBeta&r. Issues are to be expected at this stage of development."
+				""
+				"[\"\",{\"text\":\"If you find something broken/missing/etc, make an issue on the \",\"color\":\"blue\"},{\"text\":\"Monifactory repository\",\"color\":\"blue\",\"underlined\":true,\"clickEvent\":{\"action\":\"open_url\",\"value\":\"https://github.com/thepansmith/monifactory\"}},{\"text\":\", or submit a Pull Request to fix it yourself.\",\"color\":\"blue\"}]"
+				""
+				"Do note that a decent number of mods in this pack are also in alpha or beta as well, so before reporting an issue, make sure that the issue can not be replicated with the mod on it's own, and if it can, report it to the mod's repository instead."
+			]
+			hide: false
+			icon: "thermal:nuke_tnt"
+			id: "2A511DB40C66CF35"
+			size: 1.5d
+			subtitle: "Bleeding Edge!"
 			tasks: [{
-				id: "2AAE22F760F73AD8"
+				id: "1A2BD249B1DBDA09"
+				title: "Acknowleged"
+				type: "checkmark"
+			}]
+			title: "&9This pack is in beta!"
+			x: 0.0d
+			y: -2.5d
+		}
+		{
+			dependencies: ["2A511DB40C66CF35"]
+			description: [
+				"This pack is intended to be played in a &bLost cities/Overworld dimension&r."
+				""
+				"If you're playing with friends, don't forget to invite them to a &eFTB Teams party&r. "
+				""
+				"If you wish to build your base in a skyblock world, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the void. Please note that you'll still need to return to the Lost Cities/Overworld dimension to mine, but you can freely build in complete safety in the &eVoid World&r."
+				"{@pagebreak}"
+				"Features new to &2CEu&r and quests with new content will be higlighted in &2dark green&r."
+				""
+				"Features new to &9Monifactory&r and quests with new content will be higlighted in &9Blue&r."
+				""
+				"Notes about things in &5Beta&r will be higlighted in &5Dark Purple&r."
+				""
+				"[\"Text with \",{\"text\":\"underlines\",\"underlined\":true,\"hoverEvent\":{\"action\":\"show_text\",\"contents\":\"But not this!\"}},\" are (mostly) clickable.\"]"
+			]
+			icon: "minecraft:crafting_table"
+			id: "66FCC26399376B55"
+			rewards: [
+				{
+					id: "031A59BA80B8796A"
+					item: "telepastries:custom_cake"
+					type: "item"
+				}
+				{
+					id: "48B3D498AC0B2BE0"
+					item: "telepastries:overworld_cake"
+					type: "item"
+				}
+				{
+					id: "3451D4471E82E65A"
+					item: {
+						Count: 1
+						id: "gtceu:prospector.hv"
+						tag: {
+							Charge: 1600000L
+						}
+					}
+					type: "item"
+				}
+				{
+					count: 4
+					id: "3316656A4E9DA8BF"
+					item: {
+						Count: 1
+						id: "gtceu:diamond_mining_hammer"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								AoEColumn: 1
+								AoELayer: 0
+								AoERow: 1
+								MaxAoEColumn: 1
+								MaxAoELayer: 0
+								MaxAoERow: 1
+							}
+							GT.Tool: {
+								Damage: 0
+								HarvestLevel: 3
+								MaxDamage: 2303
+								ToolSpeed: 6.4f
+							}
+							HideFlags: 2
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "19598A860287E726"
+					item: {
+						Count: 1
+						id: "gtceu:diamond_axe"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								DisableShields: 1b
+								TreeFelling: 1b
+							}
+							GT.Tool: {
+								Damage: 0
+								HarvestLevel: 3
+								MaxDamage: 767
+								ToolSpeed: 8.0f
+							}
+							HideFlags: 2
+						}
+					}
+					type: "item"
+				}
+				{
+					auto: "no_toast"
+					icon: "enderio:cake_base"
+					id: "612FEB595285D353"
+					title: "&6Infinite Cakes!"
+					type: "custom"
+				}
+				{
+					auto: "invisible"
+					id: "75FD5BC7147B8397"
+					ignore_reward_blocking: true
+					stage: "intro_complete"
+					type: "gamestage"
+				}
+			]
+			shape: "hexagon"
+			size: 2.0d
+			subtitle: "Welcome to Monifactory"
+			tasks: [{
+				id: "1FF132DED1748D11"
+				title: "Genesis #3"
+				type: "checkmark"
+			}]
+			title: "&9Genesis"
+			x: 0.0d
+			y: 0.0d
+		}
+		{
+			can_repeat: true
+			dependencies: ["66FCC26399376B55"]
+			description: ["This quest is repeatable and gives you a free cake to the &6Void World&r or &2Overworld&r every hour. You can also refill your cakes with the items indicated in their tooltips."]
+			disable_toast: true
+			icon: "telepastries:overworld_cake"
+			id: "542F0090D8975D3C"
+			optional: true
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "1F03FEFB5B2A3B47"
+				table_id: 7942624913962637807L
+				type: "choice"
+			}]
+			subtitle: "Cakes are magical!"
+			tags: ["moni_cakequest"]
+			tasks: [
+				{
+					id: "423B4FAF11B1C0FA"
+					title: "Cake Based Dimensional Transit"
+					type: "checkmark"
+				}
+				{
+					disable_toast: true
+					icon: "minecraft:clock"
+					id: "138B92A597D63C12"
+					tags: [
+						"moni_timer"
+						"moni_timer_60"
+					]
+					title: "Timer"
+					type: "custom"
+				}
+			]
+			title: "Cake Based Dimensional Transit"
+			x: -2.0d
+			y: -0.5d
+		}
+		{
+			dependencies: ["66FCC26399376B55"]
+			description: [
+				"&bFunctional Storage&f provides a huge amount of storage for a single item type. Use them for things you have a lot of, such as stone, dirt and ores."
+				""
+				"&9Framing Template items can be used to easily decorate your drawers.&r"
+				""
+				"Furthermore, you can do special stuff with your drawers, with &9Tools&r and &9Upgrades! Search &e@Functionalstorage&r in &bEMI&r to see them!"
+			]
+			disable_toast: true
+			id: "4A696D4BA5442928"
+			optional: true
+			subtitle: "&oThis quest completes with any drawer."
+			tasks: [{
+				id: "02543E826A43185A"
 				item: {
 					Count: 1
 					id: "itemfilters:tag"
 					tag: {
-						value: "moni:polarizer"
+						value: "functionalstorage:drawer"
 					}
 				}
-				title: "LV or MV Polarizer"
+				title: "Any Drawer"
 				type: "item"
 			}]
-			title: "&2Polarizer"
+			title: "&9Drawers"
 			x: -2.0d
-			y: 2.0d
+			y: 0.5d
 		}
 		{
-			dependencies: ["62BBD1F6767A4D90"]
-			description: ["Also useful as a machine cover for continuously moving items, read the &aMachine Covers&r quest for more info on the various covers."]
-			id: "1FF652D16CE97C79"
-			rewards: [{
-				id: "718769C41EB34A2D"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			subtitle: "Not as common a component, but used in a number of critical machines."
-			tasks: [{
-				id: "766F95CEB364086E"
-				item: "gtceu:lv_conveyor_module"
-				type: "item"
-			}]
-			title: "LV Conveyor"
-			x: 0.0d
-			y: 5.0d
-		}
-		{
-			dependencies: [
-				"2D31856F6EF1ED69"
-				"62BBD1F6767A4D90"
-			]
+			dependencies: ["66FCC26399376B55"]
 			description: [
-				"A &6Programmed Circuit&r is an item used to configure machines. In essence, they tell a machine what to make if there's multiple things it could make from a certain input."
+				"&b&lEMI&r is the list of all items that you see every time you open your inventory. It's the better(tm) recipe book that shows you all available items and recipes in the modpack. Note that &b&lEMI&r is based on &b&lJEI&r, and people tend to use the names interchangably."
 				""
-				"For example, the &3Wiremill&r produces different thicknesses of &6wires&r depending on the config - &ecircuit 1&r produces &61x wires&r, &ecircuit 4&r produces &64x wires&r, etc. The &eEMI&r recipe will tell you which circuit configuration is required."
-				"{@pagebreak}"
-				"Each machine and item input bus comes with a &2free \"ghost circuit\"&r. Click the circuit slot on the &9bottom right&r of the GUI to access this ghost circuit. Left- and right-click or scroll to adjust the configuration. "
+				"To see it in action, pull up a quest that requires an item of some sort and just click the item!"
 				""
-				"That said, the Programmed Circuit item (crafted from a single &6LV Circuit&r) still has its uses:"
+				"[\"If you want to know how to craft an item, just hover your mouse over it and press \",{\"keybind\":\"key.jei.showRecipe\",\"color\":\"gold\",\"bold\":true,\"underlined\":true,\"hoverEvent\":{\"action\":\"show_text\",\"contents\":\"\\\"Show Recipe\\\" in keybind option\"}},\". EMI will list all available recipes.\"]"
 				""
-				"- Whilst holding a programmed circuit, shift-right click the machine to set a &bGhost Circuit&r of the same configuration in the machine's circuit slot."
+				"[\"If you instead want to know what recipes use an item, hover over it and press \",{\"keybind\":\"key.jei.showUses\",\"color\":\"gold\",\"bold\":true,\"underlined\":true,\"hoverEvent\":{\"action\":\"show_text\",\"value\":\"\",\"contents\":\"\\\"Show Uses\\\" in keybind option\"}},\".\"]"
 				""
-				"- When you're sure that the items you put into a machine won't have any conflicts, you can put &emultiple circuit configs&r into a machine, and it will be able to handle recipes which call for any of those configs. This is useful for machines such as the &3Alloy Blast Smelter&r, but you won't encounter that for a while."
+				"[\"Hover over an item and press \",{\"keybind\":\"key.jei.bookmark\",\"color\":\"gold\",\"bold\":true,\"underlined\":true,\"hoverEvent\":{\"action\":\"show_text\",\"contents\":\"\\\"Add/Remove Bookmark\\\" in keybind option\"}},\" to bookmark it. To remove a bookmarked item from the list, press \",{\"keybind\":\"key.jei.bookmark\",\"color\":\"gold\",\"bold\":true,\"underlined\":true,\"hoverEvent\":{\"action\":\"show_text\",\"contents\":\"\\\"Add/Remove Bookmark\\\" in keybind option\"}},\" on the bookmark.\"]"
+				""
+				"[\"One of the remarkable features of EMI is that it's also capable of helping you with recipes, covered more in \", {\"text\": \"this\", \"underlined\": \"true\", \"clickEvent\": { \"action\": \"change_page\", \"value\": \"58566C7BF4C22D86\" } },\" quest.\"]"
 			]
-			icon: {
-				Count: 1
-				id: "gtceu:programmed_circuit"
-				tag: {
-					Configuration: 0
-				}
-			}
-			id: "0381DCD3FD3C9ED2"
-			rewards: [{
-				id: "3B97398BAE233115"
-				item: {
-					Count: 1
-					id: "gtceu:programmed_circuit"
-					tag: {
-						Configuration: 0
-					}
-				}
-				type: "item"
-			}]
-			size: 1.25d
+			disable_toast: true
+			icon: "ftbquests:book"
+			id: "3B200AD6EFF90DFA"
+			size: 1.0d
+			subtitle: "&eUSE EMI!!!&r"
 			tasks: [{
-				id: "381F87172DB87754"
+				id: "7449A54608D60DF8"
 				type: "checkmark"
 			}]
-			title: "&9Programmed Circuits"
-			x: -1.9047619047619193d
-			y: 3.720238095238088d
-		}
-		{
-			dependencies: ["055193574D203872"]
-			description: [
-				"&2Assembling Machines come early in CEu! Circuit recipes are handled through a separate machine, the Circuit Assembler. &r"
-				""
-				"Assembling Machines open up a plethora of &eequal or more efficient recipes that don't require hand tools&r. &2For example, you can make up to 4 Vacuum Tubes in a single craft! &rCheck &eEMI&r for all the components you've been making to see if the Assembler can improve their recipes."
-				""
-				"Many of the Assembler's recipes require &9fluids&r. Hence, the &3Extractor&r will be required to take full advantage of this machine. "
-				""
-				"Hand tool recipes also don't play nice with &bApplied Energistics&r. Take advantage of Assembling Machines: &cphase out all use of hand tools for crafting items in your automation going forward.&r Once you have all the important machines, you will never need hand tools for crafting."
-			]
-			id: "6197C51E04761371"
-			rewards: [{
-				id: "2C089F5BA39C3864"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			size: 2.0d
-			subtitle: "Assembling Machine 1"
-			tasks: [{
-				id: "4FEE8532736A49E2"
-				item: "gtceu:lv_assembler"
-				type: "item"
-			}]
-			title: "&2LV Assembling Machine"
-			x: -4.5d
-			y: 5.0d
-		}
-		{
-			dependencies: ["7A12743F5ECCED90"]
-			description: [
-				"&6Robot Arms&r are components of several powerful machines, and are also useful as a machine cover for precise item movement."
-				""
-				"One of the most expensive components, as it requires motors, pistons, and a circuit."
-			]
-			id: "055193574D203872"
-			rewards: [{
-				id: "434A32B85AEC20E3"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [{
-				id: "5B30A9407F5E838F"
-				item: "gtceu:lv_robot_arm"
-				type: "item"
-			}]
-			title: "LV Robot Arm"
-			x: -4.5d
-			y: 2.0d
-		}
-		{
-			dependencies: ["62BBD1F6767A4D90"]
-			description: ["One of the more intricate components, as it is made using a motor."]
-			id: "7A12743F5ECCED90"
-			rewards: [{
-				id: "60DD7C7B1FC64B80"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			size: 1.25d
-			subtitle: "A piston is a specialized motor, which is needed to make certain machines."
-			tasks: [{
-				id: "7341F3ADD0737579"
-				item: "gtceu:lv_electric_piston"
-				type: "item"
-			}]
-			title: "LV Pistons"
-			x: -4.5d
+			title: "&9&lUse EMI! Use EMI! USE. EMI."
+			x: 1.75d
 			y: -0.5d
 		}
 		{
-			dependencies: ["7A12743F5ECCED90"]
-			description: [
-				"The &3Lathe&r is an important machine that makes &6rods&r less expensive to craft. One ingot will yield two rods, doubling your output compared to manually crafting it"
-				""
-				"In addition to this, it is can also be used to craft &6screws&r and &6buzzsaw blades&r."
-				""
-				"You will need it later on to craft &6lenses&r"
-			]
-			id: "2A84013C14085C7B"
+			dependencies: ["66FCC26399376B55"]
+			description: ["&9Can be used to autobuild multiblocks&r."]
+			disable_toast: true
+			icon: "gtceu:terminal"
+			id: "07DC7FC23332B847"
 			rewards: [{
-				id: "1344CFC701E35C5F"
-				item: "kubejs:moni_nickel"
+				id: "280FA1B26199881B"
+				item: "gtceu:terminal"
 				type: "item"
 			}]
-			shape: "hexagon"
+			subtitle: "GT Guide book"
 			tasks: [{
-				id: "5D06DCFA7A00AE81"
-				item: "gtceu:lv_lathe"
-				type: "item"
+				id: "380954E57B7C36EC"
+				title: "Terminal"
+				type: "checkmark"
 			}]
-			title: "LV Lathe"
-			x: -2.0d
-			y: -0.5d
+			title: "&9Terminal"
+			x: 1.75d
+			y: 0.5d
 		}
 		{
-			dependencies: ["7A12743F5ECCED90"]
+			dependencies: ["66FCC26399376B55"]
 			description: [
-				"The &3Bending Machine&r improves the yield of a great deal of items. Most notably, you can use it to get one &6Plate&r from a single ingot, instead of having to spend two ingots for a single plate."
-				""
-				"As with the &3Wiremill&r, this requires a &6Programmed Circuit&r to tell it what to make. For plates, this is &econfiguration 1&r. Refer to &eEMI&r for which configuration to use for your recipe."
-				" "
-				"Other materials it can produce include:"
-				"- 4 &6Foils&r from a Plate"
-				"- &6Double Plates&r from two Plates"
-				"- &6Dense Plates&r from nine Plates"
-				"- &6Small Springs&r from one Rod"
-				"- &6Springs&r from one Long Rod. "
+				"&c&rOres in &9Monifactory&f exist in large clusters, or '&eveins&f'. These veins are scattered around the world, and are relatively common. &2The upgraded HV Electric Prospector's Scanner you were given will tell you the types of ores you can find within a 7x7 chunk area!"
 				"&r"
-				"If you played the CE version of &9Nomifactory&r, note that the functions of the &3Compressor&r (for making Plates) and &3Cluster Mill&r are merged into this machine."
+				"While the Scanner requires energy to work, you are unlikely to deplete its battery. That said, the quest book will later guide you towards making &2an HV Battery&r to charge &aHV tools &rin your inventory."
+				"{@pagebreak}"
+				"In order to proceed, you'll need to locate a source of &6Iron&f. You have a few options. &6Magnetite&f veins are higher up and contain large amounts of iron, as well as some &6Vanadium&f and &6Gold&f. Another good source of iron is &9Goethite&f veins, which contain several types of iron. Finally, &6Pyrite&f can be found paired with &6Copper&f in several types of veins."
+				""
+				"&6Wrought Iron&f is obtained simply by &esmelting Iron a second time&f. It has more durability than Iron, so it is better for making tools, but &cdo not convert your entire Iron supply over to Wrought Iron&f. The two materials are not interchangeable and you'll need Iron or Wrought Iron as demanded by various recipes."
 			]
-			id: "3EDD0A986384F2A7"
+			icon: "gtceu:wrought_iron_ingot"
+			id: "2E8BFA2E719B1C47"
 			rewards: [{
-				id: "0AE3BBBCE40C2F66"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [{
-				id: "5D9E01E9FFB9F05B"
-				item: "gtceu:lv_bender"
-				type: "item"
-			}]
-			title: "&2LV Bending Machine"
-			x: -7.0d
-			y: -0.5d
-		}
-		{
-			dependencies: ["7A12743F5ECCED90"]
-			description: [
-				"Great for automatically converting between Nuggets, Ingots, and Blocks of metals, or simply storing massive amounts of things. Also works with &9monicoins&r."
-				""
-				"The appearance can be customized by crafting the drawer into &aFramed Compacting Drawer&r and then using a &9Framing Template&r or your crafting grid."
-			]
-			id: "7460F22545A4EFB2"
-			rewards: [{
-				id: "46EA0B4F09642C8E"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "05CB7EE672B034D4"
-				item: "functionalstorage:compacting_drawer"
-				type: "item"
-			}]
-			title: "&9Compacting Drawers"
-			x: -7.0d
-			y: 2.0d
-		}
-		{
-			dependencies: ["7A12743F5ECCED90"]
-			description: [
-				"&2&2Most plates are made in the Bending Machine instead of here. (Technically this was the case in CE, but this modpack transferred its recipes to the Compressor.)&r"
-				""
-				"However, this machine will still see use for compressing &eNuggets&r into&e Ingots&r, &eIngots&r into &eBlocks&r, &eGem Dusts&r into &ePlates&r (such as &6Certus Quartz&r), as well as various other useful recipes."
-			]
-			id: "5795EE147D4879B7"
-			shape: "hexagon"
-			tasks: [{
-				id: "2B92B2273B4DBA4E"
-				item: "gtceu:lv_compressor"
-				type: "item"
-			}]
-			title: "&2LV Compressor"
-			x: -9.5d
-			y: -0.5d
-		}
-		{
-			dependencies: [
-				"6A262AA410619C23"
-				"7A12743F5ECCED90"
-			]
-			description: [
-				"&3Extractors&r are useful for melting things into liquids. For example, you can melt down ingots into molten metals, or &6Rubber Sheets&r into liquid &9Rubber&r."
-				""
-				"When you have access to &6Steel&r, you can make molds and use &3Fluid Solidifiers&r to form various components more efficiently from fluids, like &6Gears&r."
-			]
-			id: "038D06BCA022C1BF"
-			shape: "hexagon"
-			subtitle: "&2The functions of the Extractor and Fluid Extractor have been combined into a single machine!"
-			tasks: [{
-				id: "302CBE00E5451E5E"
-				item: "gtceu:lv_extractor"
-				type: "item"
-			}]
-			title: "&2LV Extractor"
-			x: -4.5d
-			y: -3.0d
-		}
-		{
-			dependencies: ["7A12743F5ECCED90"]
-			description: [
-				"&3Macerators&r are useful for grinding things down, replacing the &aMortars&r you've needed until now. This is an important machine you will be using for many things in the future."
-				""
-				"You don't really need a LV one, as you can use the superior &3Steam Grinder&r. LV or MV ones could be used for automation. However, HV ones provide chanced output, extremely important for &eOre Processing&r and other processes."
-				""
-				"One useful application for a Macerator in the near future is grinding down &6Clay&r or &6Terracotta&r into &6Clay Dust&f."
-				""
-				"Besides not having limited durability, a key advantage of Macerators over Mortars is the chance to get additional materials when grinding things down. These are called &ebyproducts&r, and HV or better Macerators have three slots instead of one so byproducts can appear."
-				""
-				"When reading Macerator recipes in &bEMI&r, you can tell which outputs are byproducts by seeing if &ethe tooltip tells you it has a chance to appear&r: guaranteed outputs do not list a chance. &2The chance increases by a certain amount for each tier of machine you have above the tier of recipe. This chance is also listed in the tooltip."
-				""
-				"Macerators can now also recycle your old Machines for some extra materials.&r"
-				""
-				"Finally, a Macerator will only start processing if there is room for all possible outputs. Make sure you empty them so they can keep working."
-			]
-			id: "4685AC9E6CD87B77"
-			rewards: [{
-				id: "06A7DC04EEC732E1"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			subtitle: "&oNote: this quest accepts LV, MV and HV Macerators."
-			tasks: [{
-				id: "29E5699EC44EAFB5"
-				item: "gtceu:lv_macerator"
-				type: "item"
-			}]
-			title: "&2Macerator"
-			x: -7.0d
-			y: -3.0d
-		}
-		{
-			dependencies: ["62BBD1F6767A4D90"]
-			description: [
-				"Another common component of any machine that uses fluids. Also usable as a cover for moving fluids between &bGregTech&r machines and adjacent tanks or machines."
-				""
-				"You must use &6 &6Rubber Rings&r, which requires a &aKnife&r to craft. A stick and a piece of flint will make a Knife with low durability, or check the recipe for metal ones."
-			]
-			id: "6A262AA410619C23"
-			shape: "hexagon"
-			tasks: [{
-				id: "79C2BBD9C422BA1E"
-				item: "gtceu:lv_electric_pump"
-				type: "item"
-			}]
-			title: "LV Pumps"
-			x: 0.0d
-			y: -3.0d
-		}
-		{
-			dependencies: [
-				"6A262AA410619C23"
-				"62BBD1F6767A4D90"
-				"404C9497C46E7608"
-			]
-			description: [
-				"If you don't want to mine Obsidian by hand, consider using a Fluid Solidifier to turn &cLava&r into &6Obsidian Blocks&r for you. The process is slow and energy intensive, though."
-				""
-				"&3Fluid Solidifiers&r are useful for lots of other things too, of course. Look through the various molds to see what you can make with one."
-			]
-			id: "4EAD8756BAAC6B2E"
-			rewards: [{
-				id: "068F5B92B80B6864"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "421570E2D8BAB4DE"
-				item: "gtceu:lv_fluid_solidifier"
-				type: "item"
-			}]
-			x: 0.0d
-			y: -5.5d
-		}
-		{
-			dependencies: ["6A262AA410619C23"]
-			description: ["&2Pumps are now available in GT. Useful for gathering Oil or perhaps Lava from the Nether."]
-			id: "09C0CDC1DFA7842D"
-			rewards: [{
-				id: "1A7962BB3B58AA55"
-				item: "kubejs:moni_quarter"
-				type: "item"
-			}]
-			tasks: [{
-				id: "03C18BA6D84BA956"
-				item: "gtceu:lv_pump"
-				type: "item"
-			}]
-			title: "&2Pumps"
-			x: 0.0d
-			y: -8.0d
-		}
-		{
-			dependencies: ["038D06BCA022C1BF"]
-			description: [
-				"An &3Autoclave&r is a machine that uses liquids (usually water) to polish stones, carve gems into lenses, infuse gems with special liquids, and crystallize various dusts."
-				""
-				"You'll need an Autoclave for many recipes, but most presently you will need it to make &6Pulsating Crystals&r and &6Vibrant Crystals&r from &bEnderIO&r."
-			]
-			id: "47094A5717952699"
-			shape: "hexagon"
-			tasks: [{
-				id: "11FEC1EF6257937D"
-				item: "gtceu:lv_autoclave"
-				type: "item"
-			}]
-			title: "LV Autoclave"
-			x: -4.5d
-			y: -6.0d
-		}
-		{
-			dependencies: [
-				"47094A5717952699"
-				"273F3F8DD6A3DCC5"
-			]
-			description: [
-				"This pack has &aSnad&r, which is simply a sand-like block that instantly grows sugar cane/cactus on top of it when it receives either a block update or a redstone update."
-				""
-				"The sugar cane it produces can be used as a fuel for your dynamos, and later you can even brew it for &9Biomass&r."
-				""
-				"This quest calls for a &aRedstone Clock&r, but there are other ways to make snad grow sugar cane even faster (like a vanilla observer clock pointing into the Snad). Make sure to set the timer to pulse as fast as possible."
-				""
-				"To collect the sugar cane, you can use a piston and an observer."
-				""
-				"For now, a &3Vacuum Chest&r should help keep the floor clean, and causes less lag than Hoppers. A &aVoid Upgrade&r in a &6Storage Drawer&r will automatically delete any items that overflow the drawer's capacity, so it's a good way to ensure you don't crash your server from accumulating a massive sugar cane pile before safer block breakers are available to you."
-			]
-			icon: "snad:snad"
-			id: "529D50CE814AF449"
-			shape: "hexagon"
-			subtitle: "Yes, Snad."
-			tasks: [
-				{
-					id: "77ADD3B3DA61DC55"
-					item: "snad:snad"
-					type: "item"
-				}
-				{
-					id: "719FAF0F70FA25E5"
-					item: "enderio:vacuum_chest"
-					type: "item"
-				}
-				{
-					id: "2DCBDFF5EB0F7CD9"
-					item: "redstone_clock:redstone_clock"
-					type: "item"
-				}
-				{
-					id: "3DBB91C93688C4FC"
-					item: "functionalstorage:void_upgrade"
-					type: "item"
-				}
-			]
-			title: "Snad"
-			x: -4.5d
-			y: -9.5d
-		}
-		{
-			dependencies: ["5301E546BAA69844"]
-			description: [
-				"&aMolds&r are used in a &3Fluid Solidifier&r or &3Alloy Smelter&r to form materials into specific shapes. These are not consumed or damaged during crafting, so you can leave them in a machine to dedicate it to that shape."
-				""
-				"The Fluid Solidifier tends to be the more efficient option: for example, you can use &e8 ingots&r to make one &6Gear&r in an Alloy Smelter, but with an Extractor and Solidifier you can accomplish the same result with &e4 ingots&r."
-				""
-				"Be careful not to accidentally make &aExtruder Shapes&r. Those are for a machine you will get access to later. The three molds in this quest are ones you will find useful right away."
-			]
-			icon: "gtceu:gear_casting_mold"
-			id: "404C9497C46E7608"
-			rewards: [{
-				id: "2CB59A2F31238EFF"
-				item: "kubejs:moni_quarter"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [
-				{
-					count: 3L
-					id: "003802F16404404C"
-					item: { Count: 3, id: "gtceu:empty_mold" }
-					type: "item"
-				}
-				{
-					id: "500A01A974ACFC7D"
-					item: "gtceu:block_casting_mold"
-					type: "item"
-				}
-				{
-					id: "427921CAA3277199"
-					item: "gtceu:gear_casting_mold"
-					type: "item"
-				}
-				{
-					id: "17037C04324A5D7A"
-					item: "gtceu:rotor_casting_mold"
-					type: "item"
-				}
-			]
-			title: "Molds"
-			x: 2.5d
-			y: -5.5d
-		}
-		{
-			dependencies: ["29A487F0BC43AAF9"]
-			description: [
-				"&6Pulsating Dust&r is a mysterious magical material that taps into the power of Ender. It has all sorts of strange and potentially dangerous applications, including the ability to make &6Pulsating Ingots&r and &6Ender Pearls&r."
-				""
-				"Your first source of Pulsating Dust is &6Uraninite&r, which you can get from &6Uraninite Ore&r. Later on, you'll be able to produce Pulsating Dust by smelting &6Resonant Clathrates&r."
-			]
-			icon: "kubejs:pulsating_dust"
-			id: "30EBD4E7BBFFEF2C"
-			shape: "hexagon"
-			tasks: [
-				{
-					id: "771429E0BF88C060"
-					item: "kubejs:pulsating_dust"
-					type: "item"
-				}
-				{
-					id: "7CD88A0039FEDB93"
-					item: "gtceu:uraninite_dust"
-					type: "item"
-				}
-			]
-			title: "Pulsating Dust"
-			x: 2.5d
-			y: -8.0d
-		}
-		{
-			dependencies: ["30EBD4E7BBFFEF2C"]
-			description: ["If you can't find one otherwise, &6Ender Pearls&r can be crafted using Pulsating Dust and a &6Diamond&r in an &3Alloy Smelter&r."]
-			icon: "gtceu:pulsating_alloy_ingot"
-			id: "273F3F8DD6A3DCC5"
-			shape: "hexagon"
-			subtitle: "A mysterious alloy, made from &6Pulsating Dust&r and &6Iron&r."
-			tasks: [
-				{
-					id: "22A4BABD40C1A481"
-					item: "gtceu:pulsating_alloy_ingot"
-					type: "item"
-				}
-				{
-					id: "1D2D8CC9B069A59B"
-					item: "minecraft:ender_pearl"
-					type: "item"
-				}
-			]
-			title: "Pulsating Iron and Ender Pearls"
-			x: 2.5d
-			y: -9.5d
-		}
-		{
-			dependencies: ["29A487F0BC43AAF9"]
-			description: ["You might want to save your &6Coal Dust&r for circuits and use &6Charcoal Dust&r instead. Later, you can also process either of these dusts, &6Coal Coke Dust&r, &2or Diamond Dust&r into &6Carbon Dust&r, which can be used for Steel and other useful things."]
-			id: "5301E546BAA69844"
-			rewards: [{
-				id: "424A2A6FAB412F69"
+				id: "318894ADCA9CF9DB"
 				item: {
 					Count: 1
 					id: "trofers:large_pillar"
 					tag: {
 						BlockEntityTag: {
-							Trophy: "monifactory:steel"
+							Trophy: "monifactory:wrought_iron"
 						}
 					}
 				}
 				type: "item"
 			}]
 			shape: "hexagon"
-			size: 2.0d
-			subtitle: "You already have &6Steel&r, but it can be made faster in the &3Alloy Smelter&r, at the cost of EU."
-			tasks: [{
-				id: "17210F38B40BAAD7"
-				item: "gtceu:steel_ingot"
-				type: "item"
-			}]
-			title: "&9Alloying Steel"
-			x: 2.5d
-			y: -3.0d
-		}
-		{
-			dependencies: ["29A487F0BC43AAF9"]
-			description: [
-				"Nickel comes from several different ores, including Pentlandite and Garnierite, but they're all found in the same vein."
-				""
-				"Nickel is used mostly for several very important alloys, including Invar and Cupronickel."
-			]
-			id: "3F6EDC2481D5877F"
-			rewards: [{
-				id: "7502BCDFFE6C0499"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			subtitle: "Copper... Nickel... Cupronickel?"
-			tasks: [{
-				id: "708858A9BC1F9ABE"
-				item: "gtceu:cupronickel_ingot"
-				type: "item"
-			}]
-			title: "Cupronickel"
-			x: 2.5d
-			y: 2.0d
-		}
-		{
-			dependencies: ["62BBD1F6767A4D90"]
-			description: [
-				"&3Alloy Smelters&r are used to create alloys by melting and reforming items together."
-				""
-				"Now you won't need to grind up metals into dusts and mix them for alloy dusts! Plus, many of the more complex alloys you couldn't make that way are now possible."
-			]
-			id: "29A487F0BC43AAF9"
-			rewards: [{
-				id: "0C69338204BAC2F3"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [{
-				id: "1E91BE2938B1B8CE"
-				item: "gtceu:lv_alloy_smelter"
-				type: "item"
-			}]
-			title: "LV Alloy Smelter"
-			x: 2.5d
-			y: -0.5d
-		}
-		{
-			dependencies: ["29A487F0BC43AAF9"]
-			description: ["Needs 2 &6Water Source Blocks&r around it to generate water. You will also need a way to pull the water out of the accumulator, such as using the &5LV water pump&f as a &acover&f."]
-			icon: {
-				Count: 1
-				id: "thermal:device_water_gen"
-				tag: { }
-			}
-			id: "46AF35D4EECA5BDB"
-			rewards: [{
-				id: "177319DF620B0BAC"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "10F80A969FA43359"
-				item: {
-					Count: 1
-					id: "thermal:device_water_gen"
-					tag: { }
-				}
-				type: "item"
-			}]
-			title: "&9Infiniter Water"
-			x: 1.0d
-			y: -0.5d
-		}
-		{
-			dependencies: ["29A487F0BC43AAF9"]
-			description: [
-				"Using plain &3Steam Dynamos&f is pretty inefficient."
-				""
-				"It's strongly recommended to upgrade your dynamos into &3steam boilers&f and &3steam turbines&f. The ratio is always &a1:2&r if all Dynamos are equally upgraded."
-				""
-				"This greatly increases the overall efficiency and the amount of power produced, from &a40 RF/t&r per basic steam dynamo to &a320 RF/t&r per set of three augmented dynamos."
-			]
-			icon: "systeams:steam_dynamo"
-			id: "545CCC24D9401794"
+			subtitle: "ULV Beginnings"
 			tasks: [
 				{
-					id: "12315AEA66B77CB2"
-					item: { Count: 2, id: "systeams:stirling_boiler" }
+					count: 12L
+					id: "674259A69F1EEC1C"
+					item: { Count: 12, id: "minecraft:iron_ingot" }
 					type: "item"
 				}
 				{
-					count: 2L
-					id: "76CB286FDDD00D40"
-					item: "systeams:steam_dynamo"
+					count: 12L
+					id: "02A10A7E907718D5"
+					item: { Count: 12, id: "gtceu:wrought_iron_ingot" }
 					type: "item"
 				}
 			]
-			title: "Boilers and Turbines"
-			x: 4.5d
-			y: -1.5d
-		}
-		{
-			dependencies: ["5301E546BAA69844"]
-			description: [
-				"&2Technically not new to CEu, but it was disabled in the original version, and it had much less functionality in CE.&r"
-				""
-				"The Arc Furnace allows you to make &6Annealed Copper&r, which will be used in the MV Age. It can also make 2 pieces of Glass from 1 Sand. Later, it can make &2Tempered Glass&r for use in higher-tier recipes."
-				""
-				"The Arc Furnace also functions as a &auniversal recycling machine&r. Pretty much anything can be recycled into ingots and dusts of its base components."
-				""
-				"All of its recipes require Oxygen."
-				""
-				"All Arc Furnace recipes use exactly 30 EU/t, so you can get away with using LV Arc Furnaces for the whole pack!"
-			]
-			id: "500E619D568C07C2"
-			rewards: [{
-				id: "028645C412CA6B28"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "13BC210346486E40"
-				item: "gtceu:lv_arc_furnace"
-				type: "item"
-			}]
-			title: "&2Arc Furnace"
-			x: 4.5d
-			y: -4.0d
-		}
-		{
-			dependencies: ["5301E546BAA69844"]
-			description: [
-				"&oThis is represented in a Processing Line. Visit the Processing Lines Tab to have more info, useful tips and a visual representation.&r"
-				""
-				"Now that you have acquired &6Steel&r, your path to infinite cobblestone awaits! The &6Igneous Extruder&r continuously generates cobblestone for free."
-				""
-				"Later on, you could look into the &6Rock Crusher&r, which can do it faster at the cost of requiring power."
-			]
-			id: "4624889F738AB21B"
-			rewards: [{
-				id: "2AFEC339114B90DE"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "20C8F57CE9379A41"
-				item: "thermal:device_rock_gen"
-				type: "item"
-			}]
-			title: "&9Infinite Cobblestone"
-			x: 4.5d
-			y: -6.0d
-		}
-		{
-			dependencies: ["4624889F738AB21B"]
-			description: ["&2This isn't new in CEu either, but in this version, you will use this to break Cobblestone into Gravel and Gravel into Sand. It's also used to combine 2 Rods into 1 Long Rod."]
-			id: "0EDFB0C24B9129AB"
-			rewards: [{
-				id: "6BE647D018E97BB3"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "29F11B4491A6064D"
-				item: "gtceu:lv_forge_hammer"
-				type: "item"
-			}]
-			title: "&2Forge Hammer"
-			x: 4.5d
-			y: -7.0d
-		}
-		{
-			dependencies: ["30EBD4E7BBFFEF2C"]
-			description: [
-				"&6&6String&r and &6Coal Dust&r can be baked together into a &6Carbon Mesh&r in an &3Alloy Furnace&r."
-				""
-				"Combine that with &6Pulsating Dust&r to get a &6Pulsating Mesh&r."
-			]
-			icon: "kubejs:pulsating_mesh"
-			id: "645B1DCB3DA7198A"
-			rewards: [{
-				id: "2D12B468C7630D14"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [
-				{
-					id: "3FB8F2F8B1867430"
-					item: "kubejs:pulsating_mesh"
-					type: "item"
-				}
-				{
-					id: "6684545526C4AD44"
-					item: "gtceu:carbon_fiber_mesh"
-					type: "item"
-				}
-			]
-			title: "Pulsating Mesh"
-			x: 6.5d
-			y: -8.0d
-		}
-		{
-			dependencies: [
-				"645B1DCB3DA7198A"
-				"3BD20358F137E7C6"
-			]
-			description: [
-				"A &3Simulation Chamber&r from &bHostile Neural Networks&r (&bHNN&r) allows you to farm mobs in a totally environmentally (and server) friendly way!"
-				""
-				"Simulated mobs can even be used to provide you with many of the basic resources you'll need (such as &6iron, gold, tin, copper, diamonds&r and many more!), through pristine matter."
-				""
-				"Setting up HNN automation during the early game is &avery important&r as it gives you access to infinite quantities of many resources!"
-				""
-				"HNN changes machines, making them no longer sided, so you can input and output from any side, as well as allowing them to be controlled by redstone."
-				""
-				"Yes, you can also use it for generating power... &owith Diamonds."
-			]
-			id: "715BC5C7DAC53B7B"
-			rewards: [{
-				id: "518DD0C9237B4DBC"
-				item: "kubejs:moni_quarter"
-				type: "item"
-			}]
-			shape: "hexagon"
-			size: 2.0d
-			tasks: [{
-				id: "15A06F5EF4CADA4C"
-				item: "hostilenetworks:sim_chamber"
-				type: "item"
-			}]
-			title: "&9Simulating Mobs"
-			x: 6.5d
-			y: -5.5d
-		}
-		{
-			dependencies: [
-				"5301E546BAA69844"
-				"74B5CA5A48CE7B39"
-			]
-			id: "3BD20358F137E7C6"
-			shape: "hexagon"
-			tasks: [{
-				id: "6C0D6663D13E8C74"
-				item: "gtceu:dark_steel_ingot"
-				type: "item"
-			}]
-			x: 6.5d
-			y: -3.0d
-		}
-		{
-			dependencies: ["545CCC24D9401794"]
-			description: [
-				"&2This Steam multiblock was intended for use in the Steam Age. This pack skips the Steam Age, but it may still be worth using.&r"
-				""
-				"The &6Steam Grinder&r functions as 5.3 &7LV &3Macerators&r in parallel! It requires an input of &9Steam&r through a &eSteam Hatch&r, but it uses very little Steam."
-				""
-				"You may want to consider setting up a rudimentary &eore-doubling&r setup with it. Point the output in the direction of several upgraded &3Furnaces&r."
-			]
-			icon: "gtceu:steam_grinder"
-			id: "41C2E49E70D76330"
-			rewards: [
-				{
-					count: 7
-					id: "6B113D9EF57E5CDE"
-					item: "kubejs:moni_nickel"
-					type: "item"
-				}
-				{
-					id: "42A15BBED3DD9B74"
-					item: {
-						Count: 1
-						id: "minecraft:enchanted_book"
-						tag: {
-							StoredEnchantments: [{
-								id: "minecraft:silk_touch"
-								lvl: 1s
-							}]
-						}
-					}
-					type: "item"
-				}
-			]
-			size: 1.75d
-			tasks: [
-				{
-					id: "7DD0FE0A1E868294"
-					item: "gtceu:steam_grinder"
-					type: "item"
-				}
-				{
-					count: 22L
-					id: "18DB8D651F2D31CB"
-					item: "gtceu:steam_machine_casing"
-					type: "item"
-				}
-				{
-					id: "570435DB56E60014"
-					item: "gtceu:steam_input_bus"
-					type: "item"
-				}
-				{
-					id: "4A720EFF7B137995"
-					item: "gtceu:steam_output_bus"
-					type: "item"
-				}
-				{
-					id: "76E984019B7F6D6B"
-					item: "gtceu:steam_input_hatch"
-					type: "item"
-				}
-			]
-			title: "&9Steam Grinder"
-			x: 4.5d
-			y: 0.0d
-		}
-		{
-			dependencies: [
-				"5301E546BAA69844"
-				"5B0200011DF8E1B6"
-			]
-			description: [
-				"A refined type of steel, made from &6Silicon Dust&r and &6Steel&r."
-				""
-				"This material is frequently used in electronics and digital equipment."
-			]
-			id: "025543EDB0A4AC22"
-			rewards: [{
-				id: "2E05259B781807C7"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "3D964DFA52F261AB"
-				item: "gtceu:electrical_steel_ingot"
-				type: "item"
-			}]
-			x: 6.5d
-			y: -0.5d
+			title: "Iron Supply"
+			x: 0.0d
+			y: 2.5d
 		}
 		{
 			dependencies: ["2E8BFA2E719B1C47"]
 			description: [
-				"You'll need &6Obsidian&r to make &6Dark Steel&r. Most of the tools you can make cannot mine Obsidian, but you do have a few potential options for ones that will work. The options you're most likely to have access to at this point are:"
+				"&bSophisticated Storage&r and &bSophisticated Backpacks&r are great options for storing items, both at base and on the go, as well as offering a variety of both helpful and fun upgrades."
 				""
-				"1) A &aDiamond Pickaxe&r or &aDiamond Mining Hammer&r."
-				""
-				"2) A &aPlatinum Mining Hammer&r (not pickaxe though)."
-				""
-				"Later. you can use a &3Rock Breaker&r at voltage &aHV&r or higher to make &6Obsidian&r without spending &6Lava&r!"
+				"&bSophisticated Storage&r in particular is great for cheap storage, able to store 3 barrels worth of items at it's lowest tier, costing only a bit of iron to craft, and can be upgraded with barrel upgrades to hold even more items and upgrades."
 			]
-			id: "74B5CA5A48CE7B39"
+			id: "61E5D7EEE745C6FB"
 			rewards: [{
-				id: "0BF9F19C54FA7B41"
+				id: "404D91696592F318"
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
-			tasks: [{
-				id: "08959EE1440564D6"
-				item: "minecraft:obsidian"
-				type: "item"
-			}]
-			x: 6.5d
-			y: -2.0d
-		}
-		{
-			dependencies: ["5301E546BAA69844"]
-			description: [
-				"Obtaining &6Grains of Infinity&r will require you to mine all the way down to Bedrock level."
-				""
-				"&5You can automate grains via molecular reassembly, as current automation methods are nonfunctional."
-			]
-			icon: "enderio:grains_of_infinity"
-			id: "1CA6D620309F2B9E"
-			rewards: [{
-				id: "67D69429C7C3148B"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
+			subtitle: "Bags of holding"
 			tasks: [
 				{
-					id: "4A822DF50CD59532"
+					id: "46CA42CF7D0730E6"
 					item: {
 						Count: 1
-						id: "minecraft:flint_and_steel"
+						id: "sophisticatedstorage:gold_barrel"
 						tag: {
-							Damage: 0
+							woodType: "spruce"
 						}
 					}
 					type: "item"
 				}
 				{
-					id: "1E07B0FCC2B8D3EF"
-					item: "enderio:grains_of_infinity"
+					id: "3A3F4984E9A1A81E"
+					item: {
+						Count: 1
+						id: "itemfilters:tag"
+						tag: {
+							value: "moni_quest:backpack"
+						}
+					}
+					title: "Any Sophisticated Backpack"
 					type: "item"
 				}
 			]
-			title: "Grains Of Infinity"
-			x: 8.5d
-			y: -3.0d
+			title: "&9Sophisticated Storage Shenanigans"
+			x: -5.5d
+			y: 2.5d
 		}
 		{
-			dependencies: [
-				"1CA6D620309F2B9E"
-				"3BD20358F137E7C6"
+			dependencies: ["2E8BFA2E719B1C47"]
+			description: [
+				"[\"Take a peek at the \",{\"text\":\"Elements and Alloys quest book tab\",\"color\":\"yellow\",\"underlined\":true,\"clickEvent\":{\"action\":\"change_page\",\"value\":\"25FEB9E61EEC1A96\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":\"Click to go to the chapter\"}},\". This might seem a bit premature to suggest, but it has a reason.\"]"
+				""
+				"These are quests for a full stack of many of the materials in the game. Those are the materials you'll need to synthesize &5Omnium&r, the basic end game resource. It's the pack's way of letting you know what materials you should be prepared to mass produce as you approach the end."
+				""
+				"Of course, it's not necessary or even advisable to try to finish up all of these quests the moment they become available. Some will be incredibly easy (like &6Iron&f and &6Copper&f), others will be brutally grindy at early tech levels. The rewards are all the same: &925 Monicoins each&f, so use your best judgement on which ones to complete and which to ignore for later."
 			]
-			description: ["Better flying."]
-			id: "4C2FE08AF5EF37F7"
+			icon: "kubejs:mote_of_omnium"
+			id: "0C173EF148EFEF8E"
+			tasks: [{
+				id: "647D560D77DBCEA5"
+				type: "checkmark"
+			}]
+			title: "Elements and Alloys"
+			x: -2.5d
+			y: 4.0d
+		}
+		{
+			dependencies: ["2E8BFA2E719B1C47"]
+			description: [
+				"&2GTCEu Fluid Pipes&r are now available, much improved from CE. Their advantage is higher &9throughput&r, but they have limitations on the kinds of fluids (&eacids, gases&r, etc) they can transport safely. Check each pipe material's tooltip for details. Fluid pipes do require a pump to be able to pull fluids from tanks or machines that lack an autooutput function, but &9ULV pumps (as well as other covers) are now buyable with Monicoins&r."
+				""
+				"There are also &6Quadruple and Nonuple Pipes&r for transporting multiple fluid types through the same block."
+				""
+				"&bEnderIO&r&6 Fluid Conduits&r are also an option. They have the advantage of being &6Conduits&r, allowing them to fit in the same block as other &6Conduits&r. "
+				""
+				"Later on, you also gain access to &9LaserIO&r, which while a little costly, allows for some rather complex and compact filtering."
+			]
+			id: "64AAF0CD958D836A"
 			rewards: [{
 				count: 2
-				id: "4990CA3675F1EDAC"
-				item: "kubejs:moni_nickel"
+				id: "56EDDA9AEA7F1EBA"
+				item: "ulvcovm:ulv_electric_pump"
 				type: "item"
 			}]
 			tasks: [{
-				id: "5117F1809E9134E3"
+				id: "150F57D9BEE7CCEE"
 				item: {
 					Count: 1
-					id: "ironjetpacks:jetpack"
+					id: "itemfilters:or"
 					tag: {
-						Id: "ironjetpacks:hardened"
-					}
-				}
-				match_nbt: true
-				type: "item"
-			}]
-			x: 8.5d
-			y: -5.5d
-		}
-		{
-			dependencies: ["4C2FE08AF5EF37F7"]
-			description: [
-				"Even better flying."
-				""
-				"You're not getting up to Resonant for a long time, just FYI."
-			]
-			id: "1657FEC07998C9D0"
-			rewards: [{
-				id: "67FF2BDD5D4AC075"
-				item: "kubejs:moni_quarter"
-				type: "item"
-			}]
-			tasks: [{
-				id: "77DC5C373B34E731"
-				item: {
-					Count: 1
-					id: "ironjetpacks:jetpack"
-					tag: {
-						Id: "ironjetpacks:reinforced"
-					}
-				}
-				match_nbt: true
-				type: "item"
-			}]
-			x: 8.5d
-			y: -7.0d
-		}
-		{
-			dependencies: ["3BD20358F137E7C6"]
-			description: [
-				"The main purpose for this device is to turn &6Certus Quartz&r into &6Charged Certus Quartz Crystals&r."
-				""
-				"This device can be powered with RF via energy conduits or use AE energy from a network via ME conduits or cables."
-				""
-				"It accepts power from &9five&r sides. Which &9five&r sides? It's pretty easy to guess."
-				""
-				"You can also easily automate charging by having hoppers input item from top or sides, and pull items from the bottom."
-			]
-			icon: "ae2:charger"
-			id: "6D03BB4A6A4BBA27"
-			rewards: [{
-				id: "4450EEE7F4D93EF0"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [{
-				id: "39AA9BBDCACBC109"
-				item: "ae2:charger"
-				type: "item"
-			}]
-			title: "Charging Quartz"
-			x: 10.5d
-			y: -3.0d
-		}
-		{
-			dependencies: ["6D03BB4A6A4BBA27"]
-			description: [
-				"Fluix is initially made via in-world crafting, by dropping &6Redstone&r, &6Nether Quartz&r, and a &6Charged Certus Quartz Crystal&r in the same block of &9Water&r. You'll see some sparks then the items will merge into a &6Fluix Crystal&r. Be sure to turn off any nearby item magnets/collectors or they might interrupt this crafting process."
-				""
-				"The &3Energy Acceptor&r converts RF power into AE power that Applied Energistics uses, in a 2 RF to 1 AE ratio. This power will be transmitted through adjacent full-block ME Network devices, as well as along all connected &6ME Cables&r, &6ME Conduits&r, and &6Quartz Fiber&r. "
-				""
-				"Quartz Fiber are &emicroparts&r you can put between an ME Cable and any ME Network block or another ME Cable. This will allow transmission of AE power but not data, which is useful for having data-isolated ME Networks all sharing the same power source."
-				"Applied Energistics 2 can be complicated for a new player, so I recommend either using &9the ingame guide&r or a video as a supplement to this chapter if need be. "
-				""
-				"[\"I personally recommend \",{\"text\": \"Pansmith's guide to Applied Energistics 2\",\"color\": \"blue\",\"underlined\": true,\"clickEvent\": {\"action\": \"copy_to_clipboard\",\"value\": \"https://www.youtube.com/watch?v=u0ouTWgdcXk\"},\"hoverEvent\": {\"action\": \"show_text\",\"contents\": \"Click to copy to clipboard!\"}}, \", while written for the 1.12 verison of AE2, most of the infomation is the exact same between the versions, and was made with Nomifactory players in mind.\"]"
-			]
-			icon: "ae2:energy_acceptor"
-			id: "4174A6C6403DD245"
-			rewards: [
-				{
-					id: "67642A41B1F7F4E8"
-					item: "kubejs:moni_nickel"
-					type: "item"
-				}
-				{
-					id: "2EAC8635F1C7A8DB"
-					item: "ae2:guide"
-					type: "item"
-				}
-			]
-			shape: "hexagon"
-			size: 2.0d
-			tasks: [
-				{
-					id: "652709622C84E4CC"
-					item: "ae2:energy_acceptor"
-					type: "item"
-				}
-				{
-					id: "3550456A821A6975"
-					item: "gtceu:fluix_gem"
-					type: "item"
-				}
-			]
-			x: 13.0d
-			y: -3.0d
-		}
-		{
-			dependencies: ["025543EDB0A4AC22"]
-			description: [
-				"The first tier of &6capacitors&r. These (or stronger versions) are required to make &bEnderIO&r machines run. They're also used as components in a variety of recipes."
-				""
-				"Higher tier capacitors will significantly increase the speed at which these machines operate, among other machine-specific properties."
-			]
-			id: "7842EC1C389C4B7E"
-			rewards: [{
-				id: "257A2797BA4F9A4F"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "12BB374292CCF6F8"
-				item: "enderio:basic_capacitor"
-				type: "item"
-			}]
-			title: "Basic Capacitors"
-			x: 8.5d
-			y: -1.5d
-		}
-		{
-			dependencies: ["7842EC1C389C4B7E"]
-			description: [
-				"Expandable multi-block storage for RF power."
-				""
-				"This first tier isn't much, but you can upgrade them over time to hold substantial amounts of power."
-			]
-			id: "2845151447537433"
-			rewards: [{
-				id: "38218FE6AA47BF71"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "61E7629E44901031"
-				item: "enderio:basic_capacitor_bank"
-				type: "item"
-			}]
-			x: 10.5d
-			y: -1.5d
-		}
-		{
-			dependencies: ["025543EDB0A4AC22"]
-			description: [
-				"What?!"
-				"&6STEAM DYNAMO&r is evolving!"
-				""
-				"Upgrade kits can be applied to Thermal Expansion Dynamos, machines, and even Portable Tanks. Machines and dynamos get additional augment slots."
-				""
-				"When applied to a dynamo, it increases the &apower generation and fuel burn rate to 150%&r."
-				""
-				"Allows machines operate at &a150% of base power per tick&r. The more power a machine can use, the faster it works."
-			]
-			id: "356DA8DE256356B8"
-			tasks: [{
-				id: "26BC97C8FD16C12D"
-				item: "thermal:upgrade_augment_1"
-				match_nbt: false
-				type: "item"
-			}]
-			x: 8.5d
-			y: 0.5d
-		}
-		{
-			dependencies: ["7842EC1C389C4B7E"]
-			description: [
-				"Being able to fly is nice. This is the first jetpack that uses &bEnderIO&r materials."
-				""
-				"There's also a quest chain for &bThermal Expansion&r material Jetpacks (starting with the &6Leadstone Jetpack&r). Eventually you'll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really really like flying."
-			]
-			id: "3A18C673D76382E9"
-			rewards: [{
-				id: "444D3A12D42D30E5"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "5FFAD74ABDA85AAA"
-				item: {
-					Count: 1
-					id: "ironjetpacks:jetpack"
-					tag: {
-						Id: "ironjetpacks:conductive_iron"
-					}
-				}
-				type: "item"
-			}]
-			x: 10.5d
-			y: 0.5d
-		}
-		{
-			dependencies: ["62BBD1F6767A4D90"]
-			description: [
-				"&3Electrolyzers&r use electricity to separate items into their more basic components."
-				""
-				"For example, you can break down Water into &9Hydrogen Gas&r and &9Oxygen Gas&r, or break down &6Clay Dust&r into &6Sodium Dust&r, &6Silicon Dust&r, &6Lithium Dust&r, and &6Aluminium Dust&r."
-			]
-			id: "5B0200011DF8E1B6"
-			rewards: [{
-				id: "3E616B7D43C03186"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [{
-				id: "7AE6F9DF96ADD8D2"
-				item: "gtceu:lv_electrolyzer"
-				type: "item"
-			}]
-			title: "LV Electrolyzer"
-			x: 6.5d
-			y: 2.0d
-		}
-		{
-			dependencies: ["5B0200011DF8E1B6"]
-			description: [
-				"&oSilicon Dioxide is an important part of a Processing Line. Visit the Processing Lines Tab to have more info, useful tips and a visual representation of how to passively automate this.&r"
-				""
-				"Around this point, you will need large quantities of &6Hydrogen&r and &6Oxygen&r. "
-				""
-				"The first way that comes to mind is electrolysing &9Water&r, but that is slow. "
-				""
-				"Instead, the best way of making early game &6Oxygen&r is &6Silicon Dioxide&r."
-				""
-				"&6Hydrogen&r is a bit trickier, but you can put &6Methane&r and &6Water&r together in a &3Chemical Reactor&r. &6Methane&r can be achieved by centrifuging &6Food&r and &6Wood&r, processing &6Pyroluse Byproducts&r, or through &6Petroleum&r. "
-				""
-				"Right now, for the small quantities you need, you can simply electrolyse &9Water&r. Just keep those other ways in mind, for later in the game."
-			]
-			icon: "gtceu:oxygen_bucket"
-			id: "6FE99EDDC6223F2E"
-			rewards: [{
-				id: "3B5D99034C7CD3F4"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [
-				{
-					id: "47392B270D61CD4C"
-					item: "gtceu:hydrogen_bucket"
-					type: "item"
-				}
-				{
-					id: "7F2D244D03684EB3"
-					item: "gtceu:oxygen_bucket"
-					type: "item"
-				}
-			]
-			title: "Hydrogen and Oxygen"
-			x: 8.5d
-			y: 2.0d
-		}
-		{
-			dependencies: ["3F6EDC2481D5877F"]
-			description: ["Carry &oeven more&r stuff."]
-			icon: {
-				Count: 1
-				id: "sophisticatedbackpacks:iron_backpack"
-				tag: {
-					contentsUuid: [I;
-						890972236
-						1590249428
-						-1212807776
-						575640463
-					]
-					inventorySlots: 54
-					upgradeSlots: 2
-				}
-			}
-			id: "15808BD9C5DBA0F7"
-			rewards: [{
-				id: "3A6C03B13D469DDC"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "209DE065BB54505D"
-				item: {
-					Count: 1
-					id: "sophisticatedbackpacks:iron_backpack"
-					tag: {
-						contentsUuid: [I;
-							890972236
-							1590249428
-							-1212807776
-							575640463
+						items: [
+							{
+								Count: 1b
+								id: "itemfilters:or"
+								tag: {
+									items: [
+										{
+											Count: 1b
+											id: "gtceu:steel_tiny_fluid_pipe"
+										}
+										{
+											Count: 1b
+											id: "gtceu:steel_small_fluid_pipe"
+										}
+										{
+											Count: 1b
+											id: "gtceu:steel_normal_fluid_pipe"
+										}
+										{
+											Count: 1b
+											id: "gtceu:steel_large_fluid_pipe"
+										}
+										{
+											Count: 1b
+											id: "gtceu:steel_huge_fluid_pipe"
+										}
+									]
+								}
+							}
+							{
+								Count: 1b
+								id: "enderio:pressurized_fluid_conduit"
+							}
+							{
+								Count: 1b
+								id: "laserio:card_fluid"
+							}
 						]
-						inventorySlots: 54
-						upgradeSlots: 2
 					}
 				}
+				title: "Fluid Transport item"
 				type: "item"
-				weak_nbt_match: true
 			}]
-			title: "&9Better Backpacks"
-			x: 4.5d
+			title: "&9Fluid Transport"
+			x: -4.0d
 			y: 3.5d
 		}
 		{
-			dependencies: [
-				"3F6EDC2481D5877F"
-				"6197C51E04761371"
-			]
+			dependencies: ["2E8BFA2E719B1C47"]
 			description: [
-				"&6Cupronickel Coils&r form part of the structure of a few multiblocks. Presently, those are the &3Electric Blast Furnace&r and &3Pyrolyse Oven&r. Each tier of coil unlocks new recipes and provides various bonuses to the multiblock they are attached to."
+				"&6Gregtech&r adds a decent bit of extra crafting to the earlygame. Thankfully, &bEMI&r has some tools to help make your life &9&lMUCH&r easier when doing all this crafting."
 				""
-				"Cupronickel Coils are produced in the &3Assembler&r with &62x Cupronickel Wire&r, &6Bronze Foil&r, and &9Tin Alloy fluid&r."
+				"[\"On the topic of crafting, if you are not already familiar with how \", {\"text\": \"recipe viewers\", \"underlined\": \"true\", \"clickEvent\": { \"action\": \"change_page\", \"value\": \"3B200AD6EFF90DFA\" } },\" like EMI or JEI, read that quest first.\"]"
 				""
-				"For now, you need 16 coils for the &3Electric Blast Furnace&r and 16 for the &3Pyrolyse Oven&r. That totals to 176 Copper, 128 Nickel, 32 Tin, and 16 Iron."
+				"When looking a recipe in EMI, you've likely noticed 3 buttons that appear on each recipe, being &c[❤]&r, &a[┴]&r, and &9[+]&r."
+				""
+				"Let's start with &9[+]&r, as it's the simplest: right-click a crafting table, look up the recipe you need and press the &9[+]&r button: if you have all required items for the recipe, this will put them all into the crafting table for you."
+				""
+				"&c[❤]&r and &a[┴]&r are used in tandem to create &arecipe trees&r. Pressing &a[┴]&r will pull up a &arecipe tree&r for that given item. Pressing &c[❤]&r on a recipe will mark it as the &cdefault recipe&r for that item, and will show that recipe (and the items used to craft it) in &arecipe trees&r. You can then add &cdefault recipes&r for the items used to craft that recipe, repeat ad nauseam. Note that you can click on a item in the &arecipe tree&r and it's recipes will be pulled up."
+				"{@pagebreak}"
+				"In the &arecipe tree&r GUI, you can change the batch size by scrolling on the number to the right of the final result. Finally, and most importantly, you can press the &6Magnifying Glass&r to switch to &6Crafting Tree Mode&r, this will &edisplay the items that you need for every step to craft the number of items that you specified&r in your sidebar, and will dynamically update as you craft items. You can click on these &6Synthetic Favorites&r with your Craft to Inventory bind (unbinded by default) to &eautomatically craft and then push items back into your inventory&r when using a crafting table, or push the exact number of items needed if using a different inventory.&r"
+				""
+				"Also note that EMI will commit &cdefault recipes&r to memory, meaning that as you save more and more recipes, EMI will remember them all, and will automatically use them when you pull up a &arecipe tree&r for any given item. Also, you can change the &cdefault recipe&r for an item, and EMI will automatically update the &arecipe tree&r as well. You can also click the &a[┴]&r button found in the bottom left of your screen and it will pull up the &arecipe tree&r GUI as well."
 			]
-			id: "4CD6C60CBEFFA317"
+			disable_toast: true
+			icon: "gtceu:crafting_table_cover"
+			id: "58566C7BF4C22D86"
+			shape: "hexagon"
+			size: 1.25d
+			subtitle: "Better than any crafting calculator."
+			tasks: [{
+				id: "3768A707E0489471"
+				type: "checkmark"
+			}]
+			title: "&9Recipe Trees and Crafting Trees"
+			x: 0.0d
+			y: 4.0d
+		}
+		{
+			dependencies: ["2E8BFA2E719B1C47"]
+			description: [
+				"The &eTool Belt&r is a item, which can store your tools, and exchange them easily! Right now, it has 2 slots, but later, once you unlock &6Steel&r, you can upgrade it with &6Belt Pouches&r, all the way to 9 slots, with an &3Anvil&r and some &aXP&r!"
+				""
+				"Make the Tool Belt, and you can use the keybind (default is `R'), while the belt is in your inventory or Bauble Slots &cand you are holding something, or the belt is not empty&r, to open its GUI. "
+				""
+				"Alternatively, you can right click while holding the belt to open its inventory."
+				"{@pagebreak}"
+				"The Tool Belt is equipable as a &bBauble&r. Open your inventory and look for the Baubles button, and click it to reveal the additional bauble slots menu, and then put it in the Belt Slot. Or, just click in every bauble slot until it goes in, if you can't tell which bauble slot looks like a belt."
+				""
+				"The Tool Belt can store anything with a stack size of 1, like swords, pickaxes, &bGregTech&r tools, and the &6Terminal&r. It has also been modified a bit, so it also allows any &bStorage Drawers&r key, and &cdoesn't allow any Thermal Satchel&r."
+				""
+				"Now, you can insert and extract from the belt! You can also use the Keybinds `&eCycle Tool Left&r' and `&eCycle Tool Right&r' whilst you are in the GUI."
+			]
+			id: "1B86EF5A24286787"
 			rewards: [{
-				id: "3E688257A7E030CE"
+				id: "637891A6BC00C62D"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			subtitle: "&2A brand new and highly requested mod to CEu to help you manage your tools!&r"
+			tasks: [{
+				id: "2BFE87C449C8D8F3"
+				item: "toolbelt:belt"
+				type: "item"
+			}]
+			title: "&2Tool Belt"
+			x: 2.5d
+			y: 4.0d
+		}
+		{
+			dependencies: ["2E8BFA2E719B1C47"]
+			description: ["No hoops to jump through here. Smelt &6Wood Logs&f to get &6Charcoal&f. It will serve you well as a fuel source until you locate a vein of &6Coal&f."]
+			id: "5D97206C8135872B"
+			tasks: [{
+				id: "36D486BE19669899"
+				item: "minecraft:charcoal"
+				type: "item"
+			}]
+			x: 4.0d
+			y: 3.5d
+		}
+		{
+			dependencies: ["2E8BFA2E719B1C47"]
+			description: ["&3Iron Furnaces&f can smelt an item in &a160 ticks&f, which is somewhat faster than a vanilla &6Furnace&f, which takes &a200 ticks&f. The fuel efficiency remains the same for all furnaces."]
+			id: "7865CDE5CFE005DC"
+			rewards: [{
+				id: "55F7CA98F66953A1"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "6A2879717EF57D8A"
+				item: "ironfurnaces:iron_furnace"
+				type: "item"
+			}]
+			title: "Furnace v2.0"
+			x: 5.5d
+			y: 2.5d
+		}
+		{
+			dependencies: ["7865CDE5CFE005DC"]
+			description: ["&3Copper Furnaces&f are another step up in speed, taking &a100 ticks&f to smelt an item."]
+			id: "0591171F13A45283"
+			rewards: [{
+				id: "20FC1982A662B6C6"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "14CDC80A449BD388"
+				item: "ironfurnaces:copper_furnace"
+				type: "item"
+			}]
+			title: "Furnace v3.0"
+			x: 5.5d
+			y: 3.75d
+		}
+		{
+			dependencies: ["0591171F13A45283"]
+			description: ["&3Silver Furnaces&f are another step up in speed, taking a mere &a80 ticks&f to smelt an item."]
+			id: "3F77EDE69BB649DA"
+			rewards: [{
+				id: "77EC0D08F5C99E37"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "266C775298CDC137"
+				item: "ironfurnaces:silver_furnace"
+				type: "item"
+			}]
+			title: "Furnace v4.0"
+			x: 5.5d
+			y: 5.0d
+		}
+		{
+			dependencies: ["3F77EDE69BB649DA"]
+			description: ["&3Gold Furnaces&f are yet another step up in speed, taking only &a40 ticks&f to smelt an item."]
+			id: "6B121BEFD852BC2D"
+			rewards: [{
+				id: "045094D4927E2AB5"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "0FD61CD4D237D131"
+				item: "ironfurnaces:gold_furnace"
+				type: "item"
+			}]
+			title: "Furnace v5.0"
+			x: 5.5d
+			y: 6.25d
+		}
+		{
+			dependencies: ["6B121BEFD852BC2D"]
+			description: ["&3Diamond Furnaces&f are even faster, taking only &a25 ticks&f to smelt an item."]
+			id: "1AE46C1970378083"
+			rewards: [{
+				id: "4F7C761D3657868A"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "67B5E4F996C454C8"
+				item: "ironfurnaces:diamond_furnace"
+				type: "item"
+			}]
+			title: "Furnace v6.0"
+			x: 5.5d
+			y: 7.5d
+		}
+		{
+			dependencies: ["1AE46C1970378083"]
+			description: ["&3Obsidian Furnaces&f are slightly faster than &3Diamond Furnaces&f, taking only &a20 ticks&r to smelt an items, and are also blastproof."]
+			id: "3969150B59EA38A2"
+			rewards: [{
+				id: "7BADB8C39CADB5FF"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "223332FE4EEB31B0"
+				item: "ironfurnaces:obsidian_furnace"
+				type: "item"
+			}]
+			title: "Furnace v7.0"
+			x: 5.5d
+			y: 8.75d
+		}
+		{
+			dependencies: ["3969150B59EA38A2"]
+			description: ["At this point, you might as well just make a &3Multi Smelter&r. But it does smelt items at a blazing quick 5 ticks"]
+			id: "69E77BD01CFF65EB"
+			invisible: true
+			rewards: [{
+				id: "2BBD659B19ED9807"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "015B7C7A82AE67C5"
+				item: "ironfurnaces:netherite_furnace"
+				type: "item"
+			}]
+			title: "Furnace v8.0"
+			x: 5.5d
+			y: 10.0d
+		}
+		{
+			dependencies: ["58566C7BF4C22D86"]
+			description: [
+				"&9With EMI, instead of showing you a separate recipe for every tool-resource combination, tools are instead grouped. You can use any any tool from that group - for example, the &6#forge:tools/hammers &9group means that any &aHammer &9can be used there."
+				""
+				"First, make a &aHammer&f (not a &aMining Hammer&f, mind you... six ingots, not plates). Hammers can be used to turn &etwo ingots into one plate&f. &6Plates&f can make a &aFile&f, Files can make &6Rods&f, etc. Use EMI to work your way down the list of tools."
+				""
+				"&6Wrought Iron&f is probably your best bet for a tool material right now, but better materials will become available as you progress."
+			]
+			icon: {
+				Count: 1
+				id: "gtceu:wrought_iron_wire_cutter"
+				tag: {
+					DisallowContainerItem: 0b
+					GT.Behaviours: { }
+					GT.Tool: {
+						Damage: 0
+						HarvestLevel: 2
+						MaxDamage: 383
+						ToolSpeed: 6.0f
+					}
+					HideFlags: 2
+				}
+			}
+			id: "4FE53F31E68F4C1C"
+			rewards: [{
+				count: 2
+				id: "1DA0C8E82ED7EAD8"
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "2EB8F8C2ABFD2637"
-				item: "gtceu:cupronickel_coil_block"
-				type: "item"
-			}]
-			title: "&2Cupronickel Coils"
-			x: 2.5d
-			y: 5.0d
-		}
-		{
-			dependencies: [
-				"5B0200011DF8E1B6"
-				"1BC6DDC2D50F9C46"
-			]
-			description: [
-				"With your EBF running, start to create a supply of &6Aluminium Ingots&r. These are crucial ingredients for MV machines, including &bApplied Energistics&r."
-				""
-				"&2With LV power, you can only get Aluminium Dust from electrolyzing Clay Dust, Sapphire Dust or Green Sapphire Dust. Clay Dust is recommended. Once you make an MV Electrolyzer, you can get it from a plethora of other raw resources.&r"
-				""
-				"If you find your power supply is faltering, you may want to make additional dynamos and turn them into steam boilers and turbines. Upgrading your dynamos is also advisable."
-				""
-				"However, you're also about to reach MV. You're bound to discover a better power source than steam before long."
-				""
-				"&2You can cut by a third the smelting time of Aluminium and some other smelting processes with Nitrogen gas. Higher-tier processes may take different gases."
-			]
-			id: "3AB0402B19DD5BA8"
-			rewards: [
+			size: 1.5d
+			tasks: [
 				{
-					id: "5155898EDA908A3F"
-					item: "kubejs:moni_nickel"
+					id: "04ED9B749EA44142"
+					item: {
+						Count: 1
+						id: "gtceu:wrought_iron_hammer"
+						tag: {
+							Damage: 0
+							GT.Tool: {
+								Damage: 0
+							}
+						}
+					}
 					type: "item"
 				}
 				{
-					id: "3D0C6CDEED481E30"
+					id: "514CE965C8FB1452"
 					item: {
 						Count: 1
-						id: "trofers:large_pillar"
+						id: "gtceu:wrought_iron_file"
 						tag: {
-							BlockEntityTag: {
-								Trophy: "monifactory:alumnium"
+							Damage: 0
+							GT.Tool: {
+								Damage: 0
+							}
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "7226082DB71F551A"
+					item: {
+						Count: 1
+						id: "gtceu:wrought_iron_saw"
+						tag: {
+							Damage: 0
+							GT.Tool: {
+								Damage: 0
+							}
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "705CACC01AD1C68E"
+					item: {
+						Count: 1
+						id: "gtceu:wrought_iron_wrench"
+						tag: {
+							Damage: 0
+							GT.Tool: {
+								Damage: 0
+							}
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "290A0FE8C389AF05"
+					item: {
+						Count: 1
+						id: "gtceu:wrought_iron_screwdriver"
+						tag: {
+							Damage: 0
+							GT.Tool: {
+								Damage: 0
+							}
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "7B41907A63748FCA"
+					item: {
+						Count: 1
+						id: "gtceu:wrought_iron_wire_cutter"
+						tag: {
+							Damage: 0
+							GT.Tool: {
+								Damage: 0
+							}
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "7298CFD7BA970AA8"
+					item: {
+						Count: 1
+						id: "gtceu:wrought_iron_mortar"
+						tag: {
+							Damage: 0
+							GT.Tool: {
+								Damage: 0
 							}
 						}
 					}
 					type: "item"
 				}
 			]
-			shape: "hexagon"
-			tasks: [{
-				id: "76883573CA1B54F4"
-				item: "gtceu:aluminium_ingot"
-				type: "item"
-			}]
-			title: "&2Aluminium Ingots"
-			x: 6.5d
-			y: 7.5d
+			title: "Some Starter Tools"
+			x: 0.0d
+			y: 5.5d
 		}
 		{
-			dependencies: ["4CD6C60CBEFFA317"]
+			dependencies: ["4FE53F31E68F4C1C"]
 			description: [
-				"The &3Electric Blast Furnace&r is a major, major milestone in your &bGregTech&r career. It has the power to smelt more advanced materials. The first of which, &6Aluminium&r, is going to be important in the immediate future."
+				"&aMining Hammers&r offer a relatively cheap way to mine out areas much faster. They clear a 3x3 of blocks (unless you're crouching) and mine quickly."
 				""
-				"Since smelting &6Aluminium&r requires MV power, you're going to have to power this with 2 LV Energy Input Hatches."
+				"&2GTCEu now has Mining Hammers natively! You can craft them with any GT tool material. &r"
 				""
-				"There is a diagram of how to build the EBF in &bEMI&r. The second and third levels must be a 3x3 square shape of Coil Blocks (&6Cupronickel&r is the only type of coil block you have access to for now) with an empty center. You can also &6sneak-right click&r the controller to enable the in-world preview."
-				""
-				"However, the bottom and top layers are very flexible. The &6EBF Controller&r must be on the &ebottom layer&r of the structure, and on the &emiddle of an outer edge&r; the &6Muffler Hatch&r must be in the &eexact middle of the top layer&r. Otherwise, you can put the hatches and buses wherever you want, filling in all gaps in each layer with &6Heatproof Machine Casings&r. It's worth noting that you must &euse at least &29&e Heatproof Machine Casings in your layout or the structure will not form&r."
-				""
-				"{@pagebreak}"
-				"This quest calls for a &2maintenance hatch&r, two energy hatches, a fluid input and output, and an item input and output, which is a total of 7 positions. Their specific order and placement don't matter, as long as you can access them. The 8th position is your EBF controller, leaving 9 gaps to be filled by Heatproof Machine Casings. If you did everything right, the structure will form: the colors on its hatches and casings will unify, and the controller will say \"Idling.\""
-				""
-				"Hatches and Buses can be replaced by Hatches and Buses of any tier, although the Input Bus must be at least LV, as there are 2 inputs."
-				""
-				"You'll most likely want to locate your power quite near to the EBF. It is very power hungry, and if it cannot get enough energy, progress on the current item smelting will start to regress. Be careful to ensure the EBF has enough power, and keep a Soft Hammer nearby to pause it by tapping the controller if you run out of power."
-				""
-				"&2In GTCEu, all hatches except Maintenance can be shared between Multiblocks!"
+				"Your free 4 Diamond Mining Hammers should last you a while, and you can always fix them using an anvil and some diamonds."
 			]
-			icon: "gtceu:electric_blast_furnace"
-			id: "1BC6DDC2D50F9C46"
+			icon: {
+				Count: 1
+				id: "gtceu:iron_mining_hammer"
+				tag: {
+					Damage: 0
+					GT.Tool: {
+						Damage: 0
+					}
+				}
+			}
+			id: "07D45A3F8A74A61C"
 			rewards: [{
-				id: "3B20DB4147336C51"
-				item: "kubejs:moni_dollar"
+				id: "0969EFC84AA58A45"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			subtitle: "Diggy Diggy Hole"
+			tasks: [{
+				consume_items: false
+				id: "589A0779F965D77A"
+				item: {
+					Count: 1
+					id: "itemfilters:tag"
+					tag: {
+						value: "forge:tools/mining_hammers"
+					}
+				}
+				match_nbt: false
+				title: "Any Mining Hammers"
+				type: "item"
+			}]
+			title: "Mining Hammers"
+			x: 1.5d
+			y: 5.0d
+		}
+		{
+			dependencies: ["4FE53F31E68F4C1C"]
+			description: ["&9Gregtech Axes are able to vienmine an entire tree at once!"]
+			icon: {
+				Count: 1
+				id: "gtceu:iron_axe"
+				tag: {
+					DisallowContainerItem: 0b
+					GT.Behaviours: {
+						DisableShields: 1b
+						TreeFelling: 1b
+					}
+					GT.Tool: {
+						Damage: 0
+						HarvestLevel: 2
+						MaxDamage: 255
+						ToolSpeed: 4.0f
+					}
+					HideFlags: 2
+				}
+			}
+			id: "527F56DFAD5E20EC"
+			tasks: [{
+				id: "254A555916313F70"
+				item: {
+					Count: 1
+					id: "itemfilters:id_regex"
+					tag: {
+						value: "^gtceu:.*_axe$"
+					}
+				}
+				title: "Any Lumber Axe"
+				type: "item"
+			}]
+			title: "&9Tree chopping"
+			x: 1.5d
+			y: 6.0d
+		}
+		{
+			dependencies: ["4FE53F31E68F4C1C"]
+			description: [
+				"The &aCrescent Hammer&r is for use on machines from &bThermal Expansion&f, but can be used for basic wrench interactions with blocks from almost every mod. &9It can also now adjust Gregtech pipes,"
+				""
+				"The &aYeta Wrench&r is used with machines and conduits from &bEnderIO&f, and has several special display modes (&6sneak-mouse wheel&f to switch between them)."
+				""
+				"The &aGregTech Wrench&r is used to rotate GregTech machines and redefine their output sides. &2It also has some of the capabilities of the other Wrenches now.&r"
+				""
+				"You can see which mod a machine is from with the &9blue text&f at the bottom of its tooltip."
+			]
+			icon: "enderio:yeta_wrench"
+			id: "04A0863937695AC4"
+			rewards: [{
+				id: "247FC44B6E456222"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			subtitle: "Confused about all the Wrenches yet?"
+			tasks: [
+				{
+					id: "70251EAC64217000"
+					item: "enderio:yeta_wrench"
+					type: "item"
+				}
+				{
+					id: "1F3EDCBF5EB70229"
+					item: {
+						Count: 1
+						id: "gtceu:wrought_iron_wrench"
+						tag: {
+							Damage: 0
+							GT.Tool: {
+								Damage: 0
+							}
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "20854F1345AB6B1E"
+					item: {
+						Count: 1
+						id: "thermal:wrench"
+						tag: { }
+					}
+					type: "item"
+				}
+			]
+			title: "&9Wrenches Galore"
+			x: -1.5d
+			y: 5.0d
+		}
+		{
+			dependencies: ["4FE53F31E68F4C1C"]
+			description: [
+				"You might want to get yourself an anvil instead of breaking and crafting new tools every time. Anvils&f spawn abundantly in &bLost Cities&f buildings, so go and snatch one!"
+				""
+				"Put a damaged tool inside and put some material it's made of. For example, you'll need to put &6Wrought Iron Ingots&f to repair tools made of &6Wrought Iron&f. The only tools unable to be repaired are the mortar and the plunger."
+				""
+				"Also, you can now repair your free &6Mining Hammers&r with some &6Diamonds&r!"
+			]
+			id: "5430ED88A8D10502"
+			rewards: [{
+				id: "1B638AF68A084203"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			subtitle: "&3Anvils&f can be used to repair almost all &bGregTech tools&f!"
+			tasks: [{
+				id: "38E44244B336F941"
+				item: "minecraft:anvil"
+				type: "item"
+			}]
+			title: "Proper Tool Care"
+			x: -1.5d
+			y: 6.0d
+		}
+		{
+			dependencies: ["4FE53F31E68F4C1C"]
+			description: [
+				"&6Redstone&f: Found only deep in the world, in massive veins paired with &6Cinnabar&f and &6Ruby&f."
+				""
+				"&6Copper&f: Two primary sources. &6Tetrahedrite&f veins are higher up, while &6Chalcopyrite&f veins are lower, paired with some small amounts of &6Iron&f. You'll also find &6Malachite&f inside of Iron veins, this is another type of copper ore."
+				""
+				"&6Tin&f: Found essentially at ground level. &6Cassiterite&f is another type of tin ore, and they're always found together. If you cannot find a vein of tin, there are small amounts of tin inside veins of &6Aluminium&f and &6Rock Salt&f, which might be enough to hold you over until you find a proper tin vein."
+				""
+				"&6Coal&f: Found in relatively shallow depths. &6Lignite Coal&f is &2removed."
+				""
+				"&6Gold&f: Found inside of &6Magnetite&f veins, close to the surface."
+			]
+			icon: "minecraft:redstone"
+			id: "1229234A71CE0A99"
+			rewards: [{
+				count: 2
+				id: "79C449A6BEC8941F"
+				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
 			shape: "hexagon"
-			size: 2.0d
+			subtitle: "Before you continue, you'll need access to some more materials."
 			tasks: [
 				{
-					id: "0E093ED43F2B2E14"
-					item: "gtceu:electric_blast_furnace"
+					count: 76L
+					id: "581CD7E50AC3F5E3"
+					item: "minecraft:redstone"
+					type: "item"
+				}
+				{
+					count: 36L
+					id: "102B3966BE895F45"
+					item: { Count: 36, id: "minecraft:copper_ingot" }
+					type: "item"
+				}
+				{
+					count: 20L
+					id: "3CEB53996CBB7381"
+					item: { Count: 20, id: "gtceu:tin_ingot" }
 					type: "item"
 				}
 				{
 					count: 16L
-					id: "0D6F9EF349C45ADA"
-					item: "gtceu:cupronickel_coil_block"
+					id: "5A94EE9BCBADE6BF"
+					item: { Count: 16, id: "minecraft:coal" }
 					type: "item"
 				}
 				{
-					count: 2L
-					id: "67A9C3501BB6F0FD"
-					item: "gtceu:lv_energy_input_hatch"
-					type: "item"
-				}
-				{
-					id: "3917BF19F1C3A0C1"
-					item: "gtceu:lv_input_bus"
-					type: "item"
-				}
-				{
-					id: "3B7D450F27322A57"
-					item: "gtceu:lv_output_bus"
-					type: "item"
-				}
-				{
-					id: "24CB1B1755F635CB"
-					item: "gtceu:lv_input_hatch"
-					type: "item"
-				}
-				{
-					id: "04B80990027093E6"
-					item: "gtceu:lv_output_hatch"
-					type: "item"
-				}
-				{
-					count: 9L
-					id: "7998F0B9E0714746"
-					item: "gtceu:heatproof_machine_casing"
-					type: "item"
-				}
-				{
-					id: "215E1D7028D4007A"
-					item: "gtceu:maintenance_hatch"
-					type: "item"
-				}
-				{
-					id: "41EA282C8B1B05AB"
-					item: "gtceu:lv_muffler_hatch"
+					count: 6L
+					id: "77FEEB10E7B091B8"
+					item: { Count: 6, id: "minecraft:gold_ingot" }
 					type: "item"
 				}
 			]
-			title: "&2Blast Furnace Fun"
-			x: 2.5d
-			y: 7.5d
+			title: "More Materials"
+			x: 0.0d
+			y: 7.25d
+		}
+		{
+			dependencies: ["1229234A71CE0A99"]
+			description: [
+				"&rThis quest accepts a item pipe of any material, any size, whether restrictive or normal."
+				""
+				"For now, the best material to make these pipes out of is probably &6Tin&r."
+				""
+				"Their advantage over &5EnderIO &3Item Conduits&r is their far higher &6throughput&r. An unupgraded EIO Item Conduit transports &98 items per second&r, and up to &9128&r when upgraded. In comparison, small low-tier Item Pipes can transfer &964 items per second&r, and those made from later materials can transfer &9multiple stacks per second&r."
+				""
+				"They don't auto-extract by themselves, so you have to use &3Conveyor covers&r etc. with them."
+				""
+				"The priority mechanics are more complicated, so skip ahead if you are not interested:"
+				"A Destination will have a Routing Value calculated, which is the sum of all Routing Values of the individual Pipes to that Destination. Whichever Destination has the lowest Routing Value will be the one selected for Insertion."
+				"Restrictive Pipes typically have the lowest Priority for insertion due to their higher Routing Value."
+			]
+			id: "57D1B1D74391A05F"
+			rewards: [{
+				count: 2
+				id: "04FB020A78370641"
+				item: "ulvcovm:ulv_conveyor_module"
+				type: "item"
+			}]
+			shape: "hexagon"
+			subtitle: "&2Item Pipes are back in GTCEu! They will transport items instantly through them."
+			tasks: [{
+				id: "72798E2CFE3F6FB5"
+				item: "gtceu:tin_normal_item_pipe"
+				type: "item"
+			}]
+			title: "&2GT Item Pipes"
+			x: -1.5d
+			y: 7.25d
+		}
+		{
+			dependencies: ["4FE53F31E68F4C1C"]
+			description: [
+				"Although most &ealloys&f require an &3Alloy Smelter&f, some alloys can be made simply by mixing the correct metal dusts together. "
+				""
+				"&9Steel is one of these alloys, being made by mixing wrought iron dust with coal dust or charcoal dust&r. &2Steel forms the basis of LV Machine Hulls&r, and allows you to make &6Belt Pouches&r, for upgrading your &eTool Belt&r."
+			]
+			id: "17312BF0197B87A8"
+			rewards: [{
+				count: 2
+				id: "716AB913E59B120B"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			shape: "hexagon"
+			tasks: [{
+				id: "7DCB0AE4BF702D13"
+				item: "gtceu:steel_ingot"
+				type: "item"
+			}]
+			title: "&9Steel"
+			x: 1.5d
+			y: 7.25d
+		}
+		{
+			dependencies: ["4FE53F31E68F4C1C"]
+			description: [
+				"&9Monifactory replaces this with a water collector from the Water Collector mod, as the NuclearCraft Infinite Water Source was overhauled.&f"
+				""
+				"Feeding a &3Steam Dynamo&f with water by hand is a pretty silly idea."
+				""
+				"A &6Water Collector&f will take care of that for you, albeit slowly. It does, however, auto-output the water to making it simple to use."
+				""
+				"&2GTCEu has a Primitive Water Pump, which can do it faster. However, it requires Treated Wood, which requires Creosote from a Coke Oven."
+			]
+			id: "0FF18D13CD42F48A"
+			rewards: [{
+				id: "5B48A2DC5BF8979D"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			shape: "hexagon"
+			tasks: [{
+				id: "2ECEDA36F2ADFDE8"
+				item: "watercollector:watercollector"
+				type: "item"
+			}]
+			title: "&9Infinite Water"
+			x: -3.0d
+			y: 5.5d
 		}
 		{
 			dependencies: [
-				"1DBBE96165C7987D"
-				"1BC6DDC2D50F9C46"
+				"4FE53F31E68F4C1C"
+				"115D2BEB18929C7C"
 			]
 			description: [
-				"This alloy is made from &2mixing 2 Gold Dust, 1 Redstone, and 1 Glowstone Dust in a Mixer, creating Energetic Alloy Dust,&r and putting it in your new &3Electric Blast Furnace&r."
+				"The &aHang Glider&f is a great way to cross long distances, if you're so inclined."
 				""
-				"Throw &2the prepared dust into the input bus&r and in twenty seconds your &6Energetic Alloy Ingot&r will be in the output bus."
-				""
-				"&2In EV Age, you can build an Alloy Blast Smelter which doubles the yield."
+				"If you don't want to go exploring for Cows, just buy a pair of \"&6Spawn Cow&f\" eggs and breed them. Seriously, spend your &9coins&f!"
 			]
-			id: "6A914B240E1A7BCB"
+			id: "7C3B69B3DC09FE96"
 			rewards: [{
-				id: "38132DACC54B8BA2"
+				id: "73A54AAACBD32969"
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
-			shape: "hexagon"
 			tasks: [{
-				id: "7FF7158E0BBDD3AE"
-				item: "gtceu:energetic_alloy_ingot"
-				type: "item"
-			}]
-			x: 2.5d
-			y: 9.5d
-		}
-		{
-			dependencies: ["6A914B240E1A7BCB"]
-			description: [
-				"Another alloy."
-				""
-				"&2In EV Age, you can build an Alloy Blast Smelter which doubles the yield."
-			]
-			id: "73C1AB31431B5C11"
-			rewards: [{
-				id: "461858A607CACCE1"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [{
-				id: "6194BD41B07BAA23"
-				item: "gtceu:vibrant_alloy_ingot"
-				type: "item"
-			}]
-			x: 2.5d
-			y: 11.0d
-		}
-		{
-			dependencies: ["6A914B240E1A7BCB"]
-			description: [
-				"Now that you have &6Energetic Alloy&r, it's time to make some better conduits!"
-				""
-				"Each time you upgrade your conduits, you'll also get more of them. Neat!"
-				""
-				"If you don't have an &3Assembling Machine&r, you'll have to make them by hand. This method isn't as efficient as the machine, but you'll make one soon enough."
-			]
-			id: "4F4F120AFB3A9250"
-			rewards: [{
-				id: "48BA7A02C52B204C"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [{
-				id: "45561FC8024BD7F3"
-				item: "enderio:energetic_conduit"
-				type: "item"
-			}]
-			title: "Energetic Alloy Energy Conduits"
-			x: 1.0d
-			y: 10.5d
-		}
-		{
-			dependencies: ["6A914B240E1A7BCB"]
-			description: [
-				"The &aAuxiliary Transmission Coil &ris an augment that will work in all types of dynamos. It will consume fuel faster to produce a correspondingly higher RF per tick."
-				""
-				"Each augment increases both base power production and fuel consumption by 100%%, additively (so the second is 200%%, third is 300%%, etc.)."
-				""
-				"Consider the tradeoffs however, as you could just make another dynamo, and you miss out on &aFuel Catalyzer&r augments that make fuels burn longer for more total RF generated. The Auxiliary Transmission Coil will put additional stress your fuel production infrastructure."
-				""
-				"If that's an acceptable tradeoff, then Auxiliary Transmission Coils are a cheap and effective way to boost your power production."
-			]
-			id: "780706A4C4AEB9CE"
-			tasks: [{
-				icon: "thermal:dynamo_output_augment"
-				id: "6A08FDD4D0930907"
+				id: "7B4500A4503F2F6D"
 				item: {
 					Count: 1
-					id: "thermal:dynamo_output_augment"
+					id: "hangglider:hang_glider"
 					tag: {
-						AugmentData: {
-							DynamoEnergy: 0.7f
-							DynamoPower: 3.0f
-							Type: "Dynamo"
-						}
+						Damage: 0
 					}
 				}
-				match_nbt: false
 				type: "item"
 			}]
-			title: "Auxiliary Transmission Coils"
-			x: 4.0d
-			y: 10.5d
+			title: "Glider"
+			x: -5.5d
+			y: 5.5d
 		}
 		{
-			dependencies: ["3AB0402B19DD5BA8"]
+			dependencies: ["4FE53F31E68F4C1C"]
 			description: [
-				"You might notice that these hulls can be made more cheaply in an &3Assembling Machine&r, but you don't have that weird fluid. Don't worry, you'll be able to make that soon."
+				"Going out in search of a &6Rubber Tree&f is a viable option for sure. However, if this isn't appealing, you can also &eshear leaves&f and make &6Plantballs&f out of them. Plantballs smelt into &6Slime&f, and Slime smelts into &6Rubber&f."
 				""
-				"&2Overclocking mechanics have changed in CEu. All overclocks now multiply the speed by 2.0x (instead of the 2.0/2.8 split in CE). This means that to save energy, you should build more low-tier machines over overclocking a high-tier machine, especially for passive processes."
-				"Additionally, ULV recipes will not overclock to LV. A ≤8 EU/t recipe won't overclock at all in an LV machine, will only overclock once in an MV machine, etc."
+				"You'll want to transition to Rubber Trees at some point, though, since the &eratio of leaves to rubber is quite poor&f."
+				""
+				"Rubber can be hammered into sheets just like metals can be turned to plates. It's quite inefficient to do it this way, but such is the life of early game &bGregTech&f. At least rubber isn't particularly hard to come by."
 			]
-			id: "5C4E189A3E401566"
+			id: "6FB3E3D9CA0F4B30"
 			rewards: [{
-				id: "09F16C5C9CFFEF84"
-				item: "kubejs:moni_quarter"
-				type: "item"
-			}]
-			shape: "hexagon"
-			size: 2.0d
-			subtitle: "Your first MV hull is as good of a place as any to consider yourself graduated from LV."
-			tasks: [{
-				id: "3F0884D8F0926142"
-				item: "gtceu:mv_machine_hull"
-				type: "item"
-			}]
-			title: "&2MV Machine Hulls"
-			x: 6.5d
-			y: 9.5d
-		}
-		{
-			dependencies: ["62BBD1F6767A4D90"]
-			description: [
-				"Mixes dusts together."
-				""
-				"For now, you'll be using it to make &6Energetic Alloy Dust&r."
-				""
-				"Energetic Alloy Dust is made from &6Redstone&r, &6Gold Dust&r and &6Glowstone Dust&r. "
-				""
-				"You should have some Glowstone from your adventures in the &cNether&r, but you can also make it by mixing &6Tricalcium Phosphate Dust&r&r&r and &6&6&6Gold Dust&r&r&r."
-			]
-			id: "1DBBE96165C7987D"
-			rewards: [{
-				id: "34F7C473C934087B"
+				id: "4949E1AF8C656F3D"
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
 			shape: "hexagon"
-			subtitle: "Will it blend?"
 			tasks: [{
-				id: "0199D55D895EDDC9"
-				item: "gtceu:lv_mixer"
+				count: 3L
+				id: "7BA753DF38DEC329"
+				item: { Count: 3, id: "gtceu:rubber_plate" }
 				type: "item"
 			}]
-			title: "LV Mixer"
+			title: "Rubber Sheets"
+			x: 3.0d
+			y: 5.5d
+		}
+		{
+			dependencies: ["6FB3E3D9CA0F4B30"]
+			description: [
+				"A &aSoft Mallet&f can be used to temporarily stop a machine from functioning. This is useful when you have two machines running and both are unable to keep going because of a lack of power... let one finish then turn the other one back on with a second hit from the mallet."
+				""
+				"Although you can make it out of &6Wood&r, it is probably better to make it out of &6Rubber&r once you can."
+				""
+				"This quest accepts a &aSoft Mallet&r made from any material."
+			]
+			icon: {
+				Count: 1
+				id: "gtceu:rubber_mallet"
+				tag: {
+					Damage: 0
+					GT.Behaviours: { }
+					GT.Tool: {
+						AttackDamage: 0.0f
+						AttackSpeed: -2.4f
+						Damage: 0
+						MaxDamage: 128
+					}
+				}
+			}
+			id: "78B5D55A3560B98E"
+			rewards: [{
+				id: "16EF260235D12825"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			shape: "hexagon"
+			subtitle: "Bonk!"
+			tasks: [{
+				id: "253D34B000F903DD"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:wood_mallet"
+								tag: {
+									DisallowContainerItem: 0b
+									GT.Behaviours: { }
+									GT.Tool: {
+										AttackDamage: 0.0f
+										AttackSpeed: -2.4f
+										Damage: 0
+										MaxDamage: 127
+									}
+									HideFlags: 2
+								}
+							}
+							{
+								Count: 1b
+								id: "gtceu:rubber_mallet"
+								tag: {
+									DisallowContainerItem: 0b
+									GT.Behaviours: { }
+									GT.Tool: {
+										Damage: 0
+										MaxDamage: 127
+									}
+									HideFlags: 2
+								}
+							}
+							{
+								Count: 1b
+								id: "gtceu:polytetrafluoroethylene_mallet"
+								tag: {
+									DisallowContainerItem: 0b
+									GT.Behaviours: { }
+									GT.Tool: {
+										Damage: 0
+										MaxDamage: 127
+									}
+									HideFlags: 2
+								}
+							}
+							{
+								Count: 1b
+								id: "gtceu:polyethylene_mallet"
+								tag: {
+									DisallowContainerItem: 0b
+									GT.Behaviours: { }
+									GT.Tool: {
+										AttackDamage: 0.0f
+										AttackSpeed: -2.4f
+										Damage: 0
+										MaxDamage: 127
+									}
+									HideFlags: 2
+								}
+							}
+							{
+								Count: 1b
+								id: "gtceu:polybenzimidazole_mallet"
+								tag: {
+									DisallowContainerItem: 0b
+									GT.Behaviours: { }
+									GT.Tool: {
+										AttackDamage: 0.0f
+										AttackSpeed: -2.4f
+										Damage: 0
+										MaxDamage: 127
+									}
+									HideFlags: 2
+								}
+							}
+						]
+					}
+				}
+				title: "Any Soft Mallet"
+				type: "item"
+			}]
+			title: "Soft Mallet"
+			x: 4.25d
+			y: 5.5d
+		}
+		{
+			dependencies: ["1229234A71CE0A99"]
+			description: [
+				"Although most &ealloys&f require an &3Alloy Smelter&f, some alloys can be made simply by mixing the correct metal dusts together. "
+				""
+				"Copper Dust mixed with Redstone makes &6Red Alloy Dust&f."
+				""
+				"Iron Dust mixed with Redstone makes &6Conductive Iron Dust&f."
+				""
+				"&3Smelt&f it into ingots, &ahammer&f it into &6Plates&f, and &acut&f them into &6Wires&f."
+			]
+			icon: "gtceu:red_alloy_dust"
+			id: "7FA0E6F3B466576C"
+			rewards: [{
+				id: "20BC4F07424D7664"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			shape: "hexagon"
+			tasks: [
+				{
+					count: 16L
+					id: "6FE4A0D51F6AF22F"
+					item: { Count: 16, id: "gtceu:copper_dust" }
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "6449998172457471"
+					item: { Count: 16, id: "gtceu:red_alloy_dust" }
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "16D7046417209756"
+					item: { Count: 16, id: "gtceu:red_alloy_ingot" }
+					type: "item"
+				}
+				{
+					count: 32L
+					id: "57A26AF688B59DAB"
+					item: { Count: 32, id: "gtceu:iron_dust" }
+					type: "item"
+				}
+				{
+					count: 32L
+					id: "5627DEBC5B168743"
+					item: { Count: 32, id: "gtceu:conductive_alloy_ingot" }
+					type: "item"
+				}
+				{
+					count: 8L
+					id: "15CAA2C5B513BFC2"
+					item: { Count: 8, id: "gtceu:red_alloy_plate" }
+					type: "item"
+				}
+				{
+					count: 3L
+					id: "14B188414BF825E6"
+					item: { Count: 3, id: "gtceu:red_alloy_single_wire" }
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "7B8835F95B9739D6"
+					item: { Count: 16, id: "gtceu:conductive_alloy_single_wire" }
+					type: "item"
+				}
+			]
+			title: "From Dust to Wires"
 			x: 0.0d
 			y: 9.5d
 		}
 		{
-			dependencies: ["1DBBE96165C7987D"]
-			description: [
-				"When making circuits, you'll need either molten &9Tin&r, or molten &9Soldering Alloy&r&r&r. &2Soldering Alloy is made in the Mixer with 6 parts Tin Dust, 3 parts Lead Dust and 1 part Antimony Dust.&r You then process it in an &3Extractor &rfor the usual 144mB of fluid per unit."
-				""
-				"The &2Circuit Assembler&r will only consume half as much Soldering Alloy as it would have consumed molten Tin per craft (72mB vs 144mB), so it's very efficient to use this stuff."
-				""
-				"&2Antimony can be directly smelted from Stibnite Ore, allowing you to skip ore processing for this."
-			]
-			icon: "gtceu:soldering_alloy_bucket"
-			id: "56924FC6B029BA0F"
-			rewards: [{
-				id: "0567EE8C4FB9F984"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "00DCE69057EC3D8F"
-				item: "gtceu:soldering_alloy_dust"
-				type: "item"
-			}]
-			title: "Soldering Alloy"
-			x: -2.0d
-			y: 9.5d
-		}
-		{
 			dependencies: [
-				"0D6C8FFD01BE5C21"
-				"1BC6DDC2D50F9C46"
+				"6FB3E3D9CA0F4B30"
+				"7FA0E6F3B466576C"
 			]
-			dependency_requirement: "one_completed"
 			description: [
-				"&2Certain multiblocks in CEu will require a Maintenance Hatch and/or Muffler Hatch. These cannot be shared between multiblocks. If you knew Maintenance in GT5u, fret not - Maintenance mechanics are far less punishing in CEu."
+				"The most basic cables, such as these &6Red Alloy Cables&f, can be wrapped in their &6Rubber&f insulation by hand."
 				""
-				"&r- &aMuffler&r: This hatch must be &cunobstructed&r so it can output its beautiful smoke particles. When a recipe is performed, there is a small chance for the &3Muffler Hatch&r to give bonus items, typically tiny Dusts of Ash. It voids excess when full, so do not worry about it stopping machines from running."
+				"More advanced types of cables will require an &3Assembling Machine&f and liquid &9Rubber&f, but you can do it the simple way for now."
 				""
-				"- &aMaintenance&r: You will need to do Maintenance for the Multiblock to begin operating. This is done by having a &9Wrench&r, a &9Screwdriver&r, a &9Soft Mallet&r, a &9Hammer&r, a &9Wire Cutter&r, and a &9Crowbar&r in your inventory, opening the Maintenance Hatch and &eclicking the center spot once&r. &cNo need to move tools individually&r. Alternatively, you can fix problems by placing &9Tape&r in the Maintenance Hatch. "
+				"&2CEu has GT6-style pipes and cables on by default. &rYou will need to use &aWire Cutters&r to connect each side of a cable to machines or other cables. Placing it against the machine or cable automatically connects it as well. The same behaviour follows for GT pipes, whose tool is the &aWrench&r."
+				"This can save you from energy or fluids going the wrong way. But if you don't like this, disable the config option for \"GT6 style pipes and cables\" in the GregTech config file."
 				""
-				"Maintenance problems may occur after &948 real hours of activity&r. Needless to say, they are very rare. Each problem increases the recipe durations by 10%%. Fixing the problems is done the same way as above."
-				""
-				"Later, you will unlock other Maintenance Hatches that do not enforce fixing the problems manually. Both start with &6no Maintenance required&r:"
-				""
-				"- &3Automatic Maintenance Hatch&r (&9IV&r): Eliminates the need for Maintenance, &6forever&r."
-				""
-				"- &3Configurable Maintenance Hatch&r (&6HV&r): You can configure it to cut off &a10%% duration&r on recipes, at the cost of making Maintenance issues happen three times as fast. That is &916 real hours&r of activity. &9Tape&r can fix problems in this Hatch as well."
+				"&2GT cables now support RF conversion natively! &rYou can plug an &9RF&r machine into an &9EU&r cable directly and it will convert the energy. You cannot, however, plug an &9RF&r power souce directly into an &9EU&r cable."
 			]
-			hide_dependency_lines: true
-			icon: "gtceu:maintenance_hatch"
-			id: "0523F4AB9A794390"
-			size: 1.5d
-			tasks: [{
-				id: "44CBD475F0332E0C"
-				type: "checkmark"
-			}]
-			title: "&2Maintenance and Muffler Mechanics"
-			x: 10.5d
-			y: 9.375d
-		}
-		{
-			dependencies: ["2D31856F6EF1ED69"]
-			description: [
-				"&9GregTech Power&r can be tricky to handle. Luckily, there are several tools you can use to tackle some of the problems."
-				""
-				"- &aDiode&r: A block which accepts energy on 5 sides, and outputs it on a single side. Its main purpose is to limit Amperage flow through it - adjust it by right-clicking it with a Soft Hammer, &2and to transport power into Cleanrooms.&r Not to be confused with the Diodes used as crafting components."
-				""
-				"- &aTransformer&r: A block which changes between 4A of a lower voltage and 1A of a voltage one tier higher."
-				""
-				"- &2Adjustable Transformer&r: Similar to the Transformer, but can be configured to transform up to 64A Low <-> 16A High."
-				""
-				"- &aBattery Buffer&r: A block which can hold GregTech Batteries. Each battery accepts up to 2A and can provide up to 1A. &2They have been reworked in CEu to not be as terrible to use."
-			]
-			icon: "gtceu:mv_transformer_1a"
-			id: "18D8D18C4494C587"
-			size: 1.5d
-			tasks: [{
-				id: "14E359BEBFB23558"
-				type: "checkmark"
-			}]
-			title: "&2GT Power Management"
-			x: 12.75d
-			y: 7.5d
-		}
-		{
-			dependencies: ["66FCC26399376B55"]
-			description: [
-				"&bGregTech&r adds a very versatile way of augmenting machines with &aMachine Covers&r. Covers are \"upgrades\" that you can put on any &eGregTech machine, crate, or drum&r to expand its functionality. These are seperate on each side of the machine, meaning you can have up to six different covers! &9Covers can be edited and removed via the given machine's GUI&r, but for the others, you'll need to make yourself a &aScrewdriver&r to configure covers, and a &aCrowbar&r to remove covers without having to break the machine."
-				""
-				"Here's a list of some covers there are in the game, and what they do:"
-				""
-				"- &lConveyor&r: transfers items continuously to or from an adjacent inventory, capable of round robin."
-				""
-				"- &lPump&r: is much like a &aConveyor&f, but for fluids."
-				""
-				"- &lRobotic Arm&r: is much like &aConveyor&r, but has two additional modes:"
-				"    * &eKeep Exact&r: moves items to keep a stock of at most the specified number of items"
-				"    * &eSupply Exact&r: transfers precisely the specified number of items per operation."
-				"This cover is very useful for crafting automation."
-				""
-				"- &lFluid Regulator&r: is like a &aRobotic Arm&r, but works with fluids instead of items."
-				""
-				"- &lShutter&r: prevents automation from interacting with a specific side of a machine."
-				""
-				"- &lDetector&2: Available in Item, Fluid, Energy, Activity, and Advanced Activity flavours. Emits a Redstone signal depending on the status of whatever it's detecting."
-				""
-				"- &lDigital Interface&r: &2A graphical display for the machine's current status. Can display things like contained fluids, energy levels, etc.&r"
-				""
-				"Covers that move items or fluids can have a &aFilter&r placed inside them. These modify the functionality of covers in ways explained in their own quests."
-			]
-			icon: "gtceu:lv_electric_pump"
-			id: "1A427A8CB43C8B59"
-			size: 1.5d
-			tasks: [{
-				id: "550495EAC8E9629D"
-				type: "checkmark"
-			}]
-			title: "&9Machine Covers"
-			x: 15.0d
-			y: 9.375d
-		}
-		{
-			dependencies: ["66FCC26399376B55"]
-			description: ["&9Pressing the second tab in any given machine's GUI will open up a view showing the machine and any blocks it is touching&r. From there, you can click on a side of the machine and easily add, edit and remove &acovers&r, and configure if the machine should &3automatically output&r it's output and which side it should output to. "]
-			icon: "minecraft:hopper"
-			id: "431BB650AC492C84"
-			size: 1.5d
-			tasks: [{
-				id: "65EF130C1913A8AD"
-				title: "Screwdrive Output Sides!"
-				type: "checkmark"
-			}]
-			title: "&9 Machine Auto-Output"
-			x: 12.75d
-			y: 9.375d
-		}
-		{
-			dependencies: ["66FCC26399376B55"]
-			description: [
-				"&aFilters&r are a type of machine cover that controls what items or fluids are allowed to pass through it. They can be used directly on the side of a machine to affect external automation or the Machine's &aAuto-Output Functionality&r."
-				""
-				"You can also &eplace filters inside of other covers&r to control what items or fluids that cover will interact with. When used in a &6Robot Arm&r, &aItem Filters&r make for a powerful automation tool for &ekeeping specific items in stock&r in specific quantities in Machines. With &6Fluid Regulators&r, similar behavior is possible with fluids using a &aFluid Filter&r. For &6Conveyors&r and &6Pumps&r, it simply limits what that cover will move."
-				"{@pagebreak}"
-				"&aFilters&r all have 9 configurable slots and whitelist/blacklist modes, and can be applied to multiple sides of machines. When placed inside a &6Robot Arm&r in &eKeep Exact&r or &eSupply Exact&r mode&r, the item count in a filter can be incremented by &eRight Clicking&r and decremented by &eLeft Clicking&r. Holding &eShift&r causes the count to increase/decrease by a factor of 2. This controls the number of each type of item that will be kept in stock or moved at a time."
-				""
-				"Similar controls are available for the &aFluid Filter&r when placed inside a &6Fluid Regulator&r."
-				""
-				"Additionally, the &aOre Dictionary Filter&r&r is a powerful tool that has a specialized filter which uses ore dictionary entries and &2uses regular expressions (regex)&r, e. g. \"&6ingotHot*&r\" will match all hot ingots, \"&6dustRegular*&r\" will match all regular dusts, and \"&6dustTiny*&r\" will match all tiny piles."
-				""
-				"All &bGregTech&r Filters can be configured using ghost items from &bEMI&r."
-			]
-			id: "5F6B13DBCABA5078"
-			size: 1.5d
-			tasks: [
-				{
-					id: "0F35F2EAFC2DF767"
-					item: "gtceu:item_filter"
-					type: "item"
-				}
-				{
-					id: "792F99EEC26B16A3"
-					item: "gtceu:item_tag_filter"
-					type: "item"
-				}
-				{
-					id: "5AA2DA67B49432C1"
-					item: "gtceu:fluid_filter"
-					type: "item"
-				}
-				{
-					id: "2FF3685DED5F68A9"
-					item: "gtceu:fluid_tag_filter"
-					type: "item"
-				}
-			]
-			title: "&2Filters"
-			x: 15.0d
-			y: 7.5d
-		}
-		{
-			dependencies: ["273F3F8DD6A3DCC5"]
-			description: [
-				"Item conduits are useful for moving items between inventories over moderate distances."
-				""
-				"Crafting them in an Assembling Machine instead of by hand gives twice as many conduits."
-			]
-			id: "4F239316765C7CA1"
+			id: "12B95158E4C792DB"
 			rewards: [{
-				id: "189732EC89DA656B"
+				id: "720A4DC6D3957258"
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
 			shape: "hexagon"
 			tasks: [{
-				id: "6DEB6911246BA1D9"
-				item: "enderio:item_conduit"
+				count: 12L
+				id: "24A84AB536BB27B0"
+				item: { Count: 12, id: "gtceu:red_alloy_single_cable" }
 				type: "item"
 			}]
-			title: "Item Conduits"
-			x: 4.5d
-			y: -9.5d
+			title: "&2Cables"
+			x: 3.0d
+			y: 9.5d
 		}
 		{
-			dependencies: ["4CD6C60CBEFFA317"]
-			description: [
-				"The main function of this oven is to increase the fuel values of your wood and coal while also recovering some of the various potentially useful waste products."
-				""
-				"Turning &6Coal&r into &6Coal Coke&r will not only make it more useful as fuel, but will also produce &9Phenol&r, which you'll need for circuits."
-				""
-				"The Pyrolyse Oven is also the source of several other fluids that can be distilled for useful ingredients."
-				""
-				"Remember that Hatches and Buses can be replaced by Hatches and Buses of any tier, although the Input Bus must be at least LV, as there are 2 inputs, and that you can  &6sneak-right click&r the controller to enable the in-world preview."
-				""
-				"&2As stated in the tooltip, higher tier coils will make this faster."
+			dependencies: [
+				"0FF18D13CD42F48A"
+				"7FA0E6F3B466576C"
 			]
-			icon: "gtceu:pyrolyse_oven"
-			id: "0D6C8FFD01BE5C21"
+			description: [
+				""
+				"The &6Steam Dynamo&r will be your source of &9power&r for the early game. It requires &9Water&r and burnable fuel like &6Coal&r or &6Sugar Cane&r to produce power."
+				""
+				"You'll need a small bit of &6Silver&f for this dynamo. If you haven't found a &6Galena vein&f yet (which is where Silver is), then consider \"buying\" some &6Silver Ore&r using &9Monicoins&r. You won't need a ton of silver and lead just yet, so it won't bankrupt you."
+				""
+				"Keep in mind that &eDynamos only output power when burning through fuel, and only the block/cable attached directly to the coil will get provided with power&f."
+			]
+			id: "39D4174834F3879D"
 			rewards: [{
-				id: "75AB1F8869901505"
+				id: "565EAB360615C53E"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			shape: "hexagon"
+			subtitle: "Your first major crafting project!"
+			tasks: [{
+				id: "78D31068BB10B20B"
+				item: "steamdynamo:steam_dynamo"
+				type: "item"
+			}]
+			title: "Steam Dynamo"
+			x: -3.0d
+			y: 12.5d
+		}
+		{
+			dependencies: ["39D4174834F3879D"]
+			description: ["Better fuel means you need to use less of it."]
+			id: "098CF1FD284B09E7"
+			rewards: [{
+				id: "5ECF74D124102662"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				count: 2L
+				id: "66B9B329F6ED7939"
+				item: { Count: 2, id: "thermal:dynamo_fuel_augment" }
+				type: "item"
+			}]
+			title: "&9More Efficient"
+			x: -4.0d
+			y: 12.5d
+		}
+		{
+			dependencies: ["7FA0E6F3B466576C"]
+			description: ["These can be used to transport energy from your &3Steam Dynamos&r to various destinations."]
+			id: "08948A23B3A17923"
+			rewards: [{
+				id: "188CE9F6FC9651C5"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			shape: "hexagon"
+			subtitle: "The most basic tier of &aRF&r energy conduits from &bEnderIO&r."
+			tasks: [{
+				id: "7D0E23630A562F6A"
+				item: "enderio:conductive_conduit"
+				type: "item"
+			}]
+			title: "Conductive Iron Energy Conduits"
+			x: 0.0d
+			y: 12.5d
+		}
+		{
+			dependencies: [
+				"1A30472430354F1E"
+				"08948A23B3A17923"
+				"39D4174834F3879D"
+			]
+			description: [
+				"&rThe &3Steam Dynamos&r&r&r you have made are generating &aRF power&r, but &bGregTech&r machines require &aEU power&r. With your first &6circuit&r in hand, you are ready to build a &eLow Voltage (LV) &3&2Energy Converter&r."
+				""
+				"The &2Energy Converter&r is a special device that &econverts &2between &aRF power&r and &aEU power&r. They come in &2four sizes: 1A, 4A, 8A, and 16A."
+				""
+				"&aRF&r converts into &aEU&r at a &e4 to 1 ratio&r. &a100 RF&r becomes &a25 EU&r, and vice-versa. &2Use a Soft Hammer to change the conversion direction."
+			]
+			icon: "gtceu:lv_4a_energy_converter"
+			id: "297B523B6C503957"
+			rewards: [{
+				id: "6F305739BEEDF49B"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			shape: "hexagon"
+			tasks: [{
+				id: "3217FC6AD2AFA67A"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:lv_1a_energy_converter"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_4a_energy_converter"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_8a_energy_converter"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_16a_energy_converter"
+							}
+						]
+					}
+				}
+				title: "Any LV Converter"
+				type: "item"
+			}]
+			title: "LV Power"
+			x: 0.0d
+			y: 15.5d
+		}
+		{
+			dependencies: ["297B523B6C503957"]
+			description: ["The &6Battery Buffer&r is a machine which can hold &6Batteries&r for energy storage. Each Battery accepts up to 2 amps and outputs up to 1 amp."]
+			id: "2FA9404468E4BBD9"
+			rewards: [{
+				id: "325B36632BC87A4F"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "0527876D6287634B"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:lv_battery_buffer_4x"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_battery_buffer_8x"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_battery_buffer_16x"
+							}
+						]
+					}
+				}
+				type: "item"
+			}]
+			title: "Charging Batteries"
+			x: 1.5d
+			y: 15.5d
+		}
+		{
+			dependencies: ["2FA9404468E4BBD9"]
+			description: [
+				"&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy."
+				""
+				"Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making."
+				""
+				"&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r."
+			]
+			id: "077AA27F26B7831F"
+			rewards: [{
+				id: "0630EB540FFAC21C"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				count: 4L
+				id: "7923DEDAB3298371"
+				item: { Count: 4, id: "gtceu:lv_battery_hull" }
+				type: "item"
+			}]
+			title: "LV Power Storage"
+			x: 1.5d
+			y: 16.75d
+		}
+		{
+			dependencies: ["297B523B6C503957"]
+			description: [
+				"The &9Tinker's Workstation&r is able to charge items at a modest rate, but can only charge items that use &aRF&r. &9This is also used for upgrading thermal items&r."
+				""
+				"The Turbo Charger is a little more expensive, but is able to charge items at a &omuch&r faster rate and is able to charge items that use &aRF&r and &aEU&r."
+			]
+			icon: "gtceu:lv_charger_4x"
+			id: "06E9B9DDDB245F38"
+			rewards: [{
+				id: "193ED94FC1B59BB0"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "0560C9C2C5EC9998"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:lv_charger_4x"
+							}
+							{
+								Count: 1b
+								id: "thermal:tinker_bench"
+							}
+							{
+								Count: 1b
+								id: "thermal:charge_bench"
+							}
+						]
+					}
+				}
+				title: "Charger"
+				type: "item"
+			}]
+			title: "&9Charging Items"
+			x: -1.5d
+			y: 15.5d
+		}
+		{
+			dependencies: ["66FCC26399376B55"]
+			description: [
+				"&6Sulfur Ore&r is the only source of &6Sulfur Dust&r that's currently available to you."
+				""
+				"You may want to spend a few &9Monicoins&r on the ore to jumpstart your power storage."
+				""
+				"Otherwise the ore is only available in &athe Nether&r, and the only way to get there is with a &6Nether Cake&r. Oh no!"
+			]
+			hide_dependency_lines: true
+			icon: "gtceu:sulfur_ore"
+			id: "081101DEE6227D87"
+			rewards: [{
+				id: "4C3153B1874D58D5"
+				item: {
+					Count: 1
+					id: "minecraft:player_head"
+					tag: {
+						SkullOwner: {
+							Id: [I;
+								1207556655
+								-2087172645
+								-1127815359
+								-166568499
+							]
+							Properties: {
+								textures: [{
+									Value: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWYxYzU4MDEzOGM2MjU0M2I0ZWVmNWU2NjI4MjNhZmNkZDNlNzdjYTQxYTU0ODY3ZWExMmUwZDM5YmNkNTliMSJ9fX0="
+								}]
+							}
+						}
+						display: {
+							Name: "{\"text\":\"I bought ores with Monicoins\",\"color\":\"blue\",\"underlined\":false,\"bold\":true,\"italic\":false}"
+						}
+					}
+				}
+				type: "item"
+			}]
+			tasks: [{
+				id: "0161A7D4C24DC421"
+				item: {
+					Count: 1
+					id: "itemfilters:tag"
+					tag: {
+						value: "forge:ores/sulfur"
+					}
+				}
+				title: "Any Sulfur Ore"
+				type: "item"
+			}]
+			title: "Sulfur Ore"
+			x: -2.75d
+			y: 14.25d
+		}
+		{
+			dependencies: [
+				"06E9B9DDDB245F38"
+				"081101DEE6227D87"
+			]
+			description: [
+				"Basic &aFlux Capacitors&r hold a whopping lot of energy - &9500 kRF&r - and are useful for keeping your &aRF-powered&r equipment and tools charged."
+				""
+				"Put one into your newly crafted &9Charger&r to charge it. You can then put it in your inventory to charge your items with &aRF&r."
+				""
+				"The Flux Capacitor is a &bBauble&r, so open your inventory and look for the Baubles button, click it to reveal the additional bauble slots menu and put it into any slot you wish."
+				""
+				"Finally, you can charge up all those depleted &m&6Dark Boots&r&r and &6The Ender&r swords you've looted."
+			]
+			icon: {
+				Count: 1
+				id: "thermal:flux_capacitor"
+				tag: { }
+			}
+			id: "3A5387B2003177B2"
+			rewards: [{
+				id: "18D835350F2E6BBE"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [
+				{
+					id: "5EF5A8A2767A69E3"
+					item: {
+						Count: 1
+						id: "thermal:flux_capacitor"
+						tag: { }
+					}
+					type: "item"
+				}
+				{
+					id: "63EE7A1364F6888B"
+					item: {
+						Count: 1
+						id: "itemfilters:tag"
+						tag: {
+							value: "forge:dusts/sulfur"
+						}
+					}
+					title: "Sulfur Dust"
+					type: "item"
+				}
+			]
+			title: "&9Flux Capacitors"
+			x: -2.75d
+			y: 15.5d
+		}
+		{
+			dependencies: ["3A5387B2003177B2"]
+			description: [
+				"It's probably a bit premature to consider a &6jetpack&r at this point, but if you really want to craft this bad boy, I won't stop you."
+				""
+				"There's also a quest chain for &bEnderIO&r Jetpacks (starting with the &6Conductive Iron Jetpack&r). Eventually you'll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really really like flying."
+			]
+			id: "7E66445087E82F65"
+			rewards: [{
+				id: "24ED21C395B4B39F"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			subtitle: "Being able to fly is pretty sick. It's also pretty expensive."
+			tasks: [{
+				id: "7CE647770625D692"
+				item: {
+					Count: 1
+					id: "ironjetpacks:jetpack"
+					tag: {
+						Id: "ironjetpacks:leadstone"
+					}
+				}
+				type: "item"
+			}]
+			x: -4.0d
+			y: 15.5d
+		}
+		{
+			dependencies: ["297B523B6C503957"]
+			description: [
+				"Unlike &aRF power&r, which is safe to transport in any &6conduit&r, &aEU power &erequires caution&r. The key is to always &amatch or exceed&r the &eVoltage &rand&e Amperage&r of your power source with your &6cables&r and machines."
+				""
+				"&cNEVER &rhook up your Energy Converter&r to a cable that has fewer &eAmps&r than your Energy Converter or Battery Buffer generates. For example, you must use &64x cable&r for a 4A Converter&r, and &616x cable&r for a filled 16-slot Battery Buffer&r. Cables with insufficient amperage rating will &cburn and be destroyed&r. &2Both the multiple-amp-source and multiple-face-input bugs from CE have been fixed - the Energy network now works as intended.&r"
+				""
+				"Similarly, your cable must match or exceed the &eVoltage&r of your machines, or they will &cburn and be destroyed&r."
+				""
+				"&cNEVER&r connect a machine to excessive &eVoltage&r or it will &cvaporize&r. Touching a &6wire&r with connected &aEU power&r will &cinjure or kill you&r, so for your safety, &euse &6cables&e instead&r!"
+				""
+				"&2Superconductor-type wires do not damage you in CEu. The 0-loss cables in CE (Conductive Iron, Energetic Alloy, etc.) are considered Superconductors."
+			]
+			icon: "gtceu:hpic_wafer"
+			id: "5A94534682807314"
+			shape: "hexagon"
+			tasks: [{
+				id: "60242EACEEB6B6C8"
+				type: "checkmark"
+			}]
+			title: "A Primer on Power"
+			x: 0.0d
+			y: 17.0d
+		}
+		{
+			dependencies: ["5A94534682807314"]
+			description: [
+				"Now that you have everything you need to power your machines, it's time to put it all together."
+				""
+				"Your Steam Dynamo needs burnable fuel (like &6Coal&r) and &9water&r. It will output RF power through the Excitation Coil (the red bit at the top). The orientation of the Steam Dynamo can be adjusted with a &aCrescent Hammer&r, if needed."
+				""
+				"&6Energy Conduits&r can be used to transfer that RF power, but the dynamo can also output RF directly into an Energy Converter by making the Excitation Coil touch the Energy Converter."
+				""
+				"The Energy Converter transforms RF power into EU, outputting the resulting EU through the side with a red dot. The orientation can be adjusted using a &aWrench&r. Attach your &6Conductive Iron Cables&r to the output side of the Energy Converter."
+				""
+				"Now all you need are some &bGregTech&r machines to hook up to the cables! You can make whatever you want, but its recommended that you get these two first:"
+				""
+				"The &6Wiremill&r will make crafting wires much, much easier."
+				""
+				"The &2Bending Machine&r will make Plates from one ingot instead of two."
+			]
+			icon: "gtceu:uhpic_wafer"
+			id: "2D31856F6EF1ED69"
+			rewards: [{
+				id: "56BBC13076DA2EA4"
 				item: "kubejs:moni_quarter"
 				type: "item"
 			}]
 			shape: "hexagon"
 			size: 2.0d
-			tasks: [
-				{
-					id: "50E21C8C3D4281DD"
-					item: "gtceu:pyrolyse_oven"
-					type: "item"
-				}
-				{
-					count: 16L
-					id: "44F21473555B9484"
-					item: "gtceu:cupronickel_coil_block"
-					type: "item"
-				}
-				{
-					count: 9L
-					id: "30B3B90B99DE0109"
-					item: "gtceu:ulv_machine_casing"
-					type: "item"
-				}
-				{
-					id: "1B762AEE66C0C4C3"
-					item: "gtceu:lv_input_bus"
-					type: "item"
-				}
-				{
-					id: "510137AE30F928EC"
-					item: "gtceu:lv_output_bus"
-					type: "item"
-				}
-				{
-					id: "2F305D8535C97A0A"
-					item: "gtceu:lv_input_hatch"
-					type: "item"
-				}
-				{
-					id: "5582D6BE794C53BB"
-					item: "gtceu:lv_output_hatch"
-					type: "item"
-				}
-				{
-					id: "0C6857FA9D64E009"
-					item: "gtceu:lv_energy_input_hatch"
-					type: "item"
-				}
-				{
-					id: "0C89E09A6E371208"
-					item: "gtceu:maintenance_hatch"
-					type: "item"
-				}
-				{
-					id: "54A14F8C85862459"
-					item: "gtceu:lv_muffler_hatch"
-					type: "item"
-				}
-			]
-			title: "&2Pyrolyse Oven"
-			x: 10.5d
-			y: 5.0d
+			tasks: [{
+				id: "44E7A2BF6528EC4E"
+				type: "checkmark"
+			}]
+			title: "Putting it all Together"
+			x: 0.0d
+			y: 18.5d
 		}
 		{
-			dependencies: [
-				"3AB0402B19DD5BA8"
-				"15808BD9C5DBA0F7"
+			dependencies: ["66FCC26399376B55"]
+			description: [
+				"Open your inventory and look at the top-left corner of the screen. Click the map-looking icon called &eClaimed Chunks&r."
+				""
+				"&6Click a chunk&r to claim it as yours. This will prevent unwanted creeper explosions and other players from interacting with your base."
+				""
+				"&eIf you're playing on a server with custom settings, ask the server owner what methods are available&f."
+				""
+				"To invite players to your &bFTB Utils&f party, look for a corresponding button in the same corner. Parties share claimed chunks with each other. You can configure permissions for your party's claimed chunks in the party settings menu."
 			]
-			description: ["Carry &o&leven more&r stuff."]
-			id: "1C2088A496D8FE4F"
-			rewards: [{
-				id: "4E4E7320F0994D1D"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
+			disable_toast: true
+			hide_dependency_lines: true
+			icon: "minecraft:tnt"
+			id: "6A7A480FAC6103D2"
+			optional: true
+			subtitle: "You might be wondering what chunkloading options there are in the pack."
 			tasks: [{
-				id: "554C5636BB994E79"
+				id: "78BC5B51125B35BD"
+				title: "Claim your chunks!"
+				type: "checkmark"
+			}]
+			title: "Claim Your Chunks and Invite Teammates!"
+			x: -10.5d
+			y: 2.5d
+		}
+		{
+			dependencies: ["66FCC26399376B55"]
+			description: [
+				"While there are no types of veins that are extremely rare, you're likely to struggle with finding at least one of the less common vein types. This isn't really avoidable."
+				""
+				"[\"You will accumulate a lot of \",{\"text\":\"Monicoins\",\"color\":\"dark_purple\",\"hoverEvent\":{\"action\":\"show_item\",\"contents\":{\"id\":\"kubejs:moni_quarter\"}}},\" from quest turn-ins while playing monifactory. Do not be hesitant to spend them on things you need!\"]"
+				""
+				"[\"Search for various ores (generally the first one listed in \",{\"text\":\"EMI\",\"color\":\"aqua\"},\") to find the coin recipes for them. Alternatively, hover your cursor over a coin and press \",{\"keybind\":\"key.jei.showRecipe\",\"color\":\"gold\",\"bold\":true,\"underlined\":true,\"hoverEvent\":{\"action\":\"show_text\",\"contents\":\"\\\"Show Recipe\\\" in keybind option\"}},\" to see what you can buy with it.\"]"
+			]
+			hide_dependency_lines: true
+			icon: "kubejs:moni_dollar"
+			id: "115D2BEB18929C7C"
+			rewards: [{
+				id: "43415141DBD13CDD"
 				item: {
 					Count: 1
-					id: "sophisticatedbackpacks:gold_backpack"
+					id: "nomowanderer:no_mo_wanderer_totem"
 					tag: {
-						contentsUuid: [I;
-							-2079088966
-							795101541
-							-1099241216
-							-1042767112
-						]
-						inventorySlots: 81
-						upgradeSlots: 3
+						Enabled: 1b
 					}
 				}
 				type: "item"
 			}]
-			title: "&9Even Better Backpacks"
-			x: 4.5d
-			y: 6.25d
-		}
-		{
-			dependencies: ["5301E546BAA69844"]
-			description: [
-				"The &bPhytogenic Insolator&r is a way to &9passively produce wood in the earlygame&r. While somewhat slow, it only requires &a10 rf/t&r to operate, meaning you can just set it down and not have to worry about it, and then come back to wood when you need some for crafting or steel production."
-				""
-				"Using &bHardened Integral Components&r in it will cause it to work 1.5x faster, while only requiring an extra &a5 rf/t&r to operate, and using &6Bonemeal&r or otherwise will boost how much wood you get per cycle."
-				""
-				"By the way, &bThermal&r Machines are capable of Automatic I/O, try placing a 2x2 drawer beside your &bPhytogenic Insolator&r and configuring it to both push to and pull from the side with the drawer."
-			]
-			id: "2607F8404B56773B"
-			rewards: [{
-				id: "6AB8644A32EF475D"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			subtitle: "...and crops as well, I guess."
-			tasks: [{
-				id: "4ED486548C376854"
-				item: "thermal:machine_insolator"
-				type: "item"
-			}]
-			title: "&9Infinite Wood"
-			x: 4.5d
-			y: -5.0d
-		}
-		{
-			dependencies: ["3EDD0A986384F2A7"]
-			description: [
-				"Now that you have a &3Wiremill&f and a &2Bending Machine&f, you can consider starting to do &eBounties&f. The &6Bounty Board&f has a global inventory containing quests to turn in specific items in exchange for &9monicoins&f. These quests have a fairly short duration, so make sure to &estockpile the items&f that come up on them or else they'll &cexpire before you can complete them&f."
-				""
-				"With renewable &9monicoins&f, you should feel free to spend the ones you have on whatever you need. &aSpend your coins!"
-			]
-			hide_dependency_lines: true
-			id: "3E69E1949316BD0C"
-			rewards: [{
-				id: "09A5BDC0CF107A1C"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			size: 1.5d
-			subtitle: "Money!"
-			tasks: [{
-				id: "79EF1B91285482AB"
-				item: "bountiful:bountyboard"
-				type: "item"
-			}]
-			title: "&2Bounties For monicoins!"
-			x: 10.5d
-			y: 7.5d
-		}
-		{
-			dependencies: ["3AB0402B19DD5BA8"]
-			description: ["Bigger barrels."]
-			id: "3E4DEA4FFD019AB9"
-			tasks: [{
-				id: "4355F32860B92456"
-				item: "sophisticatedstorage:gold_to_diamond_tier_upgrade"
-				type: "item"
-			}]
-			title: "&9Upgrades, people, upgrades."
-			x: 8.5d
-			y: 7.5d
-		}
-		{
-			dependencies: ["545CCC24D9401794"]
-			description: ["The &6Steam Foundry&r functions as 5.3 &7LV &3Alloy Smelters&r in parallel! It requires an input of &9Steam&r through a &eSteam Hatch&r, but it uses very little Steam, perfect for bulk crafting alloys or mold recipes."]
-			icon: "steamadditions:steam_foundry"
-			id: "5D60CAE3A33000C3"
-			rewards: [{
-				id: "0543D4882AD0F771"
-				item: "kubejs:moni_quarter"
-				type: "item"
-			}]
-			size: 1.25d
+			subtitle: "Don't be a hoarder!"
 			tasks: [
 				{
-					id: "31167A476BC0B4F1"
-					item: "steamadditions:steam_foundry"
-					type: "item"
+					id: "7275E7D7E7F140B8"
+					type: "checkmark"
 				}
 				{
-					count: 13L
-					id: "505B1290E3042129"
-					item: { Count: 13, id: "gtceu:steam_machine_casing" }
-					type: "item"
-				}
-				{
-					count: 9L
-					id: "5B5968BA75F69B32"
-					item: "gtceu:bronze_firebox_casing"
-					type: "item"
-				}
-				{
-					id: "20CC19C928014F7F"
-					item: "gtceu:steam_input_bus"
-					type: "item"
-				}
-				{
-					id: "3F8C63CA26639558"
-					item: "gtceu:steam_output_bus"
-					type: "item"
-				}
-				{
-					id: "2855C331EB019FD9"
-					item: "gtceu:steam_input_hatch"
+					disable_toast: true
+					id: "34ADCB8BA7F14B03"
+					item: {
+						Count: 1
+						id: "itemfilters:tag"
+						tag: {
+							value: "moni:coins"
+						}
+					}
+					optional_task: true
+					title: "Monicoins"
 					type: "item"
 				}
 			]
-			title: "&9Steam Foundry"
-			x: 4.517857142857139d
-			y: 1.4285714285714306d
+			title: "Spend Your Coins!"
+			x: -9.0d
+			y: 2.5d
+		}
+		{
+			dependencies: ["115D2BEB18929C7C"]
+			description: [
+				"In most expert packs, you want to try to process as little ore as possible before you get access to ore doubling. It's a habit most of us pick up."
+				""
+				"[\"You shouldn't feel any pressure to do that in \",{\"text\":\"Monifactory\",\"color\":\"blue\"},\", though. Ore veins are massive, mining is extremely fast with \",{\"text\":\"Mining Hammers\",\"color\":\"green\",\"underlined\":true,\"clickEvent\":{\"action\":\"change_page\",\"value\":\"07D45A3F8A74A61C\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":\"Click to go to the quest\"}},{\"text\":\", and \"},{\"text\":\"chanced byproducts aren't available until HV.\",\"color\":\"yellow\"}] "
+				""
+				"Obvious exceptions would be rare materials or anything you buy with &9Monicoins &fbecause you can't find it. Those are worth doubling, if possible."
+				""
+				"But at least for now, you shouldn't feel any guilt about smelting the more common ores without doubling them! &eOre doubling can be safely ignored until you have the &2Steam Grinder&r&e or High Voltage machines.&r"
+			]
+			icon: "gtceu:crushed_redstone_ore"
+			id: "17E92ED356B6737F"
+			tasks: [{
+				id: "36817889D65727FA"
+				type: "checkmark"
+			}]
+			title: "&2Ore Doubling?"
+			x: -9.0d
+			y: 4.0d
+		}
+		{
+			dependencies: ["66FCC26399376B55"]
+			description: [
+				"&n&9Monifactory&r&r shares an official Discord server with Pansmith's other projects, which serves as a useful community resource."
+				""
+				"On the server, there are flowcharts and guides to help you with many parts of the pack accessable via the server's helpful bot, development announcements and more are available in the &nMoni-News&r channel, and the community helps with tech support questions, and investigates possible bug reports."
+				""
+				"You can also chat with many fellow players there if you like, who are largely willing to help with general questions one might have."
+				"{@pagebreak}"
+				"[\"To join the server, you can use the button on the Main Menu to go to the join URL, or if you're not into Discord you can find my projects on GitHub on my page \", {\"text\": \"here.\", \"color\": \"blue\", \"underlined\": \"true\", \"clickEvent\": {\"action\": \"open_url\", \"value\": \"https://github.com/ThePansmith\"}}, \".\"]"
+				""
+				"[\"Issue tracking and development is handled on the respective GitHub project repositories. The repository for this pack is \", {\"text\": \"here\", \"color\": \"blue\", \"underlined\": \"true\", \"clickEvent\": {\"action\": \"open_url\", \"value\": \"https://github.com/ThePansmith/Monifactory\"}}, \".\"]"
+			]
+			disable_toast: true
+			hide_dependency_lines: true
+			icon: "minecraft:writable_book"
+			id: "70026930847E8EC0"
+			optional: true
+			subtitle: "what's a voltage? can I eat it?"
+			tasks: [{
+				id: "1278CD7DD38F751A"
+				type: "checkmark"
+			}]
+			title: "Discord and GitHub"
+			x: -9.0d
+			y: 5.5d
+		}
+		{
+			dependencies: ["66FCC26399376B55"]
+			description: [
+				"[\"\",{\"text\":\"This tab\",\"color\":\"dark_green\",\"underlined\":true,\"clickEvent\":{\"action\":\"change_page\",\"value\":\"395B849AC6294153\"},\"hoverEvent\":{\"action\":\"show_text\",\"value\":\"055C0B43FE14258F\",\"contents\":\"Click to go to the chapter\"}},{\"text\":\" was added to help you visualise and give you tips on making chemicals, among other important things to automate. Use it wisely!\",\"color\":\"dark_green\"}]"
+				""
+				"Each quest in the tab will give you a description of the machine and the minimum voltage required to run the recipe. Furthermore, although each quest can be completed via a checkbox, all quests in a processing line will auto-complete once you get the item positioned on the right. Either the checkbox or achieving the product will complete the quests."
+			]
+			disable_toast: true
+			hide_dependency_lines: true
+			icon: "gtceu:mv_chemical_bath"
+			id: "73C713703AB6387C"
+			optional: true
+			tasks: [{
+				id: "4BEDF2126C896A50"
+				type: "checkmark"
+			}]
+			title: "&2Processing Lines Tab"
+			x: -10.5d
+			y: 5.5d
+		}
+		{
+			dependencies: ["66FCC26399376B55"]
+			description: [
+				"[\"The \",{\"text\":\"Progression tab\",\"color\":\"yellow\",\"underlined\":true,\"clickEvent\":{\"action\":\"change_page\",\"value\":\"395B849AC6294153\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":\"Click to go to the chapter\"}},\" was added so you can keep track of the important bits of the pack.\"]"
+				""
+				"Circuits are the baseline of the entire Monifactory progression, so keep climbing!"
+			]
+			disable_toast: true
+			hide_dependency_lines: true
+			icon: "gtceu:quantum_processor"
+			id: "400AD2B735FF135D"
+			optional: true
+			tasks: [{
+				id: "3378D5EF8B48960E"
+				type: "checkmark"
+			}]
+			title: "Progression Tab"
+			x: -9.0d
+			y: 7.0d
+		}
+		{
+			dependencies: ["66FCC26399376B55"]
+			description: [
+				"&bGregTech&r adds an &einteractive in-world preview&r for all &bGregTech&r multiblocks! &6Shift-right-click&r a placed controller &ewith an empty hand&r to activate a hologram depicting the default layout of the structure to help you with building. As you place blocks, the structure will be validated and the &efirst incorrect block&r it detects will be highlighted in red."
+				"{@pagebreak}"
+				"&6Sneak-right-click&r to cycle from the full view through each layer. When on the final layer of the preview, this will remove the preview."
+				""
+				"&6Sneak-left-click&r to go back to the previous layer, or close the preview from the full view."
+				""
+				"In the &eJEI previews&r for multiblocks, &6left-click&r and drag the mouse to rotate the preview."
+				""
+				"Additionally, you can &6right-click&r and drag the mouse to pan the preview or &6shift-right-click&r and drag to zoom in or out."
+				""
+				"Some blocks in the multiblock preview have additional tooltips to provide more information on how the multiblock can form."
+			]
+			disable_toast: true
+			hide_dependency_lines: true
+			icon: "gtceu:electric_blast_furnace"
+			id: "50591843C8501055"
+			optional: true
+			tasks: [{
+				id: "0765BFA6BDBFD386"
+				type: "checkmark"
+			}]
+			title: "Multiblock Machine Previews"
+			x: -10.5d
+			y: 7.0d
+		}
+		{
+			dependencies: ["66FCC26399376B55"]
+			description: ["[\"This pack has \",{\"text\":\"Inventory Tweaks\",\"color\":\"aqua\"},\", allowing for quick, customizable, and easy sorting of any inventory! The keybind is \",{\"keybind\":\"key.invtweaks_sort_player.desc\",\"color\":\"gold\",\"bold\":true,\"underlined\":true,\"hoverEvent\":{\"action\":\"show_text\",\"contents\":\"\\\"Sort Player Inventory\\\" in keybind option\"}}]"]
+			disable_toast: true
+			hide_dependency_lines: true
+			icon: "minecraft:chest"
+			id: "0DE9B264A3BA75BB"
+			optional: true
+			subtitle: "Clean your inventory"
+			tasks: [{
+				id: "6EF2221B59F470CB"
+				type: "checkmark"
+			}]
+			title: "Inventory Sorting"
+			x: -10.5d
+			y: 4.0d
+		}
+		{
+			can_repeat: true
+			dependencies: ["66FCC26399376B55"]
+			description: [
+				"If you &osomehow&r run out of charge on your prospector. Simply submit it back in, and we'll give you a fresh one!"
+				""
+				"Available once per hour."
+			]
+			disable_toast: true
+			hide_dependency_lines: true
+			icon: "gtceu:prospector.hv"
+			id: "726528BE5A1A6AC2"
+			optional: true
+			rewards: [{
+				id: "21CED765A341AC89"
+				item: {
+					Count: 1
+					id: "gtceu:prospector.hv"
+					tag: {
+						Charge: 1600000L
+					}
+				}
+				type: "item"
+			}]
+			tasks: [
+				{
+					consume_items: true
+					id: "652A1DDFD9E1626F"
+					item: "gtceu:prospector.hv"
+					match_nbt: false
+					type: "item"
+				}
+				{
+					icon: "minecraft:clock"
+					id: "028124026E3BCE59"
+					tags: [
+						"moni_timer"
+						"moni_timer_60"
+					]
+					title: "Timer"
+					type: "custom"
+				}
+			]
+			title: "Recharge Your Prospector!"
+			x: -9.75d
+			y: 8.5d
+		}
+		{
+			dependencies: ["7041EC01A69404E6"]
+			description: [
+				""
+				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
+				""
+				""
+			]
+			disable_toast: true
+			hide_dependency_lines: true
+			icon: "minecraft:purple_bed"
+			id: "33195ED6D7008E5F"
+			optional: true
+			rewards: [{
+				id: "3DE844F3B9CF2903"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			subtitle: "Make returning home easy!"
+			tasks: [{
+				id: "01BB1FD4BE3716C4"
+				title: "Checkmark"
+				type: "checkmark"
+			}]
+			title: "Registering Homes"
+			x: -9.75d
+			y: 1.0d
 		}
 	]
-	title: "The Beginning"
+	title: "Genesis"
 }


### PR DESCRIPTION
Peaceful players can't complete these three quests in Genesis alone:

- Lost Cities and Registering Homes (requires heads)
- Electromagnet (requires autoclave)
- Inspector Gadget (requires alloy smelter)

Recommend removing Lost Cities entirely (since cakes are the easiest and most ubiquitous method of Overworld transport from the very first Genesis quest) and leaving it only as Registering Homes.

Recommend requiring Electromagnet after Autoclave

Recommend requiring Inspector Gadget after Pulsating Dust and Ender Pearls