### PR TITLE
Fix Recipe Errors in Create Deco Compatibility

### DIFF
--- a/kubejs/server_scripts/mods/optionalCompats/createdeco.js
+++ b/kubejs/server_scripts/mods/optionalCompats/createdeco.js
@@ -233,7 +233,7 @@ if (Platform.isLoaded('createdeco')) {
               event.recipes.gtceu.assembler('createdeco:red_' + decorOutput + '_lamp')
               .itemInputs('2x ' + ingot)
               .itemInputs('minecraft:redstone_torch')
-              .itemOutputs('createdeco:yellow_' + decorOutput + '_lamp')
+              .itemOutputs('createdeco:red_' + decorOutput + '_lamp')
               .duration(300)
               .EUt(7)
               event.shaped('createdeco:green_' + decorOutput + '_lamp', [
@@ -293,7 +293,7 @@ if (Platform.isLoaded('createdeco')) {
         decor('createdeco:andesite_sheet', 'create:andesite_alloy', 'createdeco:andesite_bars', 'andesite', '#forge:storage_blocks/andesite_alloy')
         decor('#forge:plates/copper', '#forge:ingots/copper', 'createdeco:copper_bars', 'copper', '#forge:storage_blocks/copper')
         decor('#forge:plates/iron', '#forge:ingots/iron', 'minecraft:iron_bars', 'iron', '#forge:storage_blocks/iron')
-        decor('createdeco:industrial_iron_sheet', 'createdeco:industrial_iron_ingot', 'createdeco:industrial_iron_bars', 'industrial_iron', '#forge:storage_blocks/industrial_iron')
+        decor('createdeco:industrial_iron_sheet', 'createdeco:industrial_iron_ingot', 'createdeco:industrial_iron_bars', 'industrial_iron', 'create:industrial_iron_block')
         decor('#forge:plates/brass', '#forge:ingots/brass', 'createdeco:brass_bars', 'brass', '#forge:storage_blocks/brass')
         decor('#forge:plates/zinc', '#forge:ingots/zinc', 'createdeco:zinc_bars', 'zinc', '#forge:storage_blocks/zinc')
 


### PR DESCRIPTION
There is a couple errors with Create Deco compatibility that I have noticed and created this pull request to fix.

The following fixes are:
- Fixed the Red Caged Lamp Assembler Recipes actually output the red lamp instead of the yellow lamp. ![Outputs Properly Now](https://github.com/user-attachments/assets/a0456026-7e2f-4988-ad8c-fce1ecd02d66)
- Fixed Industrial Iron's decor call to use the Industrial Iron Block instead of an empty forge tag. ![No longer uses a forge tag](https://github.com/user-attachments/assets/5f1af666-35a7-4850-bb1c-c3ae7f045704)

I have not noticed any other errors in the config file and everything else seems fine.

