### PR TITLE
Revert Crafting Station update

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,4 @@
-/{
+{
   "minecraft": {
     "version": "1.20.1",
     "modLoaders": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,4 @@
-{
+/{
   "minecraft": {
     "version": "1.20.1",
     "modLoaders": [
@@ -441,7 +441,7 @@
       "required": true
     },
     {
-      "fileID": 5496566,
+      "fileID": 4770683,
       "projectID": 318551,
       "required": true
     },


### PR DESCRIPTION
There are reports in Discord (linked below) of crashes and issues related to Crafting Stations in the latest update. There are items misaligned in the sidebar inventory views, crafting items doesn't work (inputs just flicker), and shift-click crafting crashes the game (at least for me).

The update was introduced in commit 83eace48f5f90fb72a4f2ae39c67d1705947cebd ([diff](https://github.com/ThePansmith/Monifactory/commit/83eace48f5f90fb72a4f2ae39c67d1705947cebd#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L444)).

There are two confirmed reports (myself and one other) of this version revert resolving all observed Crafting Station issues.

Discord reports:

- https://discordapp.com/channels/914926812948234260/1297294004509081630
- https://discordapp.com/channels/914926812948234260/1297282214672732261
- https://discordapp.com/channels/914926812948234260/1297293342408970316