### PR TITLE
Add Advanced Laser Connector and Energy Card, but reasonably gated

### DIFF
--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -190,7 +190,7 @@ JEIEvents.hideItems(event => {
     event.hide('gtceu:steel_machine_casing')
 
     //Laserio
-    event.hide(['laserio:card_energy', 'laserio:laser_connector_advanced', 'laserio:logic_chip_raw', 'laserio:logic_chip'])
+    event.hide(['laserio:logic_chip_raw', 'laserio:logic_chip'])
 
     // PEX
     event.hide(['packagedexcrafting:flux_crafter', 'packagedexcrafting:basic_crafter'])

--- a/kubejs/server_scripts/mods/laserio.js
+++ b/kubejs/server_scripts/mods/laserio.js
@@ -4,29 +4,38 @@ ServerEvents.recipes(event => {
         event.remove({ output: /laserio/ })
         return
     } 
-
-    //LaserIO is not to be used for Energy or wireless transport.
-    event.remove({ output: ['laserio:card_energy', 'laserio:laser_connector_advanced'] })
     
     //Replace Logic chips with circuits.
     event.remove({ output: ['laserio:logic_chip_raw', 'laserio:logic_chip'] })
-    event.replaceInput({ mod: 'laserio', not: [{ id: 'laserio:card_item' }, { id: 'laserio:card_fluid' }, { id: 'laserio:card_redstone' }]}, 'laserio:logic_chip', '#gtceu:circuits/lv')
-    event.replaceInput([{ id: 'laserio:card_item' }, { id: 'laserio:card_fluid' }, { id: 'laserio:card_redstone' }], 'laserio:logic_chip', '#gtceu:circuits/ulv')
+    event.replaceInput({ mod: 'laserio', not: [{ id: 'laserio:card_item' }, { id: 'laserio:card_fluid' }, { id: 'laserio:card_energy' }, { id: 'laserio:card_redstone' }]}, 'laserio:logic_chip', '#gtceu:circuits/lv')
+    event.replaceInput([{ id: 'laserio:card_item' }, { id: 'laserio:card_fluid' }, { id: 'laserio:card_energy' }, { id: 'laserio:card_redstone' }], 'laserio:logic_chip', '#gtceu:circuits/ulv')
 
-    //Laser Connector
-    event.remove({ output: 'laserio:laser_connector' })
-    event.shaped(
-        "4x laserio:laser_connector", [
-        " E ",
-        "RCR",
-        "SSS"
-    ], {
-        S: 'gtceu:steel_plate',
-        E: 'gtceu:lv_emitter',
-        C: '#gtceu:circuits/lv',
-        R: 'gtceu:red_alloy_plate'
-    }
-    )
+    //Gate Energy card to Lumium, where equivalent throughput can be achieved through Conduits.
+    event.replaceInput({ id: 'laserio:card_energy' }, '#forge:storage_blocks/redstone', 'gtceu:lumium_foil')
+
+    //Laser Connectors
+    event.shaped("4x laserio:laser_connector", [
+            " E ",
+            "RCR",
+            "SSS"
+        ], {
+            S: 'gtceu:steel_plate',
+            E: 'gtceu:lv_emitter',
+            C: '#gtceu:circuits/lv',
+            R: 'gtceu:red_alloy_plate'
+        }
+    ).id('laserio:laser_connector')
+    event.shaped("laserio:laser_connector_advanced", [
+            " E ",
+            "RCR",
+            "FFF"
+        ], {
+            F: 'gtceu:electrum_flux_plate',
+            E: 'gtceu:luv_emitter',
+            C: '#gtceu:circuits/luv',
+            R: 'gtceu:red_alloy_plate'
+        }
+    ).id('laserio:laser_connector_advanced')
 
     //Overclockers
     event.remove({ output: ['laserio:overclocker_card', 'laserio:overclocker_node']})


### PR DESCRIPTION
Advanced Laser Connector, as it offers wireless item/fluid/energy transfer, is gated to LuV.
Energy card, as it can achieve similar throughput to a Lumium conduit with full card overclockers, is gated behind Lumium Foil.