### PR TITLE
Add power transformer recipes post UV

### DIFF
--- a/kubejs/server_scripts/gregtech/Post_UV_Components.js
+++ b/kubejs/server_scripts/gregtech/Post_UV_Components.js
@@ -140,6 +140,17 @@ ServerEvents.recipes(event => {
                 H: `gtceu:${tier}_machine_hull`,
                 W: 'gtceu:uhpic_chip'
             })
+
+            event.shaped(Item.of(`gtceu:${tier}_transformer_16a`), [
+                'WBB',
+                'AH ',
+                'WBB'
+            ], {
+                A: `gtceu:${mat1}_hex_wire`,
+                B: `gtceu:${mat2}_hex_wire`,
+                H: `gtceu:${tier}_machine_hull`,
+                W: 'gtceu:uhpic_chip'
+            })
         })
 
 


### PR DESCRIPTION
These are needed for substation 64A hatches.

The current auto generated recipe from GTM is broken because of unregistered small springs. This PR adds the crafting table recipes that exist for all other tiers UV and down, using the same cable materials as the recently added 2a and 4a transformers.

Also side note, all these recipes including the 2a and 4a ones should use cables instead of wires to be consistent, but cable recipes for these wires dont exist

I only tested this in my single player world, not really sure what the normal dev environment here is.