### PR TITLE
Update README.md to reference explicit Forge version

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To spice up your Monifactory experience, you can add one of the following mods t
 
 ### Dedicated Server Installation:
 1. Download a server.zip file from the releases page.
-2. Download the forge installer from [here](https://files.minecraftforge.net/net/minecraftforge/forge/index_1.20.1.html).
+2. Download the ``47.3.7`` forge installer from [here](https://files.minecraftforge.net/net/minecraftforge/forge/index_1.20.1.html).
 3. Create a folder for the server (``mkdir MonifactoryServer``, name doesnt matter)
 4. Move the server.zip and forge installer into your server directory. The rest of the guide assumes your current directory is the server directory.
 5. Run the forge installer and install the forge server, this can be done with the command ``java -jar TheForgeInstallerName.jar --installServer``


### PR DESCRIPTION
Update the README.md instructions to reference the forge version 47.3.7 because the new 47.3.10 will cause the server to crash.

https://discord.com/channels/914926812948234260/1287594638072483870/1287906083125334028