### PR TITLE
Recolor Pulsating Alloy to be closer to Pulsating Dust

### DIFF
--- a/kubejs/startup_scripts/gregtech_material_registry/enderio.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/enderio.js
@@ -36,7 +36,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     // Pulsating Iron
     event.create("pulsating_alloy")
         .ingot().fluid()
-        .color(0x6ae26e).iconSet('shiny')
+        .color(0x2AB38F).iconSet('shiny')
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR)
         .components('iron')
         .cableProperties(8, 1, 0, true)


### PR DESCRIPTION
Title.

Although Pulsating Alloy has a semi-iconic color, it doesn't match the color of the other "pulsating" items (Mesh, dust, and Prediction Matrix) and is easy to confuse with Vibrant Alloy.
This new color is intended to be closer to the pulsating items' colors, but also be recognizeable compared to other, similarly-colored metals (Like Lutetium, Europium, and Enderium)
I also added as much of the original color's green as possible without compromising on the above two goals.