### PR TITLE
Update simulating_resources.snbt

### DIFF
--- a/config/ftbquests/quests/chapters/simulating_resources.snbt
+++ b/config/ftbquests/quests/chapters/simulating_resources.snbt
@@ -19,7 +19,7 @@
 				""
 				"Putting Pristine matter into a &3Loot Fabricator&r will allow you to obtain one of various items related to that mob."
 				""
-				"Much like &3Simulation Chambers&r, Loot Fabricators are &asided&r, accepting input from &athe top side&r and allowing extraction from &aall sides except the top&r."
+				"Unlike &3Simulation Chambers&r, Loot Fabricators are &asided&r, accepting input from &athe top side&r and allowing extraction from &aall sides except the top&r."
 			]
 			hide_until_deps_visible: true
 			id: "0006FEA1843FEA0A"


### PR DESCRIPTION
it was statet : "&bHNN&r machines are not sided, so you can input and output from any side."

so there was a mismatch

loot fabricators are sided