### PR TITLE
Removed old Storage Drawer Keys from toolbelt config.

### DIFF
--- a/defaultconfigs/toolbelt-server.toml
+++ b/defaultconfigs/toolbelt-server.toml
@@ -1,7 +1,7 @@
 
 [general]
 	#List of items to force-allow placing in the belt. Takes precedence over blacklist.
-	whitelist = ['storagedrawers:drawer_key', 'storagedrawers:quantify_key', 'storagedrawers:shroud_key']
+	whitelist = []
 	#List of items to disallow from placing in the belt. (whitelist takes precedence)
 	blacklist = ["thermal:satchel", "toolbelt:belt", "minecraft:shulker_box", "minecraft:white_shulker_box", "minecraft:orange_shulker_box", "minecraft:magenta_shulker_box", "minecraft:light_blue_shulker_box", "minecraft:yellow_shulker_box", "minecraft:lime_shulker_box", "minecraft:pink_shulker_box", "minecraft:gray_shulker_box", "minecraft:light_gray_shulker_box", "minecraft:cyan_shulker_box", "minecraft:purple_shulker_box", "minecraft:blue_shulker_box", "minecraft:brown_shulker_box", "minecraft:green_shulker_box", "minecraft:red_shulker_box", "minecraft:black_shulker_box"]
 


### PR DESCRIPTION
Since Storage Drawers no longer exists these are useless and shows a tiny error when left in.

Hope I'm doing this pull request stuff right haha. 