### PR TITLE
Make GT Credits burnable in Numis to match Thermal Expansion coins

### DIFF
--- a/kubejs/data/hostilenetworks/data_models/slime.json
+++ b/kubejs/data/hostilenetworks/data_models/slime.json
@@ -32,8 +32,8 @@
             "count": 4
         },
         {
-            "item": "gtceu:platinum_credit",
-            "count": 1
+            "item": "gtceu:platinum_nugget",
+            "count": 3
         }
     ]
 }

--- a/kubejs/server_scripts/gregtech/superfabricator.js
+++ b/kubejs/server_scripts/gregtech/superfabricator.js
@@ -54,7 +54,7 @@ ServerEvents.recipes(event => {
     fabricator('slime', 1, '32x minecraft:slime_ball')
     fabricator('slime', 2, '8x minecraft:slime_block')
     fabricator('slime', 3, '4x gtceu:nickel_ingot')
-    fabricator('slime', 4, 'gtceu:platinum_credit')
+    fabricator('slime', 4, '3x gtceu:platinum_nugget')
     fabricator('spider', 1, '32x minecraft:string')
     fabricator('spider', 2, '16x minecraft:spider_eye')
     fabricator('spider', 3, '12x minecraft:copper_ingot')

--- a/kubejs/server_scripts/gregtech_credits.js
+++ b/kubejs/server_scripts/gregtech_credits.js
@@ -1,0 +1,32 @@
+/*
+Creates Forming Press recipes for all tiers of Gregtech Credits,
+replacing the singular one for Cupronickel.
+*/
+ServerEvents.recipes(event => {
+    //Remove the one forming press recipe for Cupronickel
+    event.remove({ id: 'gtceu:forming_press/credit_cupronickel'})
+
+    const metals = [
+        'copper',
+        'cupronickel',
+        'silver',
+        'gold',
+        'platinum',
+        'osmium',
+        'naquadah',
+        'neutronium'
+    ]
+
+    for (let index = 0; index < metals.length; index++) {
+        //Total energy cost (default 1600 EU for Cupronickel)
+        let energyIn = 1600 * Math.pow(4, index);
+
+        //Create recipes for all coin types
+        event.recipes.gtceu.forming_press(`gtceu:forming_press/${metals[index]}_credit`)
+            .notConsumable('gtceu:credit_casting_mold')
+            .itemInputs(`gtceu:${metals[index]}_plate`)
+            .itemOutputs(`4x gtceu:${metals[index]}_credit`)
+            .EUt(energyIn/(20 * 5))
+            .duration(20 * 5)
+    }
+})

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -30,14 +30,6 @@ ServerEvents.recipes(event => {
     // Glider
     event.replaceInput({ id: "hangglider:glider_framework" }, 'minecraft:iron_ingot', 'gtceu:iron_rod')
     event.replaceInput({ id: "gtceu:shaped/basic_circuit_board" }, 'gtceu:copper_single_wire', 'gtceu:fine_copper_wire')
-    event.remove({ id: "gtceu:shapeless/credit_platinum" })
-    event.remove({ id: "gtceu:shapeless/credit_platinum_alt" })
-
-    event.recipes.gtceu.extractor('fluid_platinum')
-        .outputFluids(Fluid.of('gtceu:platinum', 48))
-        .itemInputs('gtceu:platinum_credit')
-        .duration(40)
-        .EUt(7)
 
     // Void Air (normal air)
     event.recipes.gtceu.gas_collector('void_air')


### PR DESCRIPTION
Also replaces Slime Models' Platinum source from coins to nuggets - this makes the use [more clear](https://discord.com/channels/914926812948234260/1229854271613436066/1288204595419676705) and more [consistent with Thermal's current recipes](https://discord.com/channels/914926812948234260/1229854271613436066/1286837926478741564). The amount of Platinum per matter is not affected - 48mB both before and after.