### PR TITLE
Update Steam Foundry Quest for Harder Mode.

### DIFF
--- a/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
@@ -1136,7 +1136,7 @@
 					type: "item"
 				}
 				{
-					count: 9L
+					count: 8L
 					id: "6D33F60793938D3C"
 					item: "gtceu:bronze_firebox_casing"
 					type: "item"


### PR DESCRIPTION
You only need 8 Fireboxes not 9 as the 9th one is the Steam Input Hatch.