### PR TITLE
GregTech integration with ProjectRed and recipe adjustments

### DIFF
--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -217,6 +217,12 @@ JEIEvents.hideItems(event => {
     
     // Hides GCYR ores as its not part of GTMaterialRegistry
     event.hide(/gcyr:(!netherrack|endstone).*_ore/)
+
+    // Hide ProjectRed unused items
+    event.hide(['projectred_core:silicon', 'projectred_core:sand_coal_comp', 'projectred_core:red_iron_comp', 'projectred_core:electrotine_iron_comp', 'projectred_core:peridot', 'projectred_core:sapphire', 'projectred_core:ruby', 'projectred_core:electrotine_dust', 'projectred_core:electrotine_generator', 'projectred_core:electrotine_ingot', 'projectred_core:red_ingot', 'projectred_core:sail', 'projectred_core:woven_cloth', 'projectred_core:motor', 'projectred_core:gold_coil', 'projectred_core:iron_coil', 'projectred_core:copper_coil', 'projectred_core:electrotine_silicon_comp', 'projectred_core:electrotine_silicon', 'projectred_core:boule', 'projectred_transmission:low_load_framed_power_wire', 'projectred_core:screwdriver', 'projectred_core:draw_plate', 'projectred_transmission:low_load_power_wire'])      
+
+    // Hide CBMultipart blocks
+    event.hide(/cb_microblock:.*/)
 })
 
 JEIEvents.addItems(event => {

--- a/kubejs/server_scripts/mods/ProjectRed.js
+++ b/kubejs/server_scripts/mods/ProjectRed.js
@@ -1,0 +1,162 @@
+ServerEvents.recipes(event => {
+        /* Remove uncessary recipes */
+        event.remove({ id: 'projectred_core:red_iron_comp' })
+        event.remove({ id: 'projectred_core:red_ingot' })
+        event.remove({ id: 'projectred_core:electrotine_iron_comp' })
+        event.remove({ id: 'projectred_core:electrotine_ingot' })
+        event.remove({ id: 'projectred_core:sand_coal_comp' })
+        event.remove({ id: 'projectred_core:boule' })
+        event.remove({ id: 'projectred_core:silicon' })
+        event.remove({ id: 'projectred_core:draw_plate' })
+        event.remove({ id: 'projectred_core:screwdriver' })
+        event.remove({ id: 'projectred_core:copper_coil' })
+        event.remove({ id: 'projectred_core:iron_coil' })
+        event.remove({ id: 'projectred_core:gold_coil' })
+        event.remove({ id: 'projectred_core:motor' })
+        event.remove({ id: 'projectred_core:woven_cloth' })
+        event.remove({ id: 'projectred_core:sail' })
+        event.remove({ id: 'projectred_core:electrotine_silicon_comp' })
+        event.remove({ id: 'projectred_core:electrotine_silicon' })
+        event.remove({ id: 'projectred_core:electrotine_generator' })
+
+        /* Remove Transmission power cable recipes */
+        event.remove({ id: 'projectred_transmission:low_load_power_wire' })
+        event.remove({ id: 'projectred_transmission:low_load_framed_power_wire' })
+
+        /* Circuit plates using GT cutter and saw */
+        event.remove({ id: 'projectred_core:plate' })
+        event.shaped('2x projectred_core:plate', [
+                ' S ',
+                ' B ',
+                '   '
+        ], {
+                S: '#forge:tools/saws',
+                B: 'minecraft:smooth_stone'
+        })
+
+        event.recipes.gtceu.cutter("projectred_circuit")
+                .itemInputs("minecraft:smooth_stone")
+                .inputFluids(Fluid.of('minecraft:water', 80))
+                .itemOutputs("8x projectred_core:plate")
+                .duration(200)
+                .EUt(32)
+
+        event.recipes.gtceu.cutter("projectred_circuit_distilled")
+                .itemInputs("minecraft:smooth_stone")
+                .inputFluids(Fluid.of('gtceu:distilled_water', 60))
+                .itemOutputs("8x projectred_core:plate")
+                .duration(200)
+                .EUt(32)
+
+        event.recipes.gtceu.cutter("projectred_circuit_lubricant")
+                .itemInputs("minecraft:smooth_stone")
+                .inputFluids(Fluid.of('gtceu:lubricant', 20))
+                .itemOutputs("8x projectred_core:plate")
+                .duration(200)
+                .EUt(32)
+
+        /* Red Alloy Wire */
+        event.remove({ id: 'projectred_transmission:red_alloy_wire' })
+        event.shaped('12x projectred_transmission:red_alloy_wire', [
+                ' R ',
+                ' R ',
+                ' R '
+        ], {
+                R: 'gtceu:red_alloy_single_wire'
+        })
+
+        /* Insulated Red Alloy Wire */
+        const dyeColors = [
+                'white', 'black', 'purple', 'red', 'orange', 'green', 'lime',
+                'blue', 'light_blue', 'pink', 'cyan', 'magenta', 'yellow', 'gray', 'light_gray', 'brown'
+        ];
+        dyeColors.forEach(color => {
+                event.remove({ id: `projectred_transmission:${color}_insulated_wire` });
+        });
+
+        event.shaped('projectred_transmission:black_insulated_wire', [
+                'WR ',
+                '   '
+        ], {
+                W: 'projectred_transmission:red_alloy_wire',
+                R: 'gtceu:rubber_plate'
+        })
+
+        /* Bundled Wire using moar rubba' mate as a second unsulation mimicking multi-core cable instead of String */
+        event.remove({ id: 'projectred_transmission:neutral_bundled_wire' })
+        event.shaped('projectred_transmission:neutral_bundled_wire', [
+                'SWS',
+                'WWW',
+                'SWS'
+        ], {
+                W: '#projectred_transmission:insulated_wire',
+                S: 'gtceu:rubber_plate'
+        })
+
+        /* Insulated Wire & Bundled Wire using Assembly Machine */
+        event.recipes.gtceu.assembler("projectred_black_insulated_wire_rubber")
+                .itemInputs("1x projectred_transmission:red_alloy_wire")
+                .inputFluids(Fluid.of('gtceu:rubber', 144))
+                .itemOutputs("1x projectred_transmission:black_insulated_wire")
+                .duration(50)
+                .EUt(7)
+
+        event.recipes.gtceu.assembler("projectred_black_insulated_wire_styrene_rubber")
+                .itemInputs("1x projectred_transmission:red_alloy_wire")
+                .inputFluids(Fluid.of('gtceu:styrene_butadiene_rubber', 36))
+                .itemOutputs("1x projectred_transmission:black_insulated_wire")
+                .duration(50)
+                .EUt(7)
+
+        event.recipes.gtceu.assembler("projectred_black_insulated_wire_silicone_rubber")
+                .itemInputs("1x projectred_transmission:red_alloy_wire")
+                .inputFluids(Fluid.of('gtceu:silicone_rubber', 72))
+                .itemOutputs("1x projectred_transmission:black_insulated_wire")
+                .duration(50)
+                .EUt(7)
+
+        event.recipes.gtceu.assembler("projectred_bundled_wire_rubber")
+                .itemInputs("5x projectred_transmission:red_alloy_wire")
+                .inputFluids(Fluid.of('gtceu:rubber', 432))
+                .itemOutputs("1x projectred_transmission:neutral_bundled_wire")
+                .duration(50)
+                .EUt(7)
+                .circuit(9)
+
+        event.recipes.gtceu.assembler("projectred_bundled_wire_styrene_rubber")
+                .itemInputs("5x projectred_transmission:red_alloy_wire")
+                .inputFluids(Fluid.of('gtceu:styrene_butadiene_rubber', 144))
+                .itemOutputs("1x projectred_transmission:neutral_bundled_wire")
+                .duration(50)
+                .EUt(7)
+                .circuit(9)
+
+        event.recipes.gtceu.assembler("projectred_bundled_wire_silicone_rubber")
+                .itemInputs("5x projectred_transmission:red_alloy_wire")
+                .inputFluids(Fluid.of('gtceu:silicone_rubber', 288))
+                .itemOutputs("1x projectred_transmission:neutral_bundled_wire")
+                .duration(50)
+                .EUt(7)
+                .circuit(9)
+
+        /* Silicon compounds using GT silicon wafers */
+        event.remove({ id: 'projectred_core:red_silicon_comp' })
+        event.shaped('projectred_core:red_silicon_comp', [
+                'SSS',
+                'SCS',
+                'SSS'
+        ], {
+                C: 'gtceu:silicon_wafer',
+                S: 'minecraft:redstone'
+        })
+
+        event.remove({ id: 'projectred_core:glow_silicon_comp' })
+        event.shaped('projectred_core:glow_silicon_comp', [
+                'SSS',
+                'SCS',
+                'SSS'
+        ], {
+                C: 'gtceu:silicon_wafer',
+                S: 'minecraft:glowstone_dust'
+        })
+})

--- a/manifest.json
+++ b/manifest.json
@@ -979,6 +979,31 @@
       "fileID": 5757044,
       "projectID": 1096531,
       "required": true
+    },
+    {
+      "fileID": 5311521,
+      "projectID": 258426,
+      "required": true
+    },
+    {
+      "fileID": 5753868,
+      "projectID": 242818,
+      "required": true
+    },
+    {
+      "fileID": 5615679,
+      "projectID": 228702,
+      "required": true
+    },
+    {
+      "fileID": 5615685,
+      "projectID": 478939,
+      "required": true
+    },
+    {
+      "fileID": 5615684,
+      "projectID": 229045,
+      "required": true
     }
   ]
 }


### PR DESCRIPTION
Feature PR for #665 

Right now there's no nice way of piping redstone around for GT covers to automate machines and more importantly power. EIO conduits exist but they currently do not connect to GT covers. ProjectRed adds Red Alloy Wire that is placeable on any block face and includes bundled cables that allow easy multi-signal automation.

This PR adds ProjectRed to the pack with Gregified recipes at LV level to allow players to automate their factory however they see fit either just using Red Alloy Wire instead of redstone, using the bundled cables or creating more complicated logic setups to fit how they want to build their factory. 

- Implemented JEI/EMI hiding for unused ProjectRed items
- Updated ProjectRed recipes to use GregTech materials
- Added ProjectRed mods and requirements to the manifest

Some images of the greg'd recipes.
![image](https://github.com/user-attachments/assets/5cc75087-4226-48d6-a9f3-9b90669c2343)
![image](https://github.com/user-attachments/assets/360dc6e8-b0ad-4f2c-b44c-183cc560128f)
![image](https://github.com/user-attachments/assets/47320d2e-1abb-401e-8f74-c4a3ada3bd9b)
![image](https://github.com/user-attachments/assets/cc8c4f2f-9cfe-4e49-90df-24aa8f398c03)
![image](https://github.com/user-attachments/assets/d1e4c43c-cbf3-4f0d-b1d5-c2f28b3aa024)
![image](https://github.com/user-attachments/assets/925e351f-5c56-4cdd-a189-25111ac2c673)
![image](https://github.com/user-attachments/assets/0af3f761-e445-4f7a-8534-6305d4ed5909)

