### PR TITLE
Update genesis.snbt

### DIFF
--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -1610,63 +1610,6 @@
 			y: 15.5d
 		}
 		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: [
-				"These devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn't make them from nothing."
-				""
-				"Also important to note that it won't work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines)."
-				""
-				"A very cool feature of this mod is how you can &9shift-right click&r an &ainventory&r with any gadget (if you are using a &6Copy-Paste Gadget&r to do this, it must be on &ePaste&r mode) and the gadget will &9pull items from the inventory&r, `connecting' the gadget to the inventory."
-				""
-				"For example, if you shift-right click a chest full of cobblestone, the gadget will use cobblestone from that chest to place blocks."
-				""
-				"By default, the config GUI is bound to &6G&r."
-			]
-			icon: "buildinggadgets2:gadget_building"
-			id: "5F9C7FB40AD2640B"
-			subtitle: "This pack has &bBuilding Gadgets&r."
-			tasks: [
-				{
-					id: "449B547CDED79AE3"
-					item: "buildinggadgets2:gadget_building"
-					type: "item"
-				}
-				{
-					id: "30A321B32CDAF437"
-					item: "buildinggadgets2:gadget_exchanging"
-					type: "item"
-				}
-				{
-					id: "4763F5F3C0771FFA"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_copy_paste"
-						tag: { }
-					}
-					type: "item"
-				}
-				{
-					id: "284A671CC5192B50"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_cut_paste"
-						tag: {
-							pastereplace: 1b
-						}
-					}
-					type: "item"
-				}
-				{
-					id: "51485964CFCB26B9"
-					item: "buildinggadgets2:gadget_destruction"
-					type: "item"
-				}
-			]
-			title: "Inspector Gadget"
-			x: -2.75d
-			y: 16.75d
-		}
-		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
 				"&6Sulfur Ore&r is the only source of &6Sulfur Dust&r that's currently available to you."
@@ -1799,34 +1742,6 @@
 			}]
 			x: -4.0d
 			y: 15.5d
-		}
-		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: ["This relatively inexpensive item will suck nearby items into your inventory."]
-			id: "39394D5596FF8BC8"
-			rewards: [{
-				id: "20D8F149F414F950"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "36817E3C33876798"
-				item: {
-					Count: 1
-					id: "enderio:electromagnet"
-					tag: {
-						Energy: {
-							EnergyStored: 0
-							MaxEnergyStored: 100000
-							MaxEnergyUse: 100000
-						}
-					}
-				}
-				type: "item"
-			}]
-			title: "Electromagnet"
-			x: -1.5d
-			y: 16.75d
 		}
 		{
 			dependencies: ["297B523B6C503957"]
@@ -1984,67 +1899,6 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"Whether or not you (or your server admin) picked the default &bLost Cities&r overworld type, you have the option of teleporting yourself to the &eLost Cities Dimension&r. This is useful if you like other world types but want to still be able to explore cities for things like &eloot and spawners&r."
-				""
-				"To create a portal, you must place a &aBed&r down on two &6Blocks of Diamond&r. Then, you surround the bed with any kind of &eMonster Skulls&r. Sleep in this bed and you will be teleported there."
-				""
-				"&cDon't forget to have a way to get back!&r You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
-				""
-				"Later on you'll have other means of teleportation."
-				""
-				"Monster Skulls might take a little while to get if you're playing in &ePeaceful&r&r. &6Skeleton Skulls&r would be the way to go in that case."
-			]
-			disable_toast: true
-			hide_dependency_lines: true
-			icon: "minecraft:purple_bed"
-			id: "33195ED6D7008E5F"
-			optional: true
-			rewards: [{
-				id: "3DE844F3B9CF2903"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			subtitle: "Free materials!"
-			tasks: [
-				{
-					count: 10L
-					id: "0221039A21A1C266"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "forge:heads"
-						}
-					}
-					title: "Any Heads"
-					type: "item"
-				}
-				{
-					id: "0E70B83A51A0ADEC"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "minecraft:beds"
-						}
-					}
-					title: "Any Bed"
-					type: "item"
-				}
-				{
-					count: 2L
-					id: "0DA16402F8B9CC9B"
-					item: "minecraft:diamond_block"
-					type: "item"
-				}
-			]
-			title: "Lost Cities and Registering Homes"
-			x: -10.5d
-			y: 5.5d
-		}
-		{
-			dependencies: ["66FCC26399376B55"]
-			description: [
 				"&n&9Monifactory&r&r shares an official Discord server with Pansmith's other projects, which serves as a useful community resource."
 				""
 				"On the server, there are flowcharts and guides to help you with many parts of the pack accessable via the server's helpful bot, development announcements and more are available in the &nMoni-News&r channel, and the community helps with tech support questions, and investigates possible bug reports."
@@ -2087,7 +1941,7 @@
 			}]
 			title: "&2Processing Lines Tab"
 			x: -10.5d
-			y: 7.0d
+			y: 5.5d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2135,7 +1989,7 @@
 			}]
 			title: "Multiblock Machine Previews"
 			x: -10.5d
-			y: 8.5d
+			y: 7.0d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2198,8 +2052,36 @@
 				}
 			]
 			title: "Recharge Your Prospector!"
-			x: -9.0d
+			x: -9.75d
 			y: 8.5d
+		}
+		{
+			dependencies: ["7041EC01A69404E6"]
+			description: [
+				""
+				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
+				""
+				""
+			]
+			disable_toast: true
+			hide_dependency_lines: true
+			icon: "minecraft:purple_bed"
+			id: "33195ED6D7008E5F"
+			optional: true
+			rewards: [{
+				id: "3DE844F3B9CF2903"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			subtitle: "Make returning home easy!"
+			tasks: [{
+				id: "01BB1FD4BE3716C4"
+				title: "Checkmark"
+				type: "checkmark"
+			}]
+			title: "Registering Homes"
+			x: -9.75d
+			y: 1.0d
 		}
 	]
 	title: "Genesis"


### PR DESCRIPTION
Peaceful players can't finish all Genesis quests.

- Lost Cities and Registering Homes can't be completed until mob learning.
- Electromagnet can't be completed until autoclave.
- Inspector Gadget can't be completed until alloy smelter.

Recommendations:
- Remove Lost Cities entirely and just keep Registering Homes since cake method of overworld transport is ubiquitous from the first Genesis quest.
- Move Electromagnet to The Beginning and require LV Autoclave quest.
- Move Inspector Gadget to The Beginning and require Pulsating Iron and Ender Pearls quest.