### PR TITLE
Quest Chapters

### DIFF
--- a/config-overrides/harder/ftbquests/quests/chapter_groups.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapter_groups.snbt
@@ -1,0 +1,6 @@
+{
+	chapter_groups: [
+		{ id: "5CF31559080744DB", title: "&9Main Progression&9" }
+		{ id: "6AA88557518775D7", title: "&3Guides \\& Help&3" }
+	]
+}

--- a/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapters/genesis.snbt
@@ -3,10 +3,10 @@
 	default_quest_shape: ""
 	disable_toast: true
 	filename: "genesis"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:lv_steam_turbine"
 	id: "0654B76C306712BE"
-	order_index: 1
+	order_index: 0
 	quest_links: [
 		{
 			id: "7FB8EA3900C4D89D"
@@ -2119,7 +2119,7 @@
 				id: "7455123A87C45A7E"
 				item: "kubejs:moni_nickel"
 				type: "item"
-			}]	
+			}]
 			subtitle: "Copying your furnace's settings"
 			tasks: [{
 				id: "4FF735E089FC1BA8"
@@ -2206,5 +2206,5 @@
 			y: 10.0d
 		}
 	]
-	title: "An Even Harder Genesis"
+	title: "Genesis - Expert"
 }

--- a/config-overrides/harder/ftbquests/quests/chapters/the_factory.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapters/the_factory.snbt
@@ -2,7 +2,7 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	disable_toast: true
-	filename: "the_beginning"
+	filename: "the_factory"
 	group: ""
 	icon: "gtceu:electric_blast_furnace"
 	id: "2763DAD954E0EED8"
@@ -1935,5 +1935,5 @@
 			y: 9.375d
 		}
 	]
-	title: "The Beginning"
+	title: "The Factory"
 }

--- a/config-overrides/harder/ftbquests/quests/chapters/the_factory.snbt
+++ b/config-overrides/harder/ftbquests/quests/chapters/the_factory.snbt
@@ -3,10 +3,10 @@
 	default_quest_shape: ""
 	disable_toast: true
 	filename: "the_factory"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:electric_blast_furnace"
 	id: "2763DAD954E0EED8"
-	order_index: 2
+	order_index: 1
 	quest_links: [
 		{
 			id: "5B0F1DA574E0A141"
@@ -1870,7 +1870,7 @@
 			tasks: [{
 				id: "725D5F61518AB7EE"
 				item: {
-					Count: 1b
+					Count: 1
 					id: "itemfilters:or"
 					tag: {
 						items: [

--- a/config-overrides/hardmode/ftbquests/quests/chapter_groups.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapter_groups.snbt
@@ -1,3 +1,6 @@
 {
-	chapter_groups: [ ]
+	chapter_groups: [
+		{ id: "5CF31559080744DB", title: "&9Main Progression&9" }
+		{ id: "6AA88557518775D7", title: "&3Guides \\& Help&3" }
+	]
 }

--- a/config-overrides/hardmode/ftbquests/quests/chapters/end_game.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/end_game.snbt
@@ -3,10 +3,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "end_game"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "kubejs:monic_processor_mainframe"
 	id: "2BEB72BC6C6FB4E9"
-	order_index: 11
+	order_index: 5
 	quest_links: [
 		{
 			id: "54018A95BECC356C"

--- a/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
@@ -3,10 +3,10 @@
 	default_quest_shape: ""
 	disable_toast: true
 	filename: "genesis"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:lp_steam_alloy_smelter"
 	id: "0654B76C306712BE"
-	order_index: 1
+	order_index: 0
 	quest_links: [
 		{
 			id: "7FB8EA3900C4D89D"
@@ -2236,7 +2236,7 @@
 				id: "7455123A87C45A7E"
 				item: "kubejs:moni_nickel"
 				type: "item"
-			}]	
+			}]
 			subtitle: "Copying your furnace's settings"
 			tasks: [{
 				id: "4FF735E089FC1BA8"
@@ -2284,5 +2284,5 @@
 			y: 10.0d
 		}
 	]
-	title: "A Harder Genesis"
+	title: "Genesis - Hard"
 }

--- a/config-overrides/hardmode/ftbquests/quests/chapters/late_game.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/late_game.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "late_game"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:wetware_processor_computer"
 	id: "58ABB361EA301019"
-	order_index: 8
+	order_index: 4
 	quest_links: [
 		{
 			id: "5522298B1FC30B2B"

--- a/config-overrides/hardmode/ftbquests/quests/chapters/simulating_resources.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/simulating_resources.snbt
@@ -3,10 +3,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "simulating_resources"
-	group: ""
+	group: "6AA88557518775D7"
 	icon: "hostilenetworks:sim_chamber"
 	id: "6D8C988EFB3F7437"
-	order_index: 4
+	order_index: 2
 	quest_links: [
 		{
 			id: "1344E3300C29A4CF"
@@ -21,13 +21,6 @@
 			shape: "hexagon"
 			x: 1.5d
 			y: -1.0d
-		}
-		{
-			id: "6EFDF0495132F8EC"
-			linked_quest: "715BC5C7DAC53B7B"
-			shape: "hexagon"
-			x: -1.5d
-			y: -3.5d
 		}
 	]
 	quests: [

--- a/config-overrides/hardmode/ftbquests/quests/chapters/the_factory.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/the_factory.snbt
@@ -3,10 +3,10 @@
 	default_quest_shape: ""
 	disable_toast: true
 	filename: "the_factory"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:electric_blast_furnace"
 	id: "2763DAD954E0EED8"
-	order_index: 2
+	order_index: 1
 	quest_links: [
 		{
 			id: "5B0F1DA574E0A141"
@@ -1924,7 +1924,7 @@
 			tasks: [{
 				id: "725D5F61518AB7EE"
 				item: {
-					Count: 1b
+					Count: 1
 					id: "itemfilters:or"
 					tag: {
 						items: [

--- a/config-overrides/hardmode/ftbquests/quests/chapters/the_factory.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/the_factory.snbt
@@ -2,7 +2,7 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	disable_toast: true
-	filename: "the_beginning"
+	filename: "the_factory"
 	group: ""
 	icon: "gtceu:electric_blast_furnace"
 	id: "2763DAD954E0EED8"
@@ -61,7 +61,7 @@
 				""
 				"&2If the machine sounds start to get on your nerves, you can mute GT machines with a GT Hammer, &9or mute the sound entirely in the ESM menu, accessable from your inventory."
 			]
-			icon: "gtceu:lv_wiremill"
+			icon: "gtceu:lv_electric_motor"
 			id: "62BBD1F6767A4D90"
 			rewards: [{
 				count: 2
@@ -513,6 +513,52 @@
 			y: -6.0d
 		}
 		{
+			dependencies: [
+				"47094A5717952699"
+				"273F3F8DD6A3DCC5"
+			]
+			description: [
+				"This pack has &aSnad&r, which is simply a sand-like block that instantly grows sugar cane/cactus on top of it when it receives either a block update or a redstone update."
+				""
+				"The sugar cane it produces can be used as a fuel for your dynamos, and later you can even brew it for &9Biomass&r."
+				""
+				"This quest calls for a &aRedstone Clock&r, but there are other ways to make snad grow sugar cane even faster (like a vanilla observer clock pointing into the Snad). Make sure to set the timer to pulse as fast as possible."
+				""
+				"To collect the sugar cane, you can use a piston and an observer."
+				""
+				"For now, a &3Vacuum Chest&r should help keep the floor clean, and causes less lag than Hoppers. A &aVoid Upgrade&r in a &6Storage Drawer&r will automatically delete any items that overflow the drawer's capacity, so it's a good way to ensure you don't crash your server from accumulating a massive sugar cane pile before safer block breakers are available to you."
+			]
+			icon: "snad:snad"
+			id: "529D50CE814AF449"
+			shape: "hexagon"
+			subtitle: "Yes, Snad."
+			tasks: [
+				{
+					id: "77ADD3B3DA61DC55"
+					item: "snad:snad"
+					type: "item"
+				}
+				{
+					id: "719FAF0F70FA25E5"
+					item: "enderio:vacuum_chest"
+					type: "item"
+				}
+				{
+					id: "2DCBDFF5EB0F7CD9"
+					item: "redstone_clock:redstone_clock"
+					type: "item"
+				}
+				{
+					id: "3DBB91C93688C4FC"
+					item: "functionalstorage:void_upgrade"
+					type: "item"
+				}
+			]
+			title: "Snad"
+			x: -4.5d
+			y: -9.5d
+		}
+		{
 			dependencies: ["5301E546BAA69844"]
 			description: [
 				"&aMolds&r are used in a &3Fluid Solidifier&r or &3Alloy Smelter&r to form materials into specific shapes. These are not consumed or damaged during crafting, so you can leave them in a machine to dedicate it to that shape."
@@ -799,70 +845,6 @@
 			title: "&2Forge Hammer"
 			x: 4.5d
 			y: -7.0d
-		}
-		{
-			dependencies: ["30EBD4E7BBFFEF2C"]
-			description: [
-				"&6&6String&r and &6Coal Dust&r can be baked together into a &6Carbon Mesh&r in an &3Alloy Furnace&r."
-				""
-				"Combine that with &6Pulsating Dust&r to get a &6Pulsating Mesh&r."
-			]
-			icon: "kubejs:pulsating_mesh"
-			id: "645B1DCB3DA7198A"
-			rewards: [{
-				id: "2D12B468C7630D14"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [
-				{
-					id: "3FB8F2F8B1867430"
-					item: "kubejs:pulsating_mesh"
-					type: "item"
-				}
-				{
-					id: "6684545526C4AD44"
-					item: "gtceu:carbon_fiber_mesh"
-					type: "item"
-				}
-			]
-			title: "Pulsating Mesh"
-			x: 6.5d
-			y: -8.0d
-		}
-		{
-			dependencies: [
-				"645B1DCB3DA7198A"
-				"3BD20358F137E7C6"
-			]
-			description: [
-				"A &3Simulation Chamber&r from &bHostile Neural Networks&r (&bHNN&r) allows you to farm mobs in a totally environmentally (and server) friendly way!"
-				""
-				"Simulated mobs can even be used to provide you with many of the basic resources you'll need (such as &6iron, gold, tin, copper, diamonds&r and many more!), through pristine matter."
-				""
-				"Setting up &bHNN&r automation during the early game is &avery important&r as it gives you access to infinite quantities of many resources!"
-				""
-				"&bHNN&r machines are not sided, so you can input and output from any side."
-				""
-				"Yes, you can also use it for generating power... &owith &6Diamonds&r."
-			]
-			id: "715BC5C7DAC53B7B"
-			rewards: [{
-				id: "518DD0C9237B4DBC"
-				item: "kubejs:moni_quarter"
-				type: "item"
-			}]
-			shape: "hexagon"
-			size: 2.0d
-			tasks: [{
-				id: "15A06F5EF4CADA4C"
-				item: "hostilenetworks:sim_chamber"
-				type: "item"
-			}]
-			title: "&9Simulating Mobs"
-			x: 6.5d
-			y: -5.5d
 		}
 		{
 			dependencies: [
@@ -2007,5 +1989,5 @@
 			y: 9.375d
 		}
 	]
-	title: "The Beginning"
+	title: "The Factory"
 }

--- a/config-overrides/normal/ftbquests/quests/chapter_groups.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapter_groups.snbt
@@ -1,3 +1,6 @@
 {
-	chapter_groups: [ ]
+	chapter_groups: [
+		{ id: "5CF31559080744DB", title: "&9Main Progression&9" }
+		{ id: "6AA88557518775D7", title: "&3Guides \\& Help&3" }
+	]
 }

--- a/config-overrides/normal/ftbquests/quests/chapters/end_game.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/end_game.snbt
@@ -3,10 +3,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "end_game"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "kubejs:monic_processor_mainframe"
 	id: "2BEB72BC6C6FB4E9"
-	order_index: 11
+	order_index: 5
 	quest_links: [
 		{
 			id: "54018A95BECC356C"

--- a/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
@@ -3,10 +3,10 @@
 	default_quest_shape: ""
 	disable_toast: true
 	filename: "genesis"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:vacuum_tube"
 	id: "0654B76C306712BE"
-	order_index: 1
+	order_index: 0
 	quest_links: [
 		{
 			id: "7FB8EA3900C4D89D"

--- a/config-overrides/normal/ftbquests/quests/chapters/late_game.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/late_game.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "late_game"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:wetware_processor_computer"
 	id: "58ABB361EA301019"
-	order_index: 8
+	order_index: 4
 	quest_links: [
 		{
 			id: "5522298B1FC30B2B"

--- a/config-overrides/normal/ftbquests/quests/chapters/simulating_resources.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/simulating_resources.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "simulating_resources"
-	group: ""
+	group: "6AA88557518775D7"
 	icon: "hostilenetworks:sim_chamber"
 	id: "6D8C988EFB3F7437"
-	order_index: 4
+	order_index: 2
 	quest_links: [
 		{
 			id: "1344E3300C29A4CF"
@@ -21,20 +21,10 @@
 			x: 1.5d
 			y: -1.0d
 		}
-		{
-			id: "6EFDF0495132F8EC"
-			linked_quest: "715BC5C7DAC53B7B"
-			shape: "hexagon"
-			x: -1.5d
-			y: -3.5d
-		}
 	]
 	quests: [
 		{
-			dependencies: [
-				"6A914B240E1A7BCB"
-				"715BC5C7DAC53B7B"
-			]
+			dependencies: ["6A914B240E1A7BCB"]
 			description: [
 				"Simulating mob kills will occasionally result in &6Pristine Matter&r of that mob's type."
 				""
@@ -133,7 +123,6 @@
 			y: -3.5d
 		}
 		{
-			dependencies: ["715BC5C7DAC53B7B"]
 			description: ["You can combine various items with a &6Model Framework&r for a completed &6Data Model&r that you can run inside the &3Simulation Chamber&r."]
 			icon: "hostilenetworks:blank_data_model"
 			id: "73C6E2724EBEC997"

--- a/config-overrides/normal/ftbquests/quests/chapters/the_factory.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/the_factory.snbt
@@ -3,10 +3,10 @@
 	default_quest_shape: ""
 	disable_toast: true
 	filename: "the_factory"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:electric_blast_furnace"
 	id: "2763DAD954E0EED8"
-	order_index: 2
+	order_index: 1
 	quest_links: [
 		{
 			id: "5B0F1DA574E0A141"
@@ -601,7 +601,7 @@
 		}
 		{
 			dependencies: ["29A487F0BC43AAF9"]
-			description: ["You might want to save your &6Coal Dust&r for circuits and use &6Charcoal Dust&r instead. Later, you can also process either of these dusts, &6Coal Coke Dust&r, &2or Diamond Dust&r into &6Carbon Dust&r, which can be used for Steel and other useful things."]
+			description: ["You might want to save your &6Coal Dust&r for circuits and use &6Charcoal Dust&r instead. Later, you can also process either of these dusts, &6Coal Coke Dust&r, &2or Diamond Dust&r into &6Carbon Dust&r, which can be used for other alloys."]
 			id: "5301E546BAA69844"
 			rewards: [{
 				id: "424A2A6FAB412F69"
@@ -618,13 +618,13 @@
 			}]
 			shape: "hexagon"
 			size: 2.0d
-			subtitle: "You already have &6Steel&r, but it can be made faster in the &3Alloy Smelter&r, at the cost of EU."
+			subtitle: "&9Steel&r is the main material in &9LV&r"
 			tasks: [{
 				id: "17210F38B40BAAD7"
 				item: "gtceu:steel_ingot"
 				type: "item"
 			}]
-			title: "&9Alloying Steel"
+			title: "&9Steel"
 			x: 2.5d
 			y: -3.0d
 		}
@@ -704,29 +704,15 @@
 		}
 		{
 			dependencies: ["29A487F0BC43AAF9"]
-			description: [
-				"Using plain &3Steam Dynamos&f is pretty inefficient."
-				""
-				"It's strongly recommended to upgrade your dynamos into &3steam boilers&f and &3steam turbines&f. The ratio is always &a1:2&r if all Dynamos are equally upgraded."
-				""
-				"This greatly increases the overall efficiency and the amount of power produced, from &a40 RF/t&r per basic steam dynamo to &a320 RF/t&r per set of three augmented dynamos."
-			]
+			description: ["Need &9RF&r to charge your items? Thermal dynamos are disabled in harder mode, but you can plug GTEU straight into a &6Tinker's Workbench&r to power it. Such convinence right?"]
 			icon: "systeams:steam_dynamo"
 			id: "545CCC24D9401794"
-			tasks: [
-				{
-					id: "12315AEA66B77CB2"
-					item: { Count: 2, id: "systeams:stirling_boiler" }
-					type: "item"
-				}
-				{
-					count: 2L
-					id: "76CB286FDDD00D40"
-					item: "systeams:steam_dynamo"
-					type: "item"
-				}
-			]
-			title: "Boilers and Turbines"
+			tasks: [{
+				id: "114F684B1AB140C8"
+				title: "Yay RF!"
+				type: "checkmark"
+			}]
+			title: "Making RF"
 			x: 4.5d
 			y: -1.5d
 		}
@@ -799,70 +785,6 @@
 			title: "&2Forge Hammer"
 			x: 4.5d
 			y: -7.0d
-		}
-		{
-			dependencies: ["30EBD4E7BBFFEF2C"]
-			description: [
-				"&6&6String&r and &6Coal Dust&r can be baked together into a &6Carbon Mesh&r in an &3Alloy Furnace&r."
-				""
-				"Combine that with &6Pulsating Dust&r to get a &6Pulsating Mesh&r."
-			]
-			icon: "kubejs:pulsating_mesh"
-			id: "645B1DCB3DA7198A"
-			rewards: [{
-				id: "2D12B468C7630D14"
-				item: "kubejs:moni_nickel"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [
-				{
-					id: "3FB8F2F8B1867430"
-					item: "kubejs:pulsating_mesh"
-					type: "item"
-				}
-				{
-					id: "6684545526C4AD44"
-					item: "gtceu:carbon_fiber_mesh"
-					type: "item"
-				}
-			]
-			title: "Pulsating Mesh"
-			x: 6.5d
-			y: -8.0d
-		}
-		{
-			dependencies: [
-				"645B1DCB3DA7198A"
-				"3BD20358F137E7C6"
-			]
-			description: [
-				"A &3Simulation Chamber&r from &bHostile Neural Networks&r (&bHNN&r) allows you to farm mobs in a totally environmentally (and server) friendly way!"
-				""
-				"Simulated mobs can even be used to provide you with many of the basic resources you'll need (such as &6iron, gold, tin, copper, diamonds&r and many more!), through pristine matter."
-				""
-				"Setting up &bHNN&r automation during the early game is &avery important&r as it gives you access to infinite quantities of many resources!"
-				""
-				"&bHNN&r machines are not sided, so you can input and output from any side."
-				""
-				"Yes, you can also use it for generating power... &owith &6Diamonds&r."
-			]
-			id: "715BC5C7DAC53B7B"
-			rewards: [{
-				id: "518DD0C9237B4DBC"
-				item: "kubejs:moni_quarter"
-				type: "item"
-			}]
-			shape: "hexagon"
-			size: 2.0d
-			tasks: [{
-				id: "15A06F5EF4CADA4C"
-				item: "hostilenetworks:sim_chamber"
-				type: "item"
-			}]
-			title: "&9Simulating Mobs"
-			x: 6.5d
-			y: -5.5d
 		}
 		{
 			dependencies: [
@@ -1897,7 +1819,7 @@
 				{
 					count: 13L
 					id: "505B1290E3042129"
-					item: { Count: 13, id: "gtceu:steam_machine_casing" }
+					item: "gtceu:steam_machine_casing"
 					type: "item"
 				}
 				{
@@ -1942,7 +1864,7 @@
 			tasks: [{
 				id: "725D5F61518AB7EE"
 				item: {
-					Count: 1b
+					Count: 1
 					id: "itemfilters:or"
 					tag: {
 						items: [

--- a/config-overrides/normal/ftbquests/quests/chapters/the_factory.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/the_factory.snbt
@@ -2,7 +2,7 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	disable_toast: true
-	filename: "the_beginning"
+	filename: "the_factory"
 	group: ""
 	icon: "gtceu:electric_blast_furnace"
 	id: "2763DAD954E0EED8"
@@ -61,7 +61,7 @@
 				""
 				"&2If the machine sounds start to get on your nerves, you can mute GT machines with a GT Hammer, &9or mute the sound entirely in the ESM menu, accessable from your inventory."
 			]
-			icon: "gtceu:lv_electric_motor"
+			icon: "gtceu:lv_wiremill"
 			id: "62BBD1F6767A4D90"
 			rewards: [{
 				count: 2
@@ -513,52 +513,6 @@
 			y: -6.0d
 		}
 		{
-			dependencies: [
-				"47094A5717952699"
-				"273F3F8DD6A3DCC5"
-			]
-			description: [
-				"This pack has &aSnad&r, which is simply a sand-like block that instantly grows sugar cane/cactus on top of it when it receives either a block update or a redstone update."
-				""
-				"The sugar cane it produces can be used as a fuel for your dynamos, and later you can even brew it for &9Biomass&r."
-				""
-				"This quest calls for a &aRedstone Clock&r, but there are other ways to make snad grow sugar cane even faster (like a vanilla observer clock pointing into the Snad). Make sure to set the timer to pulse as fast as possible."
-				""
-				"To collect the sugar cane, you can use a piston and an observer."
-				""
-				"For now, a &3Vacuum Chest&r should help keep the floor clean, and causes less lag than Hoppers. A &aVoid Upgrade&r in a &6Storage Drawer&r will automatically delete any items that overflow the drawer's capacity, so it's a good way to ensure you don't crash your server from accumulating a massive sugar cane pile before safer block breakers are available to you."
-			]
-			icon: "snad:snad"
-			id: "529D50CE814AF449"
-			shape: "hexagon"
-			subtitle: "Yes, Snad."
-			tasks: [
-				{
-					id: "77ADD3B3DA61DC55"
-					item: "snad:snad"
-					type: "item"
-				}
-				{
-					id: "719FAF0F70FA25E5"
-					item: "enderio:vacuum_chest"
-					type: "item"
-				}
-				{
-					id: "2DCBDFF5EB0F7CD9"
-					item: "redstone_clock:redstone_clock"
-					type: "item"
-				}
-				{
-					id: "3DBB91C93688C4FC"
-					item: "functionalstorage:void_upgrade"
-					type: "item"
-				}
-			]
-			title: "Snad"
-			x: -4.5d
-			y: -9.5d
-		}
-		{
 			dependencies: ["5301E546BAA69844"]
 			description: [
 				"&aMolds&r are used in a &3Fluid Solidifier&r or &3Alloy Smelter&r to form materials into specific shapes. These are not consumed or damaged during crafting, so you can leave them in a machine to dedicate it to that shape."
@@ -845,6 +799,70 @@
 			title: "&2Forge Hammer"
 			x: 4.5d
 			y: -7.0d
+		}
+		{
+			dependencies: ["30EBD4E7BBFFEF2C"]
+			description: [
+				"&6&6String&r and &6Coal Dust&r can be baked together into a &6Carbon Mesh&r in an &3Alloy Furnace&r."
+				""
+				"Combine that with &6Pulsating Dust&r to get a &6Pulsating Mesh&r."
+			]
+			icon: "kubejs:pulsating_mesh"
+			id: "645B1DCB3DA7198A"
+			rewards: [{
+				id: "2D12B468C7630D14"
+				item: "kubejs:moni_nickel"
+				type: "item"
+			}]
+			shape: "hexagon"
+			tasks: [
+				{
+					id: "3FB8F2F8B1867430"
+					item: "kubejs:pulsating_mesh"
+					type: "item"
+				}
+				{
+					id: "6684545526C4AD44"
+					item: "gtceu:carbon_fiber_mesh"
+					type: "item"
+				}
+			]
+			title: "Pulsating Mesh"
+			x: 6.5d
+			y: -8.0d
+		}
+		{
+			dependencies: [
+				"645B1DCB3DA7198A"
+				"3BD20358F137E7C6"
+			]
+			description: [
+				"A &3Simulation Chamber&r from &bHostile Neural Networks&r (&bHNN&r) allows you to farm mobs in a totally environmentally (and server) friendly way!"
+				""
+				"Simulated mobs can even be used to provide you with many of the basic resources you'll need (such as &6iron, gold, tin, copper, diamonds&r and many more!), through pristine matter."
+				""
+				"Setting up &bHNN&r automation during the early game is &avery important&r as it gives you access to infinite quantities of many resources!"
+				""
+				"&bHNN&r machines are not sided, so you can input and output from any side."
+				""
+				"Yes, you can also use it for generating power... &owith &6Diamonds&r."
+			]
+			id: "715BC5C7DAC53B7B"
+			rewards: [{
+				id: "518DD0C9237B4DBC"
+				item: "kubejs:moni_quarter"
+				type: "item"
+			}]
+			shape: "hexagon"
+			size: 2.0d
+			tasks: [{
+				id: "15A06F5EF4CADA4C"
+				item: "hostilenetworks:sim_chamber"
+				type: "item"
+			}]
+			title: "&9Simulating Mobs"
+			x: 6.5d
+			y: -5.5d
 		}
 		{
 			dependencies: [
@@ -1989,5 +2007,5 @@
 			y: 9.375d
 		}
 	]
-	title: "The Beginning"
+	title: "The Factory"
 }

--- a/config/ftbquests/quests/chapter_groups.snbt
+++ b/config/ftbquests/quests/chapter_groups.snbt
@@ -1,3 +1,6 @@
 {
-	chapter_groups: [ ]
+	chapter_groups: [
+		{ id: "5CF31559080744DB", title: "&9Main Progression&9" }
+		{ id: "6AA88557518775D7", title: "&3Guides \\& Help&3" }
+	]
 }

--- a/config/ftbquests/quests/chapters/early_game.snbt
+++ b/config/ftbquests/quests/chapters/early_game.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "early_game"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:advanced_integrated_circuit"
 	id: "7041EC01A69404E6"
-	order_index: 5
+	order_index: 2
 	quest_links: [
 		{
 			id: "7471AD069CC1E5EC"

--- a/config/ftbquests/quests/chapters/end_game.snbt
+++ b/config/ftbquests/quests/chapters/end_game.snbt
@@ -3,10 +3,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "end_game"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "kubejs:monic_processor_mainframe"
 	id: "2BEB72BC6C6FB4E9"
-	order_index: 11
+	order_index: 5
 	quest_links: [
 		{
 			id: "54018A95BECC356C"

--- a/config/ftbquests/quests/chapters/fun_with_fusion.snbt
+++ b/config/ftbquests/quests/chapters/fun_with_fusion.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: "hexagon"
 	filename: "fun_with_fusion"
-	group: ""
+	group: "6AA88557518775D7"
 	icon: "gtceu:luv_fusion_reactor"
 	id: "40F7695BE1E65C41"
-	order_index: 9
+	order_index: 3
 	quest_links: [
 		{
 			id: "569E4C671C9A4419"

--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -3,10 +3,10 @@
 	default_quest_shape: ""
 	disable_toast: true
 	filename: "genesis"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:vacuum_tube"
 	id: "0654B76C306712BE"
-	order_index: 1
+	order_index: 0
 	quest_links: [
 		{
 			id: "7FB8EA3900C4D89D"

--- a/config/ftbquests/quests/chapters/into_the_microverse.snbt
+++ b/config/ftbquests/quests/chapters/into_the_microverse.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "into_the_microverse"
-	group: ""
+	group: "6AA88557518775D7"
 	icon: "kubejs:microminer_t1"
 	id: "68F29871402A6B1B"
-	order_index: 6
+	order_index: 5
 	quest_links: [{
 		id: "3494A1A9317B9F3B"
 		linked_quest: "5F688F22A3DB2ADD"

--- a/config/ftbquests/quests/chapters/late_game.snbt
+++ b/config/ftbquests/quests/chapters/late_game.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "late_game"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:wetware_processor_computer"
 	id: "58ABB361EA301019"
-	order_index: 8
+	order_index: 4
 	quest_links: [
 		{
 			id: "5522298B1FC30B2B"

--- a/config/ftbquests/quests/chapters/matterenergy.snbt
+++ b/config/ftbquests/quests/chapters/matterenergy.snbt
@@ -484,7 +484,7 @@
 				""
 				"Also, if you connect a gadget from &bBuilding Gadgets&r to the Pattern Provider, the gadget will pull materials straight from the attached AE2 network, &aNOT&r the Pattern Provider."
 				""
-				"There is information of the Gadgets, and how to connect them to inventories, in the &eInspector Gadget&r quest in &cGenesis&r in &cMatter Energy&r or &cThe Beginning&r."
+				"There is information of the Gadgets, and how to connect them to inventories, in the &eInspector Gadget&r quest in &cGenesis&r in &cMatter Energy&r or &cThe Factory&r."
 			]
 			icon: "ae2:pattern_provider"
 			id: "1040D941027962B1"

--- a/config/ftbquests/quests/chapters/matterenergy.snbt
+++ b/config/ftbquests/quests/chapters/matterenergy.snbt
@@ -3,10 +3,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "matterenergy"
-	group: ""
+	group: "6AA88557518775D7"
 	icon: "ae2:controller"
 	id: "118959024F296F70"
-	order_index: 3
+	order_index: 4
 	quest_links: [
 		{
 			id: "20253D681F399A92"

--- a/config/ftbquests/quests/chapters/mid_game.snbt
+++ b/config/ftbquests/quests/chapters/mid_game.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "mid_game"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "nuclearcraft:plutonium_rtg"
 	id: "7D825FFA33DC85A7"
-	order_index: 7
+	order_index: 3
 	quest_links: [
 		{
 			id: "4864F8F7C33860D9"

--- a/config/ftbquests/quests/chapters/omnium.snbt
+++ b/config/ftbquests/quests/chapters/omnium.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "omnium"
-	group: ""
+	group: "6AA88557518775D7"
 	icon: "kubejs:mote_of_omnium"
 	id: "25FEB9E61EEC1A96"
-	order_index: 10
+	order_index: 1
 	quest_links: [ ]
 	quests: [
 		{

--- a/config/ftbquests/quests/chapters/processing_lines.snbt
+++ b/config/ftbquests/quests/chapters/processing_lines.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "processing_lines"
-	group: ""
+	group: "6AA88557518775D7"
 	icon: "gtceu:lv_chemical_reactor"
 	id: "055C0B43FE14258F"
-	order_index: 12
+	order_index: 0
 	quest_links: [ ]
 	quests: [
 		{

--- a/config/ftbquests/quests/chapters/progression.snbt
+++ b/config/ftbquests/quests/chapters/progression.snbt
@@ -3,10 +3,10 @@
 	default_quest_shape: ""
 	disable_toast: true
 	filename: "progression"
-	group: ""
+	group: "6AA88557518775D7"
 	icon: "minecraft:writable_book"
 	id: "395B849AC6294153"
-	order_index: 13
+	order_index: 6
 	quest_links: [
 		{
 			id: "7D217833035647CD"

--- a/config/ftbquests/quests/chapters/simulating_resources.snbt
+++ b/config/ftbquests/quests/chapters/simulating_resources.snbt
@@ -2,10 +2,10 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "simulating_resources"
-	group: ""
+	group: "6AA88557518775D7"
 	icon: "hostilenetworks:sim_chamber"
 	id: "6D8C988EFB3F7437"
-	order_index: 4
+	order_index: 2
 	quest_links: [
 		{
 			id: "1344E3300C29A4CF"
@@ -21,20 +21,10 @@
 			x: 1.5d
 			y: -1.0d
 		}
-		{
-			id: "6EFDF0495132F8EC"
-			linked_quest: "715BC5C7DAC53B7B"
-			shape: "hexagon"
-			x: -1.5d
-			y: -3.5d
-		}
 	]
 	quests: [
 		{
-			dependencies: [
-				"6A914B240E1A7BCB"
-				"715BC5C7DAC53B7B"
-			]
+			dependencies: ["6A914B240E1A7BCB"]
 			description: [
 				"Simulating mob kills will occasionally result in &6Pristine Matter&r of that mob's type."
 				""
@@ -133,7 +123,6 @@
 			y: -3.5d
 		}
 		{
-			dependencies: ["715BC5C7DAC53B7B"]
 			description: ["You can combine various items with a &6Model Framework&r for a completed &6Data Model&r that you can run inside the &3Simulation Chamber&r."]
 			icon: "hostilenetworks:blank_data_model"
 			id: "73C6E2724EBEC997"

--- a/config/ftbquests/quests/chapters/the_factory.snbt
+++ b/config/ftbquests/quests/chapters/the_factory.snbt
@@ -3,10 +3,10 @@
 	default_quest_shape: ""
 	disable_toast: true
 	filename: "the_factory"
-	group: ""
+	group: "5CF31559080744DB"
 	icon: "gtceu:electric_blast_furnace"
 	id: "2763DAD954E0EED8"
-	order_index: 2
+	order_index: 1
 	quest_links: [
 		{
 			id: "5B0F1DA574E0A141"

--- a/config/ftbquests/quests/chapters/the_factory.snbt
+++ b/config/ftbquests/quests/chapters/the_factory.snbt
@@ -2,7 +2,7 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	disable_toast: true
-	filename: "the_beginning"
+	filename: "the_factory"
 	group: ""
 	icon: "gtceu:electric_blast_furnace"
 	id: "2763DAD954E0EED8"
@@ -1929,5 +1929,5 @@
 			y: 9.375d
 		}
 	]
-	title: "The Beginning"
+	title: "The Factory"
 }


### PR DESCRIPTION
Based on group consensus, this is this most popular rename since Genesis and The Beginning are synonymous and often confusing. So renaming The Beginning to The Factory makes the most sense. File name changed accordingly as well.

Quest Chapters created and quests reordered in logical progression. Additional lines are moved to Guides & Help. Tested in normal, hard, and harder modes. 
![w9gsqJr 1](https://github.com/user-attachments/assets/fdb4f4aa-31b9-4f3b-9d17-9a31adf0bd52)

Genesis is displayed in the Quest Book as:
Normal: Genesis
Hard Mode: Genesis - Hard
Harder Mode: Genesis - Expert