### PR TITLE
Genesis Peaceful Playthrough Compatibility

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -119,6 +119,14 @@ Check the [Known Issues document](KNOWN-ISSUES.md) first. If it's not there, rep
 
 <hr>
 
+## Server
+
+**Q. How do I update Monifactory on my server?**
+
+In your server directory delete config-overrides, config, defaultconfig, kubejs, and mods. Then from the new Monifactory server zip copy over those same directories to replace the ones you removed. Enjoy!
+
+<hr>
+
 ## Contributing to Monifactory
 
 See more at [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ To spice up your Monifactory experience, you can add one of the following mods t
 6. ``unzip server.zip``
 7. Move the contents of the overrides folder (from server.zip) into the server directory, this can be done with the command ``mv overrides/* .``
 8. Use ``./run.sh`` to generate the eula.txt, then again after you accepted run it again to start the server. Modifying the server.properties file to change the port may be neccesary.
+9. To upgrade an existing Monifactory server, see See [FAQ.md](FAQ.md).
 
 ## Contributing
 

--- a/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
@@ -56,11 +56,17 @@
 		{
 			dependencies: ["2A511DB40C66CF35"]
 			description: [
-				"This pack is intended to be played in a &bLost cities/Overworld dimension&r."
+				"This pack is intended to be played in the &bOverworld and Lost City Dimensions&r."
 				""
-				"If you're playing with friends, don't forget to invite them to a &eFTB Teams party&r. "
+				"If you wish to build your base in total safety, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the &7Void World&r. "
 				""
-				"If you wish to build your base in a skyblock world, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the void. Please note that you'll still need to return to the Lost Cities/Overworld dimension to mine, but you can freely build in complete safety in the &eVoid World&r."
+				"The &2Overworld&r has ores to mine, and is a great place to gather resources."
+				""
+				"The &3Lost City&r can be explored for &eloot and spawners&r. There are no ores in the Lost City Dimension. "
+				""
+				"Simply place down and eat any dimensional cake for access to that dimension."
+				""
+				"If you're playing with friends, don't forget to invite them to an &eFTB Teams party&r. "
 				"{@pagebreak}"
 				"Features new to &2CEu&r and quests with new content will be higlighted in &2dark green&r."
 				""
@@ -79,20 +85,25 @@
 					type: "item"
 				}
 				{
-					id: "48B3D498AC0B2BE0"
+					id: "1B82F40F0A97AD98"
+					item: "telepastries:lost_city_cake"
+					type: "item"
+				}
+				{
+					id: "5B41064803D613C4"
 					item: "telepastries:overworld_cake"
 					type: "item"
 				}
 				{
-					auto: "no_toast"
+					auto: "invisible"
 					icon: "enderio:cake_base"
-					id: "612FEB595285D353"
+					id: "08F3F8B775082201"
 					title: "&6Infinite Cakes!"
 					type: "custom"
 				}
 				{
 					auto: "invisible"
-					id: "75FD5BC7147B8397"
+					id: "23FA506BA1CA21E4"
 					ignore_reward_blocking: true
 					stage: "intro_complete"
 					type: "gamestage"
@@ -114,9 +125,11 @@
 			can_repeat: true
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"In &9Monifactory&r, all dimensional transit is done through the power of &bTelePastries&r. No Portals here!"
+				"In &9Monifactory&r, all dimensional transit is done through the power of &6TelePastries&r. No Portals here!"
 				""
-				"This quest is repeatable and gives you a free cake to the &6Void World&r or &2Overworld&r every hour. You can also refill your cakes with the items indicated in their tooltips."
+				"This quest is repeatable and gives you a free cake to the &2Overworld&r, &3Lost City&r, or &7Void World&r every hour. You can also refill your cakes with the items indicated in their tooltips."
+				""
+				"&cDon't forget to have a way to get back!&r If you do, click on the Emergency Items heart on the right side of the quest book screen."
 			]
 			disable_toast: true
 			icon: "telepastries:overworld_cake"
@@ -128,7 +141,7 @@
 				table_id: 7942624913962637807L
 				type: "choice"
 			}]
-			subtitle: "Cakes are magical!"
+			subtitle: "Cakes are quantum objects!"
 			tags: ["moni_cakequest"]
 			tasks: [
 				{
@@ -330,7 +343,6 @@
 					id: "itemfilters:or"
 					tag: {
 						items: [
-						
 							{
 								Count: 1b
 								id: "gtceu:potin_tiny_fluid_pipe"
@@ -1761,63 +1773,6 @@
 		{
 			dependencies: ["06E9B9DDDB245F38"]
 			description: [
-				"These devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn't make them from nothing."
-				""
-				"Also important to note that it won't work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines)."
-				""
-				"A very cool feature of this mod is how you can &9shift-right click&r an &ainventory&r with any gadget (if you are using a &6Copy-Paste Gadget&r to do this, it must be on &ePaste&r mode) and the gadget will &9pull items from the inventory&r, `connecting' the gadget to the inventory."
-				""
-				"For example, if you shift-right click a chest full of cobblestone, the gadget will use cobblestone from that chest to place blocks."
-				""
-				"By default, the config GUI is bound to &6G&r."
-			]
-			icon: "buildinggadgets2:gadget_building"
-			id: "5F9C7FB40AD2640B"
-			subtitle: "This pack has &bBuilding Gadgets&r."
-			tasks: [
-				{
-					id: "449B547CDED79AE3"
-					item: "buildinggadgets2:gadget_building"
-					type: "item"
-				}
-				{
-					id: "30A321B32CDAF437"
-					item: "buildinggadgets2:gadget_exchanging"
-					type: "item"
-				}
-				{
-					id: "4763F5F3C0771FFA"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_copy_paste"
-						tag: { }
-					}
-					type: "item"
-				}
-				{
-					id: "284A671CC5192B50"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_cut_paste"
-						tag: {
-							pastereplace: 1b
-						}
-					}
-					type: "item"
-				}
-				{
-					id: "51485964CFCB26B9"
-					item: "buildinggadgets2:gadget_destruction"
-					type: "item"
-				}
-			]
-			title: "Inspector Gadget"
-			x: -2.75d
-			y: 16.75d
-		}
-		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: [
 				"Basic &aFlux Capacitors&r hold a whopping lot of energy - &9500 kRF&r - and are useful for keeping your &aRF-powered&r equipment and tools charged."
 				""
 				"Put one into your newly crafted &9Charger&r to charge it. You can then put it in your inventory to charge your items with &aRF&r."
@@ -1861,34 +1816,6 @@
 			title: "&9Flux Capacitors"
 			x: -2.75d
 			y: 15.5d
-		}
-		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: ["This relatively inexpensive item will suck nearby items into your inventory."]
-			id: "39394D5596FF8BC8"
-			rewards: [{
-				id: "20D8F149F414F950"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "36817E3C33876798"
-				item: {
-					Count: 1
-					id: "enderio:electromagnet"
-					tag: {
-						Energy: {
-							EnergyStored: 0
-							MaxEnergyStored: 100000
-							MaxEnergyUse: 100000
-						}
-					}
-				}
-				type: "item"
-			}]
-			title: "Electromagnet"
-			x: -1.5d
-			y: 16.75d
 		}
 		{
 			dependencies: ["297B523B6C503957"]
@@ -2029,63 +1956,24 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"Whether or not you (or your server admin) picked the default &bLost Cities&r overworld type, you have the option of teleporting yourself to the &eLost Cities Dimension&r. This is useful if you like other world types but want to still be able to explore cities for things like &eloot and spawners&r."
+				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
-				"To create a portal, you must place a &aBed&r down on two &6Blocks of Diamond&r. Then, you surround the bed with any kind of &eMonster Skulls&r. Sleep in this bed and you will be teleported there."
-				""
-				"&cDon't forget to have a way to get back!&r You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
-				""
-				"Later on you'll have other means of teleportation."
-				""
-				"Monster Skulls might take a little while to get if you're playing in &ePeaceful&r&r. &6Skeleton Skulls&r would be the way to go in that case."
+				"Later on you'll discover other means of teleportation."
 			]
 			disable_toast: true
 			hide_dependency_lines: true
 			icon: "minecraft:purple_bed"
 			id: "33195ED6D7008E5F"
 			optional: true
-			rewards: [{
-				id: "3DE844F3B9CF2903"
-				item: "kubejs:moni_nickel"
-				type: "item"
+			subtitle: "Make returning home easy!"
+			tasks: [{
+				id: "43065369D0A75820"
+				title: "Checkmark"
+				type: "checkmark"
 			}]
-			subtitle: "Free materials!"
-			tasks: [
-				{
-					count: 10L
-					id: "0221039A21A1C266"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "forge:heads"
-						}
-					}
-					title: "Any Heads"
-					type: "item"
-				}
-				{
-					id: "0E70B83A51A0ADEC"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "minecraft:beds"
-						}
-					}
-					title: "Any Bed"
-					type: "item"
-				}
-				{
-					count: 2L
-					id: "0DA16402F8B9CC9B"
-					item: "minecraft:diamond_block"
-					type: "item"
-				}
-			]
-			title: "Lost Cities and Registering Homes"
-			x: -10.5d
-			y: 7.0d
+			title: "Registering Homes"
+			x: -9.75d
+			y: 1.0d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2132,7 +2020,7 @@
 			}]
 			title: "&2Processing Lines Tab"
 			x: -10.5d
-			y: 8.5d
+			y: 7.0d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2179,8 +2067,8 @@
 				type: "checkmark"
 			}]
 			title: "Multiblock Machine Previews"
-			x: -10.5d
-			y: 10.0d
+			x: -9.75d
+			y: 8.5d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]

--- a/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
@@ -1956,9 +1956,9 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
+				"If your server admin allows it, you can use JourneyMap to create and teleport to waypoints you set. You can access JourneyMap waypoints by hitting the N key by default. Use this feature to gather resources quickly."
 				""
-				"Additionally if your server admin allows it, you can use JourneyMap to teleport to even more waypoints. Access JourneyMap waypoints by N key."
+				"If JourneyMap teleportation is disabled, you can still use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: there is a limit on the number of homes you can set, &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
 				"Later on you'll discover other means of teleportation."
 			]
@@ -1973,7 +1973,7 @@
 				title: "Checkmark"
 				type: "checkmark"
 			}]
-			title: "Registering Homes"
+			title: "JourneyMap and Registering Homes"
 			x: -9.75d
 			y: 1.0d
 		}

--- a/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
@@ -1958,6 +1958,8 @@
 			description: [
 				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
+				"Additionally if your server admin allows it, you can use JourneyMap to teleport to even more waypoints. Access JourneyMap waypoints by N key."
+				""
 				"Later on you'll discover other means of teleportation."
 			]
 			disable_toast: true

--- a/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
@@ -2071,9 +2071,9 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
+				"If your server admin allows it, you can use JourneyMap to create and teleport to waypoints you set. You can access JourneyMap waypoints by hitting the N key by default. Use this feature to gather resources quickly."
 				""
-				"Additionally if your server admin allows it, you can use JourneyMap to teleport to even more waypoints. Access JourneyMap waypoints by N key."
+				"If JourneyMap teleportation is disabled, you can still use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: there is a limit on the number of homes you can set, &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
 				"Later on you'll discover other means of teleportation."
 			]
@@ -2088,7 +2088,7 @@
 				title: "Checkmark"
 				type: "checkmark"
 			}]
-			title: "Registering Homes"
+			title: "JourneyMap and Registering Homes"
 			x: -9.75d
 			y: 1.0d
 		}

--- a/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
@@ -56,11 +56,17 @@
 		{
 			dependencies: ["2A511DB40C66CF35"]
 			description: [
-				"This pack is intended to be played in a &bLost cities/Overworld dimension&r."
+				"This pack is intended to be played in the &bOverworld and Lost City Dimensions&r."
 				""
-				"If you're playing with friends, don't forget to invite them to a &eFTB Teams party&r. "
+				"If you wish to build your base in total safety, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the &7Void World&r. "
 				""
-				"If you wish to build your base in a skyblock world, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the void. Please note that you'll still need to return to the Lost Cities/Overworld dimension to mine, but you can freely build in complete safety in the &eVoid World&r."
+				"The &2Overworld&r has ores to mine, and is a great place to gather resources."
+				""
+				"The &3Lost City&r can be explored for &eloot and spawners&r. There are no ores in the Lost City Dimension. "
+				""
+				"Simply place down and eat any dimensional cake for access to that dimension."
+				""
+				"If you're playing with friends, don't forget to invite them to an &eFTB Teams party&r. "
 				"{@pagebreak}"
 				"Features new to &2CEu&r and quests with new content will be higlighted in &2dark green&r."
 				""
@@ -79,12 +85,17 @@
 					type: "item"
 				}
 				{
-					id: "48B3D498AC0B2BE0"
+					id: "382D4560F38A3AF2"
+					item: "telepastries:lost_city_cake"
+					type: "item"
+				}
+				{
+					id: "12BD64A82DB08429"
 					item: "telepastries:overworld_cake"
 					type: "item"
 				}
 				{
-					id: "3451D4471E82E65A"
+					id: "3FD07C604E5C3BDD"
 					item: {
 						Count: 1
 						id: "gtceu:prospector.hv"
@@ -95,15 +106,15 @@
 					type: "item"
 				}
 				{
-					auto: "no_toast"
+					auto: "invisible"
 					icon: "enderio:cake_base"
-					id: "612FEB595285D353"
-					title: "&6Infinite Cakes!"
+					id: "66946B00EE424149"
+					title: "&6Inifinite Cakes!"
 					type: "custom"
 				}
 				{
 					auto: "invisible"
-					id: "75FD5BC7147B8397"
+					id: "7538AE25269C2962"
 					ignore_reward_blocking: true
 					stage: "intro_complete"
 					type: "gamestage"
@@ -125,9 +136,11 @@
 			can_repeat: true
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"In &9Monifactory&r, all dimensional transit is done through the power of &bTelePastries&r. No Portals here!"
+				"In &9Monifactory&r, all dimensional transit is done through the power of &6TelePastries&r. No Portals here!"
 				""
-				"This quest is repeatable and gives you a free cake to the &6Void World&r or &2Overworld&r every hour. You can also refill your cakes with the items indicated in their tooltips."
+				"This quest is repeatable and gives you a free cake to the &2Overworld&r, &3Lost City&r, or &7Void World&r every hour. You can also refill your cakes with the items indicated in their tooltips."
+				""
+				"&cDon't forget to have a way to get back!&r If you do, click on the Emergency Items heart on the right side of the quest book screen."
 			]
 			disable_toast: true
 			icon: "telepastries:overworld_cake"
@@ -139,7 +152,7 @@
 				table_id: 7942624913962637807L
 				type: "choice"
 			}]
-			subtitle: "Cakes are magical!"
+			subtitle: "Cakes are quantum objects!"
 			tags: ["moni_cakequest"]
 			tasks: [
 				{
@@ -361,7 +374,6 @@
 					id: "itemfilters:or"
 					tag: {
 						items: [
-						
 							{
 								Count: 1b
 								id: "gtceu:potin_tiny_fluid_pipe"
@@ -1872,63 +1884,6 @@
 		{
 			dependencies: ["06E9B9DDDB245F38"]
 			description: [
-				"These devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn't make them from nothing."
-				""
-				"Also important to note that it won't work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines)."
-				""
-				"A very cool feature of this mod is how you can &9shift-right click&r an &ainventory&r with any gadget (if you are using a &6Copy-Paste Gadget&r to do this, it must be on &ePaste&r mode) and the gadget will &9pull items from the inventory&r, `connecting' the gadget to the inventory."
-				""
-				"For example, if you shift-right click a chest full of cobblestone, the gadget will use cobblestone from that chest to place blocks."
-				""
-				"By default, the config GUI is bound to &6G&r."
-			]
-			icon: "buildinggadgets2:gadget_building"
-			id: "5F9C7FB40AD2640B"
-			subtitle: "This pack has &bBuilding Gadgets&r."
-			tasks: [
-				{
-					id: "449B547CDED79AE3"
-					item: "buildinggadgets2:gadget_building"
-					type: "item"
-				}
-				{
-					id: "30A321B32CDAF437"
-					item: "buildinggadgets2:gadget_exchanging"
-					type: "item"
-				}
-				{
-					id: "4763F5F3C0771FFA"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_copy_paste"
-						tag: { }
-					}
-					type: "item"
-				}
-				{
-					id: "284A671CC5192B50"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_cut_paste"
-						tag: {
-							pastereplace: 1b
-						}
-					}
-					type: "item"
-				}
-				{
-					id: "51485964CFCB26B9"
-					item: "buildinggadgets2:gadget_destruction"
-					type: "item"
-				}
-			]
-			title: "Inspector Gadget"
-			x: -2.75d
-			y: 16.75d
-		}
-		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: [
 				"Basic &aFlux Capacitors&r hold a whopping lot of energy - &9500 kRF&r - and are useful for keeping your &aRF-powered&r equipment and tools charged."
 				""
 				"Put one into your newly crafted &9Charger&r to charge it. You can then put it in your inventory to charge your items with &aRF&r."
@@ -1972,34 +1927,6 @@
 			title: "&9Flux Capacitors"
 			x: -2.75d
 			y: 15.5d
-		}
-		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: ["This relatively inexpensive item will suck nearby items into your inventory."]
-			id: "39394D5596FF8BC8"
-			rewards: [{
-				id: "20D8F149F414F950"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "36817E3C33876798"
-				item: {
-					Count: 1
-					id: "enderio:electromagnet"
-					tag: {
-						Energy: {
-							EnergyStored: 0
-							MaxEnergyStored: 100000
-							MaxEnergyUse: 100000
-						}
-					}
-				}
-				type: "item"
-			}]
-			title: "Electromagnet"
-			x: -1.5d
-			y: 16.75d
 		}
 		{
 			dependencies: ["297B523B6C503957"]
@@ -2144,63 +2071,24 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"Whether or not you (or your server admin) picked the default &bLost Cities&r overworld type, you have the option of teleporting yourself to the &eLost Cities Dimension&r. This is useful if you like other world types but want to still be able to explore cities for things like &eloot and spawners&r."
+				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
-				"To create a portal, you must place a &aBed&r down on two &6Blocks of Diamond&r. Then, you surround the bed with any kind of &eMonster Skulls&r. Sleep in this bed and you will be teleported there."
-				""
-				"&cDon't forget to have a way to get back!&r You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
-				""
-				"Later on you'll have other means of teleportation."
-				""
-				"Monster Skulls might take a little while to get if you're playing in &ePeaceful&r&r. &6Skeleton Skulls&r would be the way to go in that case."
+				"Later on you'll discover other means of teleportation."
 			]
 			disable_toast: true
 			hide_dependency_lines: true
 			icon: "minecraft:purple_bed"
 			id: "33195ED6D7008E5F"
 			optional: true
-			rewards: [{
-				id: "3DE844F3B9CF2903"
-				item: "kubejs:moni_nickel"
-				type: "item"
+			subtitle: "Make returning home easy!"
+			tasks: [{
+				id: "030DEF4A0C0A553F"
+				title: "Checkmark"
+				type: "checkmark"
 			}]
-			subtitle: "Free materials!"
-			tasks: [
-				{
-					count: 10L
-					id: "0221039A21A1C266"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "forge:heads"
-						}
-					}
-					title: "Any Heads"
-					type: "item"
-				}
-				{
-					id: "0E70B83A51A0ADEC"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "minecraft:beds"
-						}
-					}
-					title: "Any Bed"
-					type: "item"
-				}
-				{
-					count: 2L
-					id: "0DA16402F8B9CC9B"
-					item: "minecraft:diamond_block"
-					type: "item"
-				}
-			]
-			title: "Lost Cities and Registering Homes"
-			x: -10.5d
-			y: 7.0d
+			title: "Registering Homes"
+			x: -9.75d
+			y: 1.0d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2247,7 +2135,7 @@
 			}]
 			title: "&2Processing Lines Tab"
 			x: -10.5d
-			y: 8.5d
+			y: 7.0d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2294,8 +2182,8 @@
 				type: "checkmark"
 			}]
 			title: "Multiblock Machine Previews"
-			x: -10.5d
-			y: 10.0d
+			x: -9.75d
+			y: 8.5d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]

--- a/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
@@ -2073,6 +2073,8 @@
 			description: [
 				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
+				"Additionally if your server admin allows it, you can use JourneyMap to teleport to even more waypoints. Access JourneyMap waypoints by N key."
+				""
 				"Later on you'll discover other means of teleportation."
 			]
 			disable_toast: true

--- a/config-overrides/hardmode/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/the_beginning.snbt
@@ -1890,6 +1890,34 @@
 			x: 4.517857142857139d
 			y: 1.4285714285714306d
 		}
+		{
+			dependencies: ["47094A5717952699"]
+			description: ["This relatively inexpensive item will suck nearby items into your inventory."]
+			id: "39394D5596FF8BC8"
+			rewards: [{
+				id: "20D8F149F414F950"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "36817E3C33876798"
+				item: {
+					Count: 1
+					id: "enderio:electromagnet"
+					tag: {
+						Energy: {
+							EnergyStored: 0
+							MaxEnergyStored: 100000
+							MaxEnergyUse: 100000
+						}
+					}
+				}
+				type: "item"
+			}]
+			title: "Electromagnet"
+			x: -2.75d
+			y: -6.0d
+		}
 	]
 	title: "The Beginning"
 }

--- a/config-overrides/hardmode/ftbquests/quests/reward_tables/cakes.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/reward_tables/cakes.snbt
@@ -4,6 +4,7 @@
 	order_index: 0
 	rewards: [
 		{ item: "telepastries:overworld_cake" }
+		{ item: "telepastries:lost_city_cake" }
 		{ item: "telepastries:custom_cake" }
 	]
 	title: "Cakes"

--- a/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
@@ -1928,6 +1928,8 @@
 			description: [
 				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
+				"Additionally if your server admin allows it, you can use JourneyMap to teleport to even more waypoints. Access JourneyMap waypoints by N key."
+				""
 				"Later on you'll discover other means of teleportation."
 			]
 			disable_toast: true

--- a/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
@@ -56,11 +56,17 @@
 		{
 			dependencies: ["2A511DB40C66CF35"]
 			description: [
-				"This pack is intended to be played in a &bLost cities/Overworld dimension&r."
+				"This pack is intended to be played in the &bOverworld and Lost City Dimensions&r."
 				""
-				"If you're playing with friends, don't forget to invite them to a &eFTB Teams party&r. "
+				"If you wish to build your base in total safety, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the &7Void World&r. "
 				""
-				"If you wish to build your base in a skyblock world, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the void. Please note that you'll still need to return to the Lost Cities/Overworld dimension to mine, but you can freely build in complete safety in the &eVoid World&r."
+				"The &2Overworld&r has ores to mine, and is a great place to gather resources."
+				""
+				"The &3Lost City&r can be explored for &eloot and spawners&r. There are no ores in the Lost City Dimension. "
+				""
+				"Simply place down and eat any dimensional cake for access to that dimension."
+				""
+				"If you're playing with friends, don't forget to invite them to an &eFTB Teams party&r. "
 				"{@pagebreak}"
 				"Features new to &2CEu&r and quests with new content will be higlighted in &2dark green&r."
 				""
@@ -79,12 +85,17 @@
 					type: "item"
 				}
 				{
-					id: "48B3D498AC0B2BE0"
+					id: "252CA17298A86759"
+					item: "telepastries:lost_city_cake"
+					type: "item"
+				}
+				{
+					id: "7539BE70E1B3DB39"
 					item: "telepastries:overworld_cake"
 					type: "item"
 				}
 				{
-					id: "3451D4471E82E65A"
+					id: "4227D8CC87BE7710"
 					item: {
 						Count: 1
 						id: "gtceu:prospector.hv"
@@ -96,7 +107,7 @@
 				}
 				{
 					count: 4
-					id: "3316656A4E9DA8BF"
+					id: "1C580CB98F808631"
 					item: {
 						Count: 1
 						id: "gtceu:diamond_mining_hammer"
@@ -122,7 +133,7 @@
 					type: "item"
 				}
 				{
-					id: "19598A860287E726"
+					id: "22786EAAD70B619D"
 					item: {
 						Count: 1
 						id: "gtceu:diamond_axe"
@@ -144,15 +155,15 @@
 					type: "item"
 				}
 				{
-					auto: "no_toast"
+					auto: "invisible"
 					icon: "enderio:cake_base"
-					id: "612FEB595285D353"
+					id: "392C56C1DA9D7978"
 					title: "&6Infinite Cakes!"
 					type: "custom"
 				}
 				{
 					auto: "invisible"
-					id: "75FD5BC7147B8397"
+					id: "1BCE4323D97D9083"
 					ignore_reward_blocking: true
 					stage: "intro_complete"
 					type: "gamestage"
@@ -174,9 +185,11 @@
 			can_repeat: true
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"In &9Monifactory&r, all dimensional transit is done through the power of &bTelePastries&r. No Portals here!"
+				"In &9Monifactory&r, all dimensional transit is done through the power of &6TelePastries&r. No Portals here!"
 				""
-				"This quest is repeatable and gives you a free cake to the &6Void World&r or &2Overworld&r every hour. You can also refill your cakes with the items indicated in their tooltips."
+				"This quest is repeatable and gives you a free cake to the &2Overworld&r, &3Lost City&r, or &7Void World&r every hour. You can also refill your cakes with the items indicated in their tooltips."
+				""
+				"&cDon't forget to have a way to get back!&r If you do, click on the Emergency Items heart on the right side of the quest book screen."
 			]
 			disable_toast: true
 			icon: "telepastries:overworld_cake"
@@ -188,7 +201,7 @@
 				table_id: 7942624913962637807L
 				type: "choice"
 			}]
-			subtitle: "Cakes are magical!"
+			subtitle: "Cakes are quantum objects!"
 			tags: ["moni_cakequest"]
 			tasks: [
 				{
@@ -1620,63 +1633,6 @@
 			y: 15.5d
 		}
 		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: [
-				"These devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn't make them from nothing."
-				""
-				"Also important to note that it won't work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines)."
-				""
-				"A very cool feature of this mod is how you can &9shift-right click&r an &ainventory&r with any gadget (if you are using a &6Copy-Paste Gadget&r to do this, it must be on &ePaste&r mode) and the gadget will &9pull items from the inventory&r, `connecting' the gadget to the inventory."
-				""
-				"For example, if you shift-right click a chest full of cobblestone, the gadget will use cobblestone from that chest to place blocks."
-				""
-				"By default, the config GUI is bound to &6G&r."
-			]
-			icon: "buildinggadgets2:gadget_building"
-			id: "5F9C7FB40AD2640B"
-			subtitle: "This pack has &bBuilding Gadgets&r."
-			tasks: [
-				{
-					id: "449B547CDED79AE3"
-					item: "buildinggadgets2:gadget_building"
-					type: "item"
-				}
-				{
-					id: "30A321B32CDAF437"
-					item: "buildinggadgets2:gadget_exchanging"
-					type: "item"
-				}
-				{
-					id: "4763F5F3C0771FFA"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_copy_paste"
-						tag: { }
-					}
-					type: "item"
-				}
-				{
-					id: "284A671CC5192B50"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_cut_paste"
-						tag: {
-							pastereplace: 1b
-						}
-					}
-					type: "item"
-				}
-				{
-					id: "51485964CFCB26B9"
-					item: "buildinggadgets2:gadget_destruction"
-					type: "item"
-				}
-			]
-			title: "Inspector Gadget"
-			x: -2.75d
-			y: 16.75d
-		}
-		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
 				"&6Sulfur Ore&r is the only source of &6Sulfur Dust&r that's currently available to you."
@@ -1779,34 +1735,6 @@
 			title: "&9Flux Capacitors"
 			x: -2.75d
 			y: 15.5d
-		}
-		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: ["This relatively inexpensive item will suck nearby items into your inventory."]
-			id: "39394D5596FF8BC8"
-			rewards: [{
-				id: "20D8F149F414F950"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "36817E3C33876798"
-				item: {
-					Count: 1
-					id: "enderio:electromagnet"
-					tag: {
-						Energy: {
-							EnergyStored: 0
-							MaxEnergyStored: 100000
-							MaxEnergyUse: 100000
-						}
-					}
-				}
-				type: "item"
-			}]
-			title: "Electromagnet"
-			x: -1.5d
-			y: 16.75d
 		}
 		{
 			dependencies: ["297B523B6C503957"]
@@ -1998,63 +1926,24 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"Whether or not you (or your server admin) picked the default &bLost Cities&r overworld type, you have the option of teleporting yourself to the &eLost Cities Dimension&r. This is useful if you like other world types but want to still be able to explore cities for things like &eloot and spawners&r."
+				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
-				"To create a portal, you must place a &aBed&r down on two &6Blocks of Diamond&r. Then, you surround the bed with any kind of &eMonster Skulls&r. Sleep in this bed and you will be teleported there."
-				""
-				"&cDon't forget to have a way to get back!&r You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
-				""
-				"Later on you'll have other means of teleportation."
-				""
-				"Monster Skulls might take a little while to get if you're playing in &ePeaceful&r&r. &6Skeleton Skulls&r would be the way to go in that case."
+				"Later on you'll discover other means of teleportation."
 			]
 			disable_toast: true
 			hide_dependency_lines: true
 			icon: "minecraft:purple_bed"
 			id: "33195ED6D7008E5F"
 			optional: true
-			rewards: [{
-				id: "3DE844F3B9CF2903"
-				item: "kubejs:moni_nickel"
-				type: "item"
+			subtitle: "Make returning home easy!"
+			tasks: [{
+				id: "1FE7AB8BD6D25B47"
+				title: "Checkmark"
+				type: "checkmark"
 			}]
-			subtitle: "Free materials!"
-			tasks: [
-				{
-					count: 10L
-					id: "0221039A21A1C266"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "forge:heads"
-						}
-					}
-					title: "Any Heads"
-					type: "item"
-				}
-				{
-					id: "0E70B83A51A0ADEC"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "minecraft:beds"
-						}
-					}
-					title: "Any Bed"
-					type: "item"
-				}
-				{
-					count: 2L
-					id: "0DA16402F8B9CC9B"
-					item: "minecraft:diamond_block"
-					type: "item"
-				}
-			]
-			title: "Lost Cities and Registering Homes"
-			x: -10.5d
-			y: 7.0d
+			title: "Registering Homes"
+			x: -9.75d
+			y: 1.0d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2101,7 +1990,7 @@
 			}]
 			title: "&2Processing Lines Tab"
 			x: -10.5d
-			y: 8.5d
+			y: 7.0d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2149,7 +2038,7 @@
 			}]
 			title: "Multiblock Machine Previews"
 			x: -10.5d
-			y: 10.0d
+			y: 8.5d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]

--- a/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
@@ -1926,9 +1926,9 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
+				"If your server admin allows it, you can use JourneyMap to create and teleport to waypoints you set. You can access JourneyMap waypoints by hitting the N key by default. Use this feature to gather resources quickly."
 				""
-				"Additionally if your server admin allows it, you can use JourneyMap to teleport to even more waypoints. Access JourneyMap waypoints by N key."
+				"If JourneyMap teleportation is disabled, you can still use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: there is a limit on the number of homes you can set, &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
 				"Later on you'll discover other means of teleportation."
 			]
@@ -1943,7 +1943,7 @@
 				title: "Checkmark"
 				type: "checkmark"
 			}]
-			title: "Registering Homes"
+			title: "JourneyMap and Registering Homes"
 			x: -9.75d
 			y: 1.0d
 		}

--- a/config-overrides/normal/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/the_beginning.snbt
@@ -1908,6 +1908,34 @@
 			x: 4.517857142857139d
 			y: 1.4285714285714306d
 		}
+		{
+			dependencies: ["47094A5717952699"]
+			description: ["This relatively inexpensive item will suck nearby items into your inventory."]
+			id: "39394D5596FF8BC8"
+			rewards: [{
+				id: "20D8F149F414F950"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "36817E3C33876798"
+				item: {
+					Count: 1
+					id: "enderio:electromagnet"
+					tag: {
+						Energy: {
+							EnergyStored: 0
+							MaxEnergyStored: 100000
+							MaxEnergyUse: 100000
+						}
+					}
+				}
+				type: "item"
+			}]
+			title: "Electromagnet"
+			x: -2.75d
+			y: -6.0d
+		}
 	]
 	title: "The Beginning"
 }

--- a/config-overrides/normal/ftbquests/quests/reward_tables/cakes.snbt
+++ b/config-overrides/normal/ftbquests/quests/reward_tables/cakes.snbt
@@ -4,6 +4,7 @@
 	order_index: 0
 	rewards: [
 		{ item: "telepastries:overworld_cake" }
+		{ item: "telepastries:lost_city_cake" }
 		{ item: "telepastries:custom_cake" }
 	]
 	title: "Cakes"

--- a/config/ftbquests/quests/chapters/early_game.snbt
+++ b/config/ftbquests/quests/chapters/early_game.snbt
@@ -1032,8 +1032,8 @@
 				item: "gtceu:lv_emitter"
 				type: "item"
 			}]
-			x: 12.5d
-			y: 8.5d
+			x: 10.5d
+			y: 12.0d
 		}
 		{
 			dependencies: ["2C6BEB5BBE5A91DC"]
@@ -2219,7 +2219,7 @@
 			}]
 			title: "&9Charging Items Wirelessly"
 			x: 12.5d
-			y: 10.0d
+			y: 12.0d
 		}
 		{
 			dependencies: ["61AD3760E271B431"]
@@ -2267,6 +2267,66 @@
 			title: "&9Steam Separator"
 			x: 3.0d
 			y: -1.0d
+		}
+		{
+			dependencies: [
+				"3E42B4AAA6D2A05B"
+				"1EBF9D9EADB7C451"
+			]
+			description: [
+				"These devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn't make them from nothing."
+				""
+				"Also important to note that it won't work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines)."
+				""
+				"A very cool feature of this mod is how you can &9shift-right click&r an &ainventory&r with any gadget (if you are using a &6Copy-Paste Gadget&r to do this, it must be on &ePaste&r mode) and the gadget will &9pull items from the inventory&r, `connecting' the gadget to the inventory."
+				""
+				"For example, if you shift-right click a chest full of cobblestone, the gadget will use cobblestone from that chest to place blocks."
+				""
+				"By default, the config GUI is bound to &6G&r."
+			]
+			icon: "buildinggadgets2:gadget_building"
+			id: "5F9C7FB40AD2640B"
+			subtitle: "This pack has &bBuilding Gadgets&r."
+			tasks: [
+				{
+					id: "449B547CDED79AE3"
+					item: "buildinggadgets2:gadget_building"
+					type: "item"
+				}
+				{
+					id: "30A321B32CDAF437"
+					item: "buildinggadgets2:gadget_exchanging"
+					type: "item"
+				}
+				{
+					id: "4763F5F3C0771FFA"
+					item: {
+						Count: 1
+						id: "buildinggadgets2:gadget_copy_paste"
+						tag: { }
+					}
+					type: "item"
+				}
+				{
+					id: "284A671CC5192B50"
+					item: {
+						Count: 1
+						id: "buildinggadgets2:gadget_cut_paste"
+						tag: {
+							pastereplace: 1b
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "51485964CFCB26B9"
+					item: "buildinggadgets2:gadget_destruction"
+					type: "item"
+				}
+			]
+			title: "Inspector Gadget"
+			x: 9.0d
+			y: 12.0d
 		}
 	]
 	title: "Early Game"

--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -1927,9 +1927,9 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
+				"If your server admin allows it, you can use JourneyMap to create and teleport to waypoints you set. You can access JourneyMap waypoints by hitting the N key by default. Use this feature to gather resources quickly."
 				""
-				"Additionally if your server admin allows it, you can use JourneyMap to teleport to even more waypoints. Access JourneyMap waypoints by N key."
+				"If JourneyMap teleportation is disabled, you can still use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: there is a limit on the number of homes you can set, &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
 				"Later on you'll discover other means of teleportation."
 			]
@@ -1944,7 +1944,7 @@
 				title: "Checkmark"
 				type: "checkmark"
 			}]
-			title: "Map and Registering Homes"
+			title: "JourneyMap and Registering Homes"
 			x: -9.75d
 			y: 1.0d
 		}

--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -1929,6 +1929,8 @@
 			description: [
 				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
+				"Additionally if your server admin allows it, you can use JourneyMap to teleport to even more waypoints. Access JourneyMap waypoints by N key."
+				""
 				"Later on you'll discover other means of teleportation."
 			]
 			disable_toast: true
@@ -1942,7 +1944,7 @@
 				title: "Checkmark"
 				type: "checkmark"
 			}]
-			title: "Registering Homes"
+			title: "Map and Registering Homes"
 			x: -9.75d
 			y: 1.0d
 		}

--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -56,11 +56,17 @@
 		{
 			dependencies: ["2A511DB40C66CF35"]
 			description: [
-				"This pack is intended to be played in a &bLost cities/Overworld dimension&r."
+				"This pack is intended to be played in the &bOverworld and Lost City Dimensions&r."
 				""
-				"If you're playing with friends, don't forget to invite them to a &eFTB Teams party&r. "
+				"If you wish to build your base in total safety, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the &7Void World&r. "
 				""
-				"If you wish to build your base in a skyblock world, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the void. Please note that you'll still need to return to the Lost Cities/Overworld dimension to mine, but you can freely build in complete safety in the &eVoid World&r."
+				"The &2Overworld&r has ores to mine, and is a great place to gather resources."
+				""
+				"The &3Lost City&r can be explored for &eloot and spawners&r. There are no ores in the Lost City Dimension. "
+				""
+				"Simply place down and eat any dimensional cake for access to that dimension."
+				""
+				"If you're playing with friends, don't forget to invite them to an &eFTB Teams party&r. "
 				"{@pagebreak}"
 				"Features new to &2CEu&r and quests with new content will be higlighted in &2dark green&r."
 				""
@@ -79,12 +85,18 @@
 					type: "item"
 				}
 				{
-					id: "48B3D498AC0B2BE0"
+					id: "468828C6AA27DBDB"
+					item: "telepastries:lost_city_cake"
+					type: "item"
+				}
+				{
+					id: "2DCB79E44EF2E774"
 					item: "telepastries:overworld_cake"
 					type: "item"
 				}
 				{
-					id: "3451D4471E82E65A"
+					exclude_from_claim_all: true
+					id: "7F51D3DEB9A3944E"
 					item: {
 						Count: 1
 						id: "gtceu:prospector.hv"
@@ -96,7 +108,7 @@
 				}
 				{
 					count: 4
-					id: "3316656A4E9DA8BF"
+					id: "0DC73E1391999FDA"
 					item: {
 						Count: 1
 						id: "gtceu:diamond_mining_hammer"
@@ -122,7 +134,7 @@
 					type: "item"
 				}
 				{
-					id: "19598A860287E726"
+					id: "6950A966C6315DAD"
 					item: {
 						Count: 1
 						id: "gtceu:diamond_axe"
@@ -144,15 +156,15 @@
 					type: "item"
 				}
 				{
-					auto: "no_toast"
+					auto: "invisible"
 					icon: "enderio:cake_base"
-					id: "612FEB595285D353"
-					title: "&6Infinite Cakes!"
+					id: "4F72726894DCE426"
+					title: "&6Inifinite Cakes!"
 					type: "custom"
 				}
 				{
 					auto: "invisible"
-					id: "75FD5BC7147B8397"
+					id: "23D6F53E5E9AB20D"
 					ignore_reward_blocking: true
 					stage: "intro_complete"
 					type: "gamestage"
@@ -174,9 +186,11 @@
 			can_repeat: true
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"In &9Monifactory&r, all dimensional transit is done through the power of &bTelePastries&r. No Portals here!"
+				"In &9Monifactory&r, all dimensional transit is done through the power of &6TelePastries&r. No Portals here!"
 				""
-				"This quest is repeatable and gives you a free cake to the &6Void World&r or &2Overworld&r every hour. You can also refill your cakes with the items indicated in their tooltips."
+				"This quest is repeatable and gives you a free cake to the &2Overworld&r, &3Lost City&r, or &7Void World&r every hour. You can also refill your cakes with the items indicated in their tooltips."
+				""
+				"&cDon't forget to have a way to get back!&r If you do, click on the Emergency Items heart on the right side of the quest book screen."
 			]
 			disable_toast: true
 			icon: "telepastries:overworld_cake"
@@ -188,7 +202,7 @@
 				table_id: 7942624913962637807L
 				type: "choice"
 			}]
-			subtitle: "Cakes are magical!"
+			subtitle: "Cakes are quantum objects!"
 			tags: ["moni_cakequest"]
 			tasks: [
 				{
@@ -1620,63 +1634,6 @@
 			y: 15.5d
 		}
 		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: [
-				"These devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn't make them from nothing."
-				""
-				"Also important to note that it won't work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines)."
-				""
-				"A very cool feature of this mod is how you can &9shift-right click&r an &ainventory&r with any gadget (if you are using a &6Copy-Paste Gadget&r to do this, it must be on &ePaste&r mode) and the gadget will &9pull items from the inventory&r, `connecting' the gadget to the inventory."
-				""
-				"For example, if you shift-right click a chest full of cobblestone, the gadget will use cobblestone from that chest to place blocks."
-				""
-				"By default, the config GUI is bound to &6G&r."
-			]
-			icon: "buildinggadgets2:gadget_building"
-			id: "5F9C7FB40AD2640B"
-			subtitle: "This pack has &bBuilding Gadgets&r."
-			tasks: [
-				{
-					id: "449B547CDED79AE3"
-					item: "buildinggadgets2:gadget_building"
-					type: "item"
-				}
-				{
-					id: "30A321B32CDAF437"
-					item: "buildinggadgets2:gadget_exchanging"
-					type: "item"
-				}
-				{
-					id: "4763F5F3C0771FFA"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_copy_paste"
-						tag: { }
-					}
-					type: "item"
-				}
-				{
-					id: "284A671CC5192B50"
-					item: {
-						Count: 1
-						id: "buildinggadgets2:gadget_cut_paste"
-						tag: {
-							pastereplace: 1b
-						}
-					}
-					type: "item"
-				}
-				{
-					id: "51485964CFCB26B9"
-					item: "buildinggadgets2:gadget_destruction"
-					type: "item"
-				}
-			]
-			title: "Inspector Gadget"
-			x: -2.75d
-			y: 16.75d
-		}
-		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
 				"&6Sulfur Ore&r is the only source of &6Sulfur Dust&r that's currently available to you."
@@ -1779,34 +1736,6 @@
 			title: "&9Flux Capacitors"
 			x: -2.75d
 			y: 15.5d
-		}
-		{
-			dependencies: ["06E9B9DDDB245F38"]
-			description: ["This relatively inexpensive item will suck nearby items into your inventory."]
-			id: "39394D5596FF8BC8"
-			rewards: [{
-				id: "20D8F149F414F950"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			tasks: [{
-				id: "36817E3C33876798"
-				item: {
-					Count: 1
-					id: "enderio:electromagnet"
-					tag: {
-						Energy: {
-							EnergyStored: 0
-							MaxEnergyStored: 100000
-							MaxEnergyUse: 100000
-						}
-					}
-				}
-				type: "item"
-			}]
-			title: "Electromagnet"
-			x: -1.5d
-			y: 16.75d
 		}
 		{
 			dependencies: ["297B523B6C503957"]
@@ -1998,63 +1927,24 @@
 		{
 			dependencies: ["66FCC26399376B55"]
 			description: [
-				"Whether or not you (or your server admin) picked the default &bLost Cities&r overworld type, you have the option of teleporting yourself to the &eLost Cities Dimension&r. This is useful if you like other world types but want to still be able to explore cities for things like &eloot and spawners&r."
+				"You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
 				""
-				"To create a portal, you must place a &aBed&r down on two &6Blocks of Diamond&r. Then, you surround the bed with any kind of &eMonster Skulls&r. Sleep in this bed and you will be teleported there."
-				""
-				"&cDon't forget to have a way to get back!&r You can use the &e/sethome&r command to register where your house is, and &e/home&r to return to it. If you supply a name (default \"home\") then you can register and go to multiple locations. There are some &erestrictions&r on this though: &eit takes a few seconds of standing still to activate&r and there is a &ecooldown&r between uses."
-				""
-				"Later on you'll have other means of teleportation."
-				""
-				"Monster Skulls might take a little while to get if you're playing in &ePeaceful&r&r. &6Skeleton Skulls&r would be the way to go in that case."
+				"Later on you'll discover other means of teleportation."
 			]
 			disable_toast: true
 			hide_dependency_lines: true
 			icon: "minecraft:purple_bed"
 			id: "33195ED6D7008E5F"
 			optional: true
-			rewards: [{
-				id: "3DE844F3B9CF2903"
-				item: "kubejs:moni_nickel"
-				type: "item"
+			subtitle: "Make returning home easy!"
+			tasks: [{
+				id: "31CCE49A4CD8809A"
+				title: "Checkmark"
+				type: "checkmark"
 			}]
-			subtitle: "Free materials!"
-			tasks: [
-				{
-					count: 10L
-					id: "0221039A21A1C266"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "forge:heads"
-						}
-					}
-					title: "Any Heads"
-					type: "item"
-				}
-				{
-					id: "0E70B83A51A0ADEC"
-					item: {
-						Count: 1
-						id: "itemfilters:tag"
-						tag: {
-							value: "minecraft:beds"
-						}
-					}
-					title: "Any Bed"
-					type: "item"
-				}
-				{
-					count: 2L
-					id: "0DA16402F8B9CC9B"
-					item: "minecraft:diamond_block"
-					type: "item"
-				}
-			]
-			title: "Lost Cities and Registering Homes"
-			x: -10.5d
-			y: 7.0d
+			title: "Registering Homes"
+			x: -9.75d
+			y: 1.0d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2101,7 +1991,7 @@
 			}]
 			title: "&2Processing Lines Tab"
 			x: -10.5d
-			y: 8.5d
+			y: 7.0d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]
@@ -2149,7 +2039,7 @@
 			}]
 			title: "Multiblock Machine Previews"
 			x: -10.5d
-			y: 10.0d
+			y: 8.5d
 		}
 		{
 			dependencies: ["66FCC26399376B55"]

--- a/config/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config/ftbquests/quests/chapters/the_beginning.snbt
@@ -1908,6 +1908,34 @@
 			x: 4.517857142857139d
 			y: 1.4285714285714306d
 		}
+		{
+			dependencies: ["47094A5717952699"]
+			description: ["This relatively inexpensive item will suck nearby items into your inventory."]
+			id: "39394D5596FF8BC8"
+			rewards: [{
+				id: "20D8F149F414F950"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			tasks: [{
+				id: "36817E3C33876798"
+				item: {
+					Count: 1
+					id: "enderio:electromagnet"
+					tag: {
+						Energy: {
+							EnergyStored: 0
+							MaxEnergyStored: 100000
+							MaxEnergyUse: 100000
+						}
+					}
+				}
+				type: "item"
+			}]
+			title: "Electromagnet"
+			x: -2.75d
+			y: -6.0d
+		}
 	]
 	title: "The Beginning"
 }

--- a/config/ftbquests/quests/data.snbt
+++ b/config/ftbquests/quests/data.snbt
@@ -9,6 +9,7 @@
 	drop_loot_crates: false
 	emergency_items: [
 		{ Count: 1, id: "telepastries:overworld_cake" }
+		{ Count: 1, id: "telepastries:lost_city_cake" }
 		{ Count: 1, id: "telepastries:custom_cake" }
 	]
 	emergency_items_cooldown: 300

--- a/config/ftbquests/quests/reward_tables/cakes.snbt
+++ b/config/ftbquests/quests/reward_tables/cakes.snbt
@@ -4,6 +4,7 @@
 	order_index: 0
 	rewards: [
 		{ item: "telepastries:overworld_cake" }
+		{ item: "telepastries:lost_city_cake" }
 		{ item: "telepastries:custom_cake" }
 	]
 	title: "Cakes"

--- a/config/telepastries-common.toml
+++ b/config/telepastries-common.toml
@@ -42,7 +42,7 @@
 	#Defines if the Lost Cities Cake gets partly consumed when eaten [default: true]
 	consumeLostCitiesCake = true
 	#Set the refill items used by the Lost Cities Cake (Only change if you know what you're doing) [modid:itemname]
-	lostCitiesCakeRefillItem = ["minecraft:bed"]
+	lostCitiesCakeRefillItem = ["minecraft:diamond"]
 
 #Custom Cake settings
 [CustomCake]

--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -53,7 +53,7 @@ JEIEvents.hideItems(event => {
     event.hide('enderio:basic_fluid_filter')
 
     //TelePastries
-    event.hide(['telepastries:lost_city_cake', 'telepastries:custom_cake2', 'telepastries:custom_cake3', 'telepastries:twilight_cake'])
+    event.hide(['telepastries:custom_cake2', 'telepastries:custom_cake3', 'telepastries:twilight_cake'])
 
     //Jetpacks
     event.hide([Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:dark_soularium"}').strongNBT(), Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:fluxed"}').strongNBT(), 'ironjetpacks:capacitor', Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:creative"}').strongNBT()])

--- a/kubejs/server_scripts/mods/TelePastries.js
+++ b/kubejs/server_scripts/mods/TelePastries.js
@@ -1,8 +1,8 @@
 ServerEvents.recipes(event => {
 
-    event.remove({ output: ["telepastries:nether_cake", 'telepastries:overworld_cake', 'telepastries:end_cake'] })
+    event.remove({ output: ["telepastries:nether_cake", 'telepastries:overworld_cake', 'telepastries:lost_city_cake', 'telepastries:end_cake'] })
 
-    // cake base
+    // Cake Base
     event.shaped(
         'enderio:cake_base', [
         'SMS',
@@ -29,9 +29,20 @@ ServerEvents.recipes(event => {
         K: 'gtceu:gold_dust'
     }
     )
+	
+    event.shaped(
+        'telepastries:lost_city_cake', [
+        'NNN',
+        'SBS',
+        'SSS'
+    ], {
+        N: 'minecraft:redstone',
+        B: "enderio:cake_base",
+        S: 'minecraft:diamond',
+    }
+    )
 
     //Void Cake
-
     event.shaped(
         'telepastries:custom_cake', [
         'ABC',

--- a/kubejs/server_scripts/quest_scripts.js
+++ b/kubejs/server_scripts/quest_scripts.js
@@ -1,5 +1,5 @@
 FTBQuestsEvents.customReward('24FE5D5A412EA666', event => {
-	// auto complete when you unlock genisis (free cake custom trigger)
+	// auto complete when you unlock genesis (free cake custom trigger)
 	FTBQuests.getServerDataFromPlayer(event.getPlayer()).complete('138B92A597D63C12')
 })
 


### PR DESCRIPTION
Currently it is not possible for peaceful players to complete Genesis quests in Genesis alone. To fix this entirely:

Universal for all modes: Normal, Hard, and Harder:
- Added craftable Lost City Cake recipe for transport to the Lost City. Refill requires diamond.
- Updated Emergency Items, and rechargeables to include Lost City Cake for Dimensional Transport.
- Updated quest descriptions for Genesis, and Cake Based Dimensional Transit accordingly.
- Renamed Lost Cities and Registering Homes to just Registering Homes and removed bed requirement and reward, as Lost City access is now  accessible from the start via Lost City Cake. 
- Moved Electromagnet to The Beginning with Autoclave requirement since current recipe demands it.
- Moved Inspector Gadget to Early Game with LV Emitter and HV Power requirements since current recipes demand it.

Tested all the above without issues in standard, normal, hard, and harder.