### PR TITLE
chore: revert gregification of most building gadgets

### DIFF
--- a/kubejs/server_scripts/mods/buildinggadgets2.js
+++ b/kubejs/server_scripts/mods/buildinggadgets2.js
@@ -1,104 +1,19 @@
-ServerEvents.recipes( event => {
-    event.remove({id: /buildinggadgets2/})
-
-    //Template Manager
-    event.shaped(
-        'buildinggadgets2:template_manager', [
-            'PMP',
-            'CGC',
-            'PLP'
-        ], {
-            M: 'minecraft:paper',
-            P: 'gtceu:iron_plate',
-            G: 'gtceu:restonia_gear',
-            C: '#gtceu:circuits/mv',
-            L: '#forge:plates/lapis'
-        }
-    )
-
-    //Gadgets
-    event.shaped(
-        'buildinggadgets2:gadget_building', [
+ServerEvents.recipes(event => {
+    // only hard mode gets a gregified recipe
+    if (isHardMode) {
+        event.remove({ id: 'buildinggadgets2:gadget_exchanging' })
+        event.shaped(
+            'buildinggadgets2:gadget_exchanging', [
             'PE',
             'CM',
             'PB'
         ], {
             M: '#forge:plates/glass',
             P: 'gtceu:iron_plate',
-            E: 'gtceu:lv_emitter',
-            C: '#gtceu:circuits/lv',
+            E: 'gtceu:iv_emitter',
+            C: '#gtceu:circuits/mv',
             B: '#gtceu:batteries/lv'
         }
-    )
-    //Exchanging gadgets use an IV emitter in HM/EM
-    if (isHardMode) {
-        event.shaped(
-            'buildinggadgets2:gadget_exchanging', [
-                'PE',
-                'CM',
-                'PB'
-            ], {
-                M: '#forge:plates/glass',
-                P: 'gtceu:iron_plate',
-                E: 'gtceu:iv_emitter',
-                C: '#gtceu:circuits/mv',
-                B: '#gtceu:batteries/lv'
-            }
-        )
-    } else {
-        event.shaped(
-            'buildinggadgets2:gadget_exchanging', [
-                'PE',
-                'CM',
-                'PB'
-            ], {
-                M: '#forge:plates/glass',
-                P: 'gtceu:iron_plate',
-                E: 'gtceu:mv_emitter',
-                C: '#gtceu:circuits/mv',
-                B: '#gtceu:batteries/lv'
-            }
         )
     }
-    event.shaped(
-        'buildinggadgets2:gadget_copy_paste', [
-            'SE',
-            'CM',
-            'PB'
-        ], {
-            M: '#forge:plates/glass',
-            P: 'gtceu:iron_plate',
-            E: 'gtceu:lv_emitter',
-            S: 'gtceu:lv_sensor',
-            C: '#gtceu:circuits/mv',
-            B: '#gtceu:batteries/mv'
-        }
-    )
-    event.shaped(
-        'buildinggadgets2:gadget_cut_paste', [
-            'SE',
-            'CM',
-            'PB'
-        ], {
-            M: '#forge:plates/glass',
-            P: 'gtceu:steel_plate',
-            E: 'gtceu:lv_emitter',
-            S: 'gtceu:lv_sensor',
-            C: '#gtceu:circuits/lv',
-            B: '#gtceu:batteries/hv'
-        }
-    )
-    event.shaped(
-        'buildinggadgets2:gadget_destruction', [
-            'PE',
-            'CM',
-            'PB'
-        ], {
-            M: '#forge:plates/glass',
-            P: 'gtceu:steel_plate',
-            E: 'gtceu:lv_emitter',
-            C: '#gtceu:circuits/lv',
-            B: '#gtceu:batteries/mv'
-        }
-    )
 })


### PR DESCRIPTION
https://github.com/ThePansmith/Monifactory/issues/787

Reverting gregification of the building gadgets as a follow up to [this conversation](https://github.com/ThePansmith/Monifactory/pull/775#issuecomment-2377632269).  Since EB is back in Moni, there is less of a need to gregificate the building gadget recipes.  With that said, I am leaving the HM recipe modification untouched.