### PR TITLE
Fix reference to Snad for RecipeRemoval

### DIFF
--- a/kubejs/server_scripts/Remove_Recipes.js
+++ b/kubejs/server_scripts/Remove_Recipes.js
@@ -2,7 +2,7 @@ ServerEvents.recipes(event => {
 
 
     // Snad
-    event.remove('snad:snadrecipe')
+    event.remove('snad:snad')
     event.remove('snad:red_snad')
     
     //Extended Crafting


### PR DESCRIPTION
I am not certain of the intent, but it looks like this might just be a small mistake. I believe this was meant to remove the easy version of the Snad recipe.