### PR TITLE
Allow Greenhouse to show all it's output on some recipes

### DIFF
--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -111,7 +111,7 @@ GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
     event.create('greenhouse')
         .category('multiblock')
         .setEUIO('in')
-        .setMaxIOSize(3, 3, 1, 0)
+        .setMaxIOSize(3, 6, 1, 0)
         .setSlotOverlay(false, false, GuiTextures.SOLIDIFIER_OVERLAY)
         .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, FillDirection.LEFT_TO_RIGHT)
         .setSound(GTSoundEntries.TURBINE)


### PR DESCRIPTION
This allows Greenhouses to show all of the output from all recipes. Previously the Warped/Crimson Fungus recipes were cut off (both boosted and not boosted)

Current live version:
![image](https://github.com/user-attachments/assets/2196b350-0861-499d-bb0a-c967a9a373a9)

Updated version:
![image](https://github.com/user-attachments/assets/400dc196-282d-4c6d-b283-baa8ce2599a3)
