### PR TITLE
Add optional compat for Modular Routers

### DIFF
--- a/kubejs/server_scripts/mods/optionalCompats/modularrouters.js
+++ b/kubejs/server_scripts/mods/optionalCompats/modularrouters.js
@@ -1,0 +1,60 @@
+/**
+ * Optional compat script for Modular Routers
+ * 
+ * Midly gated behind LV circuits & alloys. Upgrades gated behind LV cutter.
+ * Energy tx gated behind LV Autoclave & MV alloy wires.
+ */
+if (Platform.isLoaded('modularrouters')) {
+    console.log("Modular Routers found, loading server compat scripts...")
+    ServerEvents.recipes(event => {
+        let replaceMultiple = function (which, arrRepl) {
+                arrRepl.forEach(
+                        ([from, to]) => event.replaceInput(which, from, to)
+                )
+        }
+
+        event.remove({output: 'modularrouters:modular_router'})
+        event.shaped('4x modularrouters:modular_router', [
+                'PBP',
+                'BCB',
+                'PBP'
+            ], {
+                P: 'gtceu:dark_steel_plate',
+                C: '#gtceu:circuits/lv',
+                B: 'enderio:dark_steel_bars'
+            }
+        )
+
+        event.replaceInput(/modularrouters:(sender|puller)_module_2(_x4)?/, 'minecraft:ender_pearl', 'enderio:pulsating_crystal')
+
+        replaceMultiple('modularrouters:energy_output_module', [
+                ['minecraft:gold_ingot', 'gtceu:vibrant_alloy_single_wire'],
+                ['#forge:storage_blocks/redstone', 'kubejs:resonating_crystal']
+        ])
+
+        replaceMultiple('modularrouters:energy_upgrade', [
+                ['minecraft:gold_ingot', 'gtceu:conductive_alloy_double_wire'],
+                ['#forge:storage_blocks/redstone', 'kubejs:resonating_crystal']
+        ])
+
+        replaceMultiple('modularrouters:speed_upgrade', [
+                ['minecraft:gold_ingot', 'thermal:redstone_servo'],
+                ['minecraft:gold_nugget', 'gtceu:electrum_plate']
+        ])
+
+        replaceMultiple('modularrouters:blank_module', [
+                ['minecraft:redstone', '#gtceu:circuits/ulv'],
+                ['minecraft:gold_nugget', 'gtceu:electrum_nugget']
+        ])
+
+        replaceMultiple('modularrouters:blank_upgrade', [
+                ['minecraft:lapis_lazuli', 'gtceu:lapis_plate'],
+                ['minecraft:gold_nugget', 'gtceu:electrum_nugget']
+        ])
+
+        replaceMultiple(/modularrouters:range_(up|down)_augment/, [
+                ['#forge:rods/wooden', 'gtceu:electrum_rod'],
+                ['minecraft:quartz', 'minecraft:ender_pearl']
+        ])
+    })
+}


### PR DESCRIPTION
This PR adds optional compat for [Modular Routers](https://www.curseforge.com/minecraft/mc-mods/modular-routers).

Given how basic\* the mod is, I thought it could be appropriate to gate it behind LV circuits & alloys. I gated upgrades behind lapis plates (LV cutter), and energy tx behind MV alloy wires (energy upgrades allow 1k FE per upgrade, up to 64k FE).
*\*: however, it can execute a large variety of [inter]actions. I can also gate those if necessary.*

Note: this mod got my attention because I plan to use it at some point to auto-replace turbine rotors remotely. Instead of adding Entangled which is too OP/permissive imo.

You're more than welcome to suggest/ask for changes &/or additions. Maintainers can edit as well.

## Recipes
<details>
<summary>Click to expand</summary>

![javaw_nDodxB0yd2](https://github.com/user-attachments/assets/e93a4695-8c2f-4788-99b2-a15a00848782)
![javaw_eRdeWObjGu](https://github.com/user-attachments/assets/7aa8215a-a7d3-44fc-9155-af74b55e8b14)
![javaw_msLmDkC0Tj](https://github.com/user-attachments/assets/ef4074fd-017e-4db3-b062-aa156755bee5)
![javaw_rfbTJIlcAc](https://github.com/user-attachments/assets/df9c6827-db77-4e5f-8765-2115da4deb73)
![javaw_MwxbwYpBxp](https://github.com/user-attachments/assets/a1a39934-f793-44e0-94a5-e80e98db92cc)
![javaw_QpvaxsQ1p5](https://github.com/user-attachments/assets/62505ce9-b068-4181-99a6-61845a3bca05)
![javaw_BkKGKjh33B](https://github.com/user-attachments/assets/b4ae9e2e-acef-4ca0-86e0-b59f790548d9)
![javaw_bnhWIjs1X2](https://github.com/user-attachments/assets/b1a3f9af-d3e4-4dcf-a56d-754937660c0b)
</details>