### PR TITLE
Add tip about new Flawless Budding Certus Quartz recipe to questbook

### DIFF
--- a/config/ftbquests/quests/chapters/matterenergy.snbt
+++ b/config/ftbquests/quests/chapters/matterenergy.snbt
@@ -1157,6 +1157,8 @@
 				"&6Certus quartz&r can be grown from &6Budding Certus Quartz&r blocks!"
 				""
 				"Check out the &9&lingame guide&r&r or &eG&r on the item for specifics on how to get this set up."
+				""
+				"Note that Monifactory adds a crafting recipe for Flawless Budding Certus Quartz — check EMI for details!"
 			]
 			icon: "ae2:flawless_budding_quartz"
 			id: "62356B88D5366D33"


### PR DESCRIPTION
> Certus quartz can be grown from Budding Certus Quartz blocks!
> Check out the ingame guide or G on the item for specifics on how to get this set up.
> **Note that Monifactory adds a crafting recipe for Flawless Budding Certus Quartz — check EMI for details!**

People did not know about this!

<img width="460" alt="image" src="https://github.com/user-attachments/assets/d1cc25e0-db65-4d63-ac7f-c189d3da0a8f">

Please add text formatting as you see fit.