### PR TITLE
fix circuit on dark steel machine hull

### DIFF
--- a/kubejs/server_scripts/mods/HostileNeuralNetworks.js
+++ b/kubejs/server_scripts/mods/HostileNeuralNetworks.js
@@ -59,7 +59,7 @@ ServerEvents.recipes(event => {
         .itemOutputs('kubejs:dark_steel_machine_hull')
         .duration(50)
         .EUt(16)
-				.circuit(8)
+				.circuit(6)
 
     event.shaped(
         'hostilenetworks:sim_chamber', [


### PR DESCRIPTION
gtm changed the circuit on lv casings causing problems with the maintanance hatch changes circuit to 6 because 6 is what casings are on