### PR TITLE
Fix typo in axe quest description

### DIFF
--- a/config-overrides/expert/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/expert/ftbquests/quests/chapters/genesis.snbt
@@ -792,7 +792,7 @@
 		}
 		{
 			dependencies: ["4FE53F31E68F4C1C"]
-			description: ["&9Gregtech Axes are able to vienmine an entire tree at once!"]
+			description: ["&9Gregtech Axes are able to veinmine an entire tree at once!"]
 			id: "527F56DFAD5E20EC"
 			tasks: [{
 				id: "254A555916313F70"

--- a/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/hardmode/ftbquests/quests/chapters/genesis.snbt
@@ -792,7 +792,7 @@
 		}
 		{
 			dependencies: ["4FE53F31E68F4C1C"]
-			description: ["&9Gregtech Axes are able to vienmine an entire tree at once!"]
+			description: ["&9Gregtech Axes are able to veinmine an entire tree at once!"]
 			icon: {
 				Count: 1
 				id: "gtceu:iron_axe"

--- a/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
+++ b/config-overrides/normal/ftbquests/quests/chapters/genesis.snbt
@@ -866,7 +866,7 @@
 		}
 		{
 			dependencies: ["4FE53F31E68F4C1C"]
-			description: ["&9Gregtech Axes are able to vienmine an entire tree at once!"]
+			description: ["&9Gregtech Axes are able to veinmine an entire tree at once!"]
 			icon: {
 				Count: 1
 				id: "gtceu:iron_axe"

--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -866,7 +866,7 @@
 		}
 		{
 			dependencies: ["4FE53F31E68F4C1C"]
-			description: ["&9Gregtech Axes are able to vienmine an entire tree at once!"]
+			description: ["&9Gregtech Axes are able to veinmine an entire tree at once!"]
 			icon: {
 				Count: 1
 				id: "gtceu:iron_axe"


### PR DESCRIPTION
It said "vienmine" instead of "veinmine" (see diff)
I did remember to change all the copies in `config-overrides`