### PR TITLE
AE2 Recipe Tweaks

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -917,11 +917,7 @@ ServerEvents.recipes(event => {
     event.remove({ output: /megacells:sky_steel/ })
 
     //MAE2 compat stuff
-    event.remove({ id: /mae2/ })
-    event.shapeless('mae2:4x_crafting_accelerator', ['ae2:crafting_accelerator', 'ae2:cell_component_4k'])
-    event.shapeless('mae2:16x_crafting_accelerator', ['ae2:crafting_accelerator', 'ae2:cell_component_16k'])
-    event.shapeless('mae2:64x_crafting_accelerator', ['ae2:crafting_accelerator', 'ae2:cell_component_64k'])
-    event.shapeless('mae2:256x_crafting_accelerator', ['ae2:crafting_accelerator', 'ae2:cell_component_256k'])
+    event.remove({ id: /mae2/, not: { id: /crafting_accelerator/ } })
 
     event.shaped(
         'mae2:item_multi_p2p_tunnel', [

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -1020,7 +1020,7 @@ ServerEvents.recipes(event => {
         .cleanroom(CleanroomType.CLEANROOM)
         
     event.recipes.gtceu.assembler("kubejs:mega/1m_storage_assembler")
-        .itemInputs("2x ae2:cell_component_256k", "2x ae2:engineering_processor", "megacells:accumulation_processor", "#gtceu:circuits/iv")
+        .itemInputs("2x ae2:cell_component_256k", "2x ae2:engineering_processor", "megacells:accumulation_processor", "#gtceu:circuits/luv")
         .inputFluids("gtceu:polytetrafluoroethylene 288")
         .itemOutputs("megacells:cell_component_1m")
         .EUt(240)
@@ -1028,7 +1028,7 @@ ServerEvents.recipes(event => {
         .cleanroom(CleanroomType.CLEANROOM)
         
     event.recipes.gtceu.assembler("kubejs:mega/4m_storage_assembler")
-        .itemInputs("2x megacells:cell_component_1m", "2x ae2:engineering_processor", "megacells:accumulation_processor", "#gtceu:circuits/luv")
+        .itemInputs("2x megacells:cell_component_1m", "2x ae2:engineering_processor", "megacells:accumulation_processor", "#gtceu:circuits/zpm")
         .inputFluids("gtceu:polytetrafluoroethylene 288")
         .itemOutputs("megacells:cell_component_4m")
         .EUt(240)
@@ -1036,7 +1036,7 @@ ServerEvents.recipes(event => {
         .cleanroom(CleanroomType.CLEANROOM)
         
     event.recipes.gtceu.assembler("kubejs:mega/16m_storage_assembler")
-        .itemInputs("2x megacells:cell_component_4m", "2x megacells:accumulation_processor", "gtceu:quantum_eye", "#gtceu:circuits/luv")
+        .itemInputs("2x megacells:cell_component_4m", "2x megacells:accumulation_processor", "gtceu:quantum_eye", "#gtceu:circuits/uv")
         .inputFluids("gtceu:polytetrafluoroethylene 288")
         .itemOutputs("megacells:cell_component_16m")
         .EUt(240)
@@ -1044,7 +1044,7 @@ ServerEvents.recipes(event => {
         .cleanroom(CleanroomType.CLEANROOM)
         
     event.recipes.gtceu.assembler("kubejs:mega/64m_storage_assembler")
-        .itemInputs("2x megacells:cell_component_16m", "2x megacells:accumulation_processor", "gtceu:quantum_eye", "#gtceu:circuits/zpm")
+        .itemInputs("2x megacells:cell_component_16m", "2x megacells:accumulation_processor", "gtceu:quantum_eye", "#gtceu:circuits/uhv")
         .inputFluids("gtceu:polybenzimidazole 288")
         .itemOutputs("megacells:cell_component_64m")
         .EUt(240)
@@ -1052,7 +1052,7 @@ ServerEvents.recipes(event => {
         .cleanroom(CleanroomType.CLEANROOM)
         
     event.recipes.gtceu.assembler("kubejs:mega/256m_storage_assembler")
-        .itemInputs("2x megacells:cell_component_64m", "2x megacells:accumulation_processor", "gtceu:quantum_eye", "#gtceu:circuits/zpm")
+        .itemInputs("2x megacells:cell_component_64m", "2x megacells:accumulation_processor", "gtceu:quantum_eye", "#gtceu:circuits/uev")
         .inputFluids("gtceu:polybenzimidazole 288")
         .itemOutputs("megacells:cell_component_256m")
         .EUt(240)

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -233,12 +233,12 @@ ServerEvents.recipes(event => {
     event.shaped(
         Item.of('ae2:crafting_unit'), [
         'ABA',
-        'CDC',
+        'SDS',
         'ABA'
     ], {
         A: 'gtceu:aluminium_plate',
         B: 'ae2:calculation_processor',
-        C: 'ae2:fluix_glass_cable',
+        S: 'ae2:sky_dust',
         D: 'ae2:logic_processor'
     }
     ).id('kubejs:ae2/cpu_crafting_unit')

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -233,12 +233,12 @@ ServerEvents.recipes(event => {
     event.shaped(
         Item.of('ae2:crafting_unit'), [
         'ABA',
-        'SDS',
+        'CDC',
         'ABA'
     ], {
         A: 'gtceu:aluminium_plate',
         B: 'ae2:calculation_processor',
-        S: 'ae2:sky_dust',
+        C: 'ae2:fluix_glass_cable',
         D: 'ae2:logic_processor'
     }
     ).id('kubejs:ae2/cpu_crafting_unit')

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -918,10 +918,10 @@ ServerEvents.recipes(event => {
 
     //MAE2 compat stuff
     event.remove({ id: /mae2/ })
-    event.shapeless('mae2:4x_crafting_accelerator', ['megacells:mega_crafting_unit', 'ae2:engineering_processor', 'ae2:cell_component_4k'])
-    event.shapeless('mae2:16x_crafting_accelerator', ['megacells:mega_crafting_unit', 'ae2:engineering_processor', 'ae2:cell_component_16k'])
-    event.shapeless('mae2:64x_crafting_accelerator', ['megacells:mega_crafting_unit', 'ae2:engineering_processor', 'ae2:cell_component_64k'])
-    event.shapeless('mae2:256x_crafting_accelerator', ['megacells:mega_crafting_unit', 'ae2:engineering_processor', 'ae2:cell_component_256k'])
+    event.shapeless('mae2:4x_crafting_accelerator', ['ae2:crafting_accelerator', 'ae2:cell_component_4k'])
+    event.shapeless('mae2:16x_crafting_accelerator', ['ae2:crafting_accelerator', 'ae2:cell_component_16k'])
+    event.shapeless('mae2:64x_crafting_accelerator', ['ae2:crafting_accelerator', 'ae2:cell_component_64k'])
+    event.shapeless('mae2:256x_crafting_accelerator', ['ae2:crafting_accelerator', 'ae2:cell_component_256k'])
 
     event.shaped(
         'mae2:item_multi_p2p_tunnel', [


### PR DESCRIPTION
There is only one significant nerf here, and that is to make Crafting CPU housings require 2 Sky Stone Dust each [as an attempt to discourage overuse of autocrafting](https://discord.com/channels/914926812948234260/1229929078547550238/1292876994891219099)

Everything else corrects an inconsistency: 
1. Megacells' storage components didn't follow the circuit tiering pattern set by the AE2 storage components (Increasing circuit tier every two storage component tiers as opposed to AE2's 1 per tier) 
2. When disassembling MAE2's multi co-processors by holding them in hand and shift+right-clicking, they return a storage component and a regular co-processor. This changes their recipes to match that hard-coded mechanic.