### PR TITLE
Fixed typo in Rocket Fuel quest

### DIFF
--- a/config/ftbquests/quests/chapters/into_the_microverse.snbt
+++ b/config/ftbquests/quests/chapters/into_the_microverse.snbt
@@ -661,7 +661,7 @@
 		}
 		{
 			dependencies: ["5E2489DE2E840738"]
-			description: ["Mix &9Oxygen&r and &91,1-Dimethylhydrazine&r together to make &9Rocket Fuel&r."]
+			description: ["Mix &9Oxygen&r and &9Dimethylhydrazine&r together to make &9Rocket Fuel&r."]
 			id: "24415A26E5A0FD72"
 			rewards: [{
 				count: 2


### PR DESCRIPTION
1,1-Dimethylhydrazine is called Dimethylhydrazine in Monifactory