### PR TITLE
Nuclearcraft: Neoteric update

### DIFF
--- a/config/NuclearCraft/common.toml
+++ b/config/NuclearCraft/common.toml
@@ -10,6 +10,8 @@
 	rtg_radiation = [56, 57800, 200000, 1900000]
 	#Steam turbine (one block) base power gen
 	steam_turbine_power_gen = 50
+	#Decay Generator base power gen
+	decay_generator_power_gen = 100
 
 [energy_storage]
 	#Allow block registration: basic_voltaic_pile, elite_voltaic_pile, advanced_voltaic_pile, basic_lithium_ion_battery, elite_lithium_ion_battery, du_lithium_ion_battery, du_voltaic_pile, advanced_lithium_ion_battery
@@ -19,6 +21,7 @@
 	lithium_ion_battery_storage = 1000000
 	qnp_energy_storage = 2000000
 	qnp_energy_per_block = 200
+	ligtning_rod_charge = 1000000
 
 [storage_blocks]
 	#Blocks to store items, fluids, etc...

--- a/config/NuclearCraft/fission.toml
+++ b/config/NuclearCraft/fission.toml
@@ -1,69 +1,14 @@
 
 #Settings for reactor fuel
 [reactor_fuel]
-	#Heat multiplier for boiling reactor.
+	#Heat multiplier affects on heat/cooling ratio multiplier.
 	heat_multiplier = 3.24444444
 	#Depletion multiplier. Affects how long fuel lasts.
 	#Range: 0.0 ~ 1000.0
 	depletion_multiplier = 100.0
-	#Base Fuel Heat: len-236, lep-241, mix-239, leb-248, tbu, lea-242, lecm-245, hecf-251, lecm-247, hep-241, hecm-245, mix-241, hecm-247, lep-239, hen-236, lecm-243, hecm-243, leu-233, leu-235, hea-242, lecf-251, lecf-249, heb-248, heu-235, heu-233, hecf-249, hep-239
-	base_heat = [45.0, 87.5, 71.875, 65.0, 22.5, 117.5, 85.0, 900.0, 67.5, 525.0, 510.0, 121.875, 405.0, 50.0, 270.0, 140.0, 840.0, 75.0, 62.5, 705.0, 150.0, 145.0, 390.0, 375.0, 450.0, 870.0, 300.0]
-	#Base Fuel Efficiency: len-236, lep-241, mix-239, leb-248, tbu, lea-242, lecm-245, hecf-251, lecm-247, hep-241, hecm-245, mix-241, hecm-247, lep-239, hen-236, lecm-243, hecm-243, leu-233, leu-235, hea-242, lecf-251, lecf-249, heb-248, heu-235, heu-233, hecf-249, hep-239
-	base_efficiency = [104, 119, 100, 157, 119, 128, 142, 176, 147, 123, 147, 109, 152, 142, 109, 138, 142, 104, 95, 133, 171, 166, 161, 100, 109, 171, 138]
-	#Base Fuel Depletion Time (seconds): len-236, lep-241, mix-239, leb-248, tbu, lea-242, lecm-245, hecf-251, lecm-247, hep-241, hecm-245, mix-241, hecm-247, lep-239, hen-236, lecm-243, hecm-243, leu-233, leu-235, hea-242, lecf-251, lecf-249, heb-248, heu-235, heu-233, hecf-249, hep-239
-	base_depletion = [89, 143, 198, 98, 654, 67, 109, 90, 98, 143, 109, 137, 98, 208, 89, 68, 68, 120, 218, 83, 90, 48, 83, 218, 120, 48, 208]
-	#Fuel Criticality: len-236, lep-241, mix-239, leb-248, tbu, lea-242, lecm-245, hecf-251, lecm-247, hep-241, hecm-245, mix-241, hecm-247, lep-239, hen-236, lecm-243, hecm-243, leu-233, leu-235, hea-242, lecf-251, lecf-249, heb-248, heu-235, heu-233, hecf-249, hep-239
-	base_criticallity = [77, 92, 103, 80, 257, 71, 82, 38, 79, 46, 40, 88, 39, 108, 38, 72, 36, 85, 112, 35, 78, 66, 35, 56, 42, 33, 53]
-
-#Settings for heat sinks
-[heat_sink]
-	#Cooling rate H/t: prismarine, aluminum, manganese, glowstone, netherite, slime, gold, liquid_nitrogen, lithium, carobbiite, enderium, end_stone, tin, copper, fluorite, lapis, obsidian, purpur, cryotheum, villiaumite, magnesium, quartz, arsenic, liquid_helium, nether_brick, water, lead, diamond, iron, silver, boron, emerald, redstone
-	cooling_rate = [115.0, 175.0, 150.0, 130.0, 150.0, 145.0, 120.0, 185.0, 130.0, 140.0, 120.0, 40.0, 120.0, 80.0, 160.0, 120.0, 40.0, 95.0, 160.0, 180.0, 110.0, 90.0, 135.0, 140.0, 70.0, 60.0, 60.0, 150.0, 80.0, 170.0, 160.0, 160.0, 90.0]
-	#You can define blocks by block_name. So water_heat_sink will fall back to nuclearcraft:water_heat_sink. Or qualify it with namespace like some_mod:some_block.
-	#Or use block tag key. #nuclearcraft:fission_reactor_casing will fall back to blocks with this tag. Do not forget to put #.
-	#if you need AND condition, add comma separated values "block1", "block2" means AND condition
-	#if you need OR condition, use | separator. "block1|block2" means block1 or block2
-	#By default you have rule condition is 'At least 1'. So if you define some block, it will go in the rule as 'at least 1'
-	#Validation options: >2 means at least 2 (use any number)
-	#-2 means between, it is always 2 (opposite sides)
-	#<2 means less than 2 (use any number)
-	#=2 means exact 2 (use any number)
-	#^3 means 3 blocks in the corner (shared vertex or edge). possible values 2 and 3
-	#Default placement rules have all examples
-	placement_explanations = ""
-	prismarine = ["water_heat_sink"]
-	aluminum = ["quartz_heat_sink", "lapis_heat_sink"]
-	manganese = ["fission_reactor_solid_fuel_cell>2"]
-	glowstone = ["#nuclearcraft:moderators>2"]
-	netherite = ["obsidian_heat_sink", "fission_reactor_irradiation_chamber"]
-	slime = ["water_heat_sink", "lead_heat_sink"]
-	gold = ["water_heat_sink", "redstone_heat_sink"]
-	liquid_nitrogen = ["copper_heat_sink", "purpur_heat_sink"]
-	lithium = ["lead_heat_sink-2"]
-	carobbiite = ["end_stone_heat_sink", "fission_reactor_irradiation_chamber"]
-	enderium = ["#nuclearcraft:fission_reactor_casing^3"]
-	end_stone = ["enderium_heat_sink"]
-	tin = ["lapis_heat_sink-2"]
-	copper = ["glowstone_heat_sink"]
-	fluorite = ["gold_heat_sink", "prismarine_heat_sink"]
-	lapis = ["fission_reactor_solid_fuel_cell", "#nuclearcraft:fission_reactor_casing"]
-	obsidian = ["glowstone_heat_sink-2"]
-	purpur = ["#nuclearcraft:fission_reactor_casing", "iron_heat_sink"]
-	cryotheum = ["fission_reactor_solid_fuel_cell>2"]
-	villiaumite = ["redstone_heat_sink", "end_stone_heat_sink"]
-	magnesium = ["#nuclearcraft:fission_reactor_casing", "#nuclearcraft:moderators"]
-	quartz = ["#nuclearcraft:moderators"]
-	arsenic = ["#nuclearcraft:moderators>3"]
-	liquid_helium = ["redstone_heat_sink", "#nuclearcraft:fission_reactor_casing"]
-	nether_brick = ["obsidian_heat_sink"]
-	water = ["fission_reactor_solid_fuel_cell|#nuclearcraft:moderators"]
-	lead = ["iron_heat_sink"]
-	diamond = ["copper_heat_sink", "quartz_heat_sink"]
-	iron = ["gold_heat_sink"]
-	silver = ["glowstone_heat_sink>2", "tin_heat_sink|fission_reactor_irradiation_chamber"]
-	boron = ["quartz_heat_sink", "#nuclearcraft:fission_reactor_casing|#nuclearcraft:moderators"]
-	emerald = ["fission_reactor_solid_fuel_cell", "#nuclearcraft:moderators"]
-	redstone = ["fission_reactor_solid_fuel_cell"]
+	#Heat multiplier. Affects to all fuels.
+	#Range: 0.01 ~ 100.0
+	fuel_heat_multiplier = 1.0
 
 #Settings for Fission Reactor
 [fission_reactor]
@@ -94,4 +39,7 @@
 	#Rate at which steam recipes produced.
 	#Range: 0.01 ~ 1000000.0
 	boiling_mult = 15.0
+	#Affects how much energy reactors produce.
+	#Range: 0.01 ~ 1000000.0
+	fe_generation_multiplier = 10.0
 

--- a/config/NuclearCraft/fission.toml
+++ b/config/NuclearCraft/fission.toml
@@ -7,7 +7,7 @@
 	#Range: 0.0 ~ 1000.0
 	depletion_multiplier = 100.0
 	#Heat multiplier. Affects to all fuels.
-	#Range: 0.01 ~ 100.0
+	#Range: 0.01 ~ 300.0
 	fuel_heat_multiplier = 1.0
 
 #Settings for Fission Reactor

--- a/config/NuclearCraft/fission.toml
+++ b/config/NuclearCraft/fission.toml
@@ -41,5 +41,5 @@
 	boiling_mult = 15.0
 	#Affects how much energy reactors produce.
 	#Range: 0.01 ~ 1000000.0
-	fe_generation_multiplier = 10.0
+	fe_generation_multiplier = 400.0
 

--- a/config/NuclearCraft/fission_fuel/americium.json
+++ b/config/NuclearCraft/fission_fuel/americium.json
@@ -1,0 +1,22 @@
+[
+  {
+    "group": "americium",
+    "name": "hea-242",
+    "forge_energy": 1536,
+    "heat": 564,
+    "criticality": 32,
+    "depletion": 92,
+    "efficiency": 140,
+    "isotopes": [242, 243]
+  },
+  {
+    "group": "americium",
+    "name": "lea-242",
+    "forge_energy": 384,
+    "heat": 94,
+    "criticality": 65,
+    "depletion": 74,
+    "efficiency": 135,
+    "isotopes": [242, 243]
+  }
+]

--- a/config/NuclearCraft/fission_fuel/berkelium.json
+++ b/config/NuclearCraft/fission_fuel/berkelium.json
@@ -1,0 +1,22 @@
+[
+  {
+    "group": "berkelium",
+    "name": "heb-248",
+    "forge_energy": 1080,
+    "heat": 312,
+    "criticality": 32,
+    "depletion": 92,
+    "efficiency": 170,
+    "isotopes": [248, 247]
+  },
+  {
+    "group": "berkelium",
+    "name": "leb-248",
+    "forge_energy": 270,
+    "heat": 52,
+    "criticality": 73,
+    "depletion": 108,
+    "efficiency": 165,
+    "isotopes": [248, 247]
+  }
+]

--- a/config/NuclearCraft/fission_fuel/californium.json
+++ b/config/NuclearCraft/fission_fuel/californium.json
@@ -1,0 +1,42 @@
+[
+  {
+    "group": "californium",
+    "name": "hecf-249",
+    "forge_energy": 1728,
+    "heat": 696,
+    "criticality": 30,
+    "depletion": 53,
+    "efficiency": 180,
+    "isotopes": [249, 252]
+  },
+  {
+    "group": "californium",
+    "name": "hecf-251",
+    "forge_energy": 1800,
+    "heat": 720,
+    "criticality": 35,
+    "depletion": 100,
+    "efficiency": 185,
+    "isotopes": [251, 252]
+  },
+  {
+    "group": "californium",
+    "name": "lecf-249",
+    "forge_energy": 432,
+    "heat": 116,
+    "criticality": 60,
+    "depletion": 53,
+    "efficiency": 175,
+    "isotopes": [249, 252]
+  },
+  {
+    "group": "californium",
+    "name": "lecf-251",
+    "forge_energy": 450,
+    "heat": 120,
+    "criticality": 71,
+    "depletion": 100,
+    "efficiency": 180,
+    "isotopes": [251, 252]
+  }
+]

--- a/config/NuclearCraft/fission_fuel/curium.json
+++ b/config/NuclearCraft/fission_fuel/curium.json
@@ -1,0 +1,62 @@
+[
+  {
+    "group": "curium",
+    "name": "hecm-243",
+    "forge_energy": 1680,
+    "heat": 672,
+    "criticality": 33,
+    "depletion": 75,
+    "efficiency": 150,
+    "isotopes": [243, 246]
+  },
+  {
+    "group": "curium",
+    "name": "hecm-245",
+    "forge_energy": 1296,
+    "heat": 408,
+    "criticality": 37,
+    "depletion": 121,
+    "efficiency": 155,
+    "isotopes": [245, 246]
+  },
+  {
+    "group": "curium",
+    "name": "hecm-247",
+    "forge_energy": 1104,
+    "heat": 324,
+    "criticality": 36,
+    "depletion": 108,
+    "efficiency": 160,
+    "isotopes": [247, 246]
+  },
+  {
+    "group": "curium",
+    "name": "lecm-243",
+    "forge_energy": 420,
+    "heat": 112,
+    "criticality": 66,
+    "depletion": 75,
+    "efficiency": 145,
+    "isotopes": [243, 246]
+  },
+  {
+    "group": "curium",
+    "name": "lecm-245",
+    "forge_energy": 324,
+    "heat": 68,
+    "criticality": 75,
+    "depletion": 121,
+    "efficiency": 150,
+    "isotopes": [245, 246]
+  },
+  {
+    "group": "curium",
+    "name": "lecm-247",
+    "forge_energy": 276,
+    "heat": 54,
+    "criticality": 72,
+    "depletion": 108,
+    "efficiency": 155,
+    "isotopes": [247, 246]
+  }
+]

--- a/config/NuclearCraft/fission_fuel/mixed.json
+++ b/config/NuclearCraft/fission_fuel/mixed.json
@@ -1,0 +1,22 @@
+[
+  {
+    "group": "mixed",
+    "name": "mix-239",
+    "forge_energy": 310,
+    "heat": 57.5,
+    "criticality": 94,
+    "depletion": 218,
+    "efficiency": 105,
+    "isotopes": [239, 238]
+  },
+  {
+    "group": "mixed",
+    "name": "mix-241",
+    "forge_energy": 468,
+    "heat": 97.5,
+    "criticality": 80,
+    "depletion": 151,
+    "efficiency": 115,
+    "isotopes": [241, 238]
+  }
+]

--- a/config/NuclearCraft/fission_fuel/neptunium.json
+++ b/config/NuclearCraft/fission_fuel/neptunium.json
@@ -1,0 +1,22 @@
+[
+  {
+    "group": "neptunium",
+    "name": "hen-236",
+    "forge_energy": 720,
+    "heat": 216,
+    "criticality": 35,
+    "depletion": 99,
+    "efficiency": 115,
+    "isotopes": [236, 237]
+  },
+  {
+    "group": "neptunium",
+    "name": "len-236",
+    "forge_energy": 180,
+    "heat": 36,
+    "criticality": 70,
+    "depletion": 99,
+    "efficiency": 110,
+    "isotopes": [236, 237]
+  }
+]

--- a/config/NuclearCraft/fission_fuel/plutonium.json
+++ b/config/NuclearCraft/fission_fuel/plutonium.json
@@ -1,0 +1,42 @@
+[
+  {
+    "group": "plutonium",
+    "name": "hep-239",
+    "forge_energy": 840,
+    "heat": 240,
+    "criticality": 49,
+    "depletion": 229,
+    "efficiency": 145,
+    "isotopes": [239, 242]
+  },
+  {
+    "group": "plutonium",
+    "name": "hep-241",
+    "forge_energy": 1320,
+    "heat": 420,
+    "criticality": 42,
+    "depletion": 158,
+    "efficiency": 130,
+    "isotopes": [241, 242]
+  },
+  {
+    "group": "plutonium",
+    "name": "lep-239",
+    "forge_energy": 210,
+    "heat": 40,
+    "criticality": 99,
+    "depletion": 229,
+    "efficiency": 150,
+    "isotopes": [239, 242]
+  },
+  {
+    "group": "plutonium",
+    "name": "lep-241",
+    "forge_energy": 330,
+    "heat": 70,
+    "criticality": 84,
+    "depletion": 158,
+    "efficiency": 125,
+    "isotopes": [241, 242]
+  }
+]

--- a/config/NuclearCraft/fission_fuel/thorium.json
+++ b/config/NuclearCraft/fission_fuel/thorium.json
@@ -1,0 +1,12 @@
+[
+  {
+    "group": "thorium",
+    "name": "tbu",
+    "forge_energy": 120,
+    "heat": 18,
+    "criticality": 234,
+    "depletion": 720,
+    "efficiency": 125,
+    "isotopes": [232, 232]
+  }
+]

--- a/config/NuclearCraft/fission_fuel/uranium.json
+++ b/config/NuclearCraft/fission_fuel/uranium.json
@@ -1,0 +1,42 @@
+[
+  {
+    "group": "uranium",
+    "name": "heu-233",
+    "forge_energy": 1152,
+    "heat": 360,
+    "criticality": 39,
+    "depletion": 133,
+    "efficiency": 115,
+    "isotopes": [233, 238]
+  },
+  {
+    "group": "uranium",
+    "name": "heu-235",
+    "forge_energy": 960,
+    "heat": 300,
+    "criticality": 51,
+    "depletion": 240,
+    "efficiency": 105,
+    "isotopes": [235, 238]
+  },
+  {
+    "group": "uranium",
+    "name": "leu-233",
+    "forge_energy": 288,
+    "heat": 60,
+    "criticality": 78,
+    "depletion": 133,
+    "efficiency": 110,
+    "isotopes": [233, 238]
+  },
+  {
+    "group": "uranium",
+    "name": "leu-235",
+    "forge_energy": 240,
+    "heat": 50,
+    "criticality": 102,
+    "depletion": 240,
+    "efficiency": 100,
+    "isotopes": [235, 238]
+  }
+]

--- a/config/NuclearCraft/heat_sinks/! README.TXT
+++ b/config/NuclearCraft/heat_sinks/! README.TXT
@@ -1,0 +1,12 @@
+You can define blocks by block_name without namespace. So water_heat_sink will fall back to nuclearcraft:water_heat_sink.
+Or qualify it with namespace like some_mod:some_block.
+Or use block tag key. #nuclearcraft:fission_reactor_casing will fall back to blocks with this tag. Do not forget to put #.
+if you need AND condition, add comma separated values "block1", "block2" means AND condition
+if you need OR condition, use | separator. "block1|block2" means block1 or block2
+By default you have rule condition is 'At least 1'. So if you define some block, it will go in the rule as 'at least 1'
+Validation options: >2 means at least 2 (use any number)
+-2 means between, it is always 2 (opposite sides)
+<2 means less than 2 (use any number)
+=2 means exact 2 (use any number)
+^3 means 3 blocks in the corner (shared vertex or edge). possible values 2 and 3
+Default placement rules have all examples

--- a/config/NuclearCraft/heat_sinks/aluminum.json
+++ b/config/NuclearCraft/heat_sinks/aluminum.json
@@ -1,0 +1,5 @@
+[{
+  "type": "aluminum",
+  "heat": 175,
+  "placement_rule": ["quartz_heat_sink", "lapis_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/arsenic.json
+++ b/config/NuclearCraft/heat_sinks/arsenic.json
@@ -1,0 +1,5 @@
+[{
+  "type": "arsenic",
+  "heat": 135,
+  "placement_rule": ["#nuclearcraft:moderators>3"]
+}]

--- a/config/NuclearCraft/heat_sinks/boron.json
+++ b/config/NuclearCraft/heat_sinks/boron.json
@@ -1,0 +1,5 @@
+[{
+  "type": "boron",
+  "heat": 160,
+  "placement_rule": ["quartz_heat_sink", "#nuclearcraft:fission_reactor_casing|#nuclearcraft:moderators"]
+}]

--- a/config/NuclearCraft/heat_sinks/carobbiite.json
+++ b/config/NuclearCraft/heat_sinks/carobbiite.json
@@ -1,0 +1,5 @@
+[{
+  "type": "carobbiite",
+  "heat": 140,
+  "placement_rule": ["end_stone_heat_sink", "fission_reactor_irradiation_chamber"]
+}]

--- a/config/NuclearCraft/heat_sinks/copper.json
+++ b/config/NuclearCraft/heat_sinks/copper.json
@@ -1,0 +1,5 @@
+[{
+  "type": "copper",
+  "heat": 80,
+  "placement_rule": ["glowstone_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/cryotheum.json
+++ b/config/NuclearCraft/heat_sinks/cryotheum.json
@@ -1,0 +1,5 @@
+[{
+  "type": "cryotheum",
+  "heat": 160,
+  "placement_rule": ["fission_reactor_solid_fuel_cell>2"]
+}]

--- a/config/NuclearCraft/heat_sinks/diamond.json
+++ b/config/NuclearCraft/heat_sinks/diamond.json
@@ -1,0 +1,5 @@
+[{
+  "type": "diamond",
+  "heat": 150,
+  "placement_rule": ["copper_heat_sink", "quartz_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/emerald.json
+++ b/config/NuclearCraft/heat_sinks/emerald.json
@@ -1,0 +1,5 @@
+[{
+  "type": "emerald",
+  "heat": 160,
+  "placement_rule": ["fission_reactor_solid_fuel_cell", "#nuclearcraft:moderators"]
+}]

--- a/config/NuclearCraft/heat_sinks/empty.json
+++ b/config/NuclearCraft/heat_sinks/empty.json
@@ -1,0 +1,5 @@
+[{
+  "type": "empty",
+  "heat": 0,
+  "placement_rule": []
+}]

--- a/config/NuclearCraft/heat_sinks/empty_active.json
+++ b/config/NuclearCraft/heat_sinks/empty_active.json
@@ -1,0 +1,5 @@
+[{
+  "type": "empty_active",
+  "heat": 0,
+  "placement_rule": []
+}]

--- a/config/NuclearCraft/heat_sinks/end_stone.json
+++ b/config/NuclearCraft/heat_sinks/end_stone.json
@@ -1,0 +1,5 @@
+[{
+  "type": "end_stone",
+  "heat": 40,
+  "placement_rule": ["enderium_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/enderium.json
+++ b/config/NuclearCraft/heat_sinks/enderium.json
@@ -1,0 +1,5 @@
+[{
+  "type": "enderium",
+  "heat": 120,
+  "placement_rule": ["#nuclearcraft:fission_reactor_casing^3"]
+}]

--- a/config/NuclearCraft/heat_sinks/fluorite.json
+++ b/config/NuclearCraft/heat_sinks/fluorite.json
@@ -1,0 +1,5 @@
+[{
+  "type": "fluorite",
+  "heat": 160,
+  "placement_rule": ["gold_heat_sink", "prismarine_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/glowstone.json
+++ b/config/NuclearCraft/heat_sinks/glowstone.json
@@ -1,0 +1,5 @@
+[{
+  "type": "glowstone",
+  "heat": 130,
+  "placement_rule": ["#nuclearcraft:moderators>2"]
+}]

--- a/config/NuclearCraft/heat_sinks/gold.json
+++ b/config/NuclearCraft/heat_sinks/gold.json
@@ -1,0 +1,5 @@
+[{
+  "type": "gold",
+  "heat": 120,
+  "placement_rule": ["water_heat_sink", "redstone_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/iron.json
+++ b/config/NuclearCraft/heat_sinks/iron.json
@@ -1,0 +1,5 @@
+[{
+  "type": "iron",
+  "heat": 80,
+  "placement_rule": ["gold_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/lapis.json
+++ b/config/NuclearCraft/heat_sinks/lapis.json
@@ -1,0 +1,5 @@
+[{
+  "type": "lapis",
+  "heat": 120,
+  "placement_rule": ["fission_reactor_solid_fuel_cell", "#nuclearcraft:fission_reactor_casing"]
+}]

--- a/config/NuclearCraft/heat_sinks/lead.json
+++ b/config/NuclearCraft/heat_sinks/lead.json
@@ -1,0 +1,5 @@
+[{
+  "type": "lead",
+  "heat": 60,
+  "placement_rule": ["iron_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/liquid_helium.json
+++ b/config/NuclearCraft/heat_sinks/liquid_helium.json
@@ -1,0 +1,5 @@
+[{
+  "type": "liquid_helium",
+  "heat": 140,
+  "placement_rule": ["redstone_heat_sink", "#nuclearcraft:fission_reactor_casing"]
+}]

--- a/config/NuclearCraft/heat_sinks/liquid_nitrogen.json
+++ b/config/NuclearCraft/heat_sinks/liquid_nitrogen.json
@@ -1,0 +1,5 @@
+[{
+  "type": "liquid_nitrogen",
+  "heat": 185,
+  "placement_rule": ["copper_heat_sink", "purpur_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/lithium.json
+++ b/config/NuclearCraft/heat_sinks/lithium.json
@@ -1,0 +1,5 @@
+[{
+  "type": "lithium",
+  "heat": 130,
+  "placement_rule": ["lead_heat_sink-2"]
+}]

--- a/config/NuclearCraft/heat_sinks/magnesium.json
+++ b/config/NuclearCraft/heat_sinks/magnesium.json
@@ -1,0 +1,5 @@
+[{
+  "type": "magnesium",
+  "heat": 110,
+  "placement_rule": ["#nuclearcraft:fission_reactor_casing", "#nuclearcraft:moderators"]
+}]

--- a/config/NuclearCraft/heat_sinks/manganese.json
+++ b/config/NuclearCraft/heat_sinks/manganese.json
@@ -1,0 +1,5 @@
+[{
+  "type": "manganese",
+  "heat": 150,
+  "placement_rule": ["fission_reactor_solid_fuel_cell>2"]
+}]

--- a/config/NuclearCraft/heat_sinks/nether_brick.json
+++ b/config/NuclearCraft/heat_sinks/nether_brick.json
@@ -1,0 +1,5 @@
+[{
+  "type": "nether_brick",
+  "heat": 70,
+  "placement_rule": ["obsidian_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/netherite.json
+++ b/config/NuclearCraft/heat_sinks/netherite.json
@@ -1,0 +1,5 @@
+[{
+  "type": "netherite",
+  "heat": 150,
+  "placement_rule": ["obsidian_heat_sink", "fission_reactor_irradiation_chamber"]
+}]

--- a/config/NuclearCraft/heat_sinks/obsidian.json
+++ b/config/NuclearCraft/heat_sinks/obsidian.json
@@ -1,0 +1,5 @@
+[{
+  "type": "obsidian",
+  "heat": 40,
+  "placement_rule": ["glowstone_heat_sink-2"]
+}]

--- a/config/NuclearCraft/heat_sinks/prismarine.json
+++ b/config/NuclearCraft/heat_sinks/prismarine.json
@@ -1,0 +1,5 @@
+[{
+  "type": "prismarine",
+  "heat": 115,
+  "placement_rule": ["water_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/purpur.json
+++ b/config/NuclearCraft/heat_sinks/purpur.json
@@ -1,0 +1,5 @@
+[{
+  "type": "purpur",
+  "heat": 95,
+  "placement_rule": ["#nuclearcraft:fission_reactor_casing", "iron_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/quartz.json
+++ b/config/NuclearCraft/heat_sinks/quartz.json
@@ -1,0 +1,5 @@
+[{
+  "type": "quartz",
+  "heat": 90,
+  "placement_rule": ["#nuclearcraft:moderators"]
+}]

--- a/config/NuclearCraft/heat_sinks/redstone.json
+++ b/config/NuclearCraft/heat_sinks/redstone.json
@@ -1,0 +1,5 @@
+[{
+  "type": "redstone",
+  "heat": 90,
+  "placement_rule": ["fission_reactor_solid_fuel_cell"]
+}]

--- a/config/NuclearCraft/heat_sinks/silver.json
+++ b/config/NuclearCraft/heat_sinks/silver.json
@@ -1,0 +1,5 @@
+[{
+  "type": "silver",
+  "heat": 170,
+  "placement_rule": ["glowstone_heat_sink>2", "tin_heat_sink|fission_reactor_irradiation_chamber"]
+}]

--- a/config/NuclearCraft/heat_sinks/slime.json
+++ b/config/NuclearCraft/heat_sinks/slime.json
@@ -1,0 +1,5 @@
+[{
+  "type": "slime",
+  "heat": 145,
+  "placement_rule": ["water_heat_sink", "lead_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/tin.json
+++ b/config/NuclearCraft/heat_sinks/tin.json
@@ -1,0 +1,5 @@
+[{
+  "type": "tin",
+  "heat": 120,
+  "placement_rule": ["lapis_heat_sink-2"]
+}]

--- a/config/NuclearCraft/heat_sinks/villiaumite.json
+++ b/config/NuclearCraft/heat_sinks/villiaumite.json
@@ -1,0 +1,5 @@
+[{
+  "type": "villiaumite",
+  "heat": 180,
+  "placement_rule": ["redstone_heat_sink", "end_stone_heat_sink"]
+}]

--- a/config/NuclearCraft/heat_sinks/water.json
+++ b/config/NuclearCraft/heat_sinks/water.json
@@ -1,0 +1,5 @@
+[{
+  "type": "water",
+  "heat": 60,
+  "placement_rule": ["fission_reactor_solid_fuel_cell|#nuclearcraft:moderators"]
+}]

--- a/config/NuclearCraft/materials.toml
+++ b/config/NuclearCraft/materials.toml
@@ -265,7 +265,6 @@
 	vein_size = 7
 	min_height = -60
 	max_height = 60
-	veins_in_chunk = 3
 
 [platinum]
 	register = true
@@ -273,7 +272,6 @@
 	vein_size = 7
 	min_height = -60
 	max_height = 0
-	veins_in_chunk = 3
 
 [thorium]
 	register = true
@@ -281,7 +279,6 @@
 	vein_size = 7
 	min_height = -60
 	max_height = 60
-	veins_in_chunk = 3
 
 [tin]
 	register = true
@@ -289,7 +286,6 @@
 	vein_size = 7
 	min_height = 4
 	max_height = 60
-	veins_in_chunk = 3
 
 [magnesium]
 	register = true
@@ -297,7 +293,6 @@
 	vein_size = 7
 	min_height = -60
 	max_height = 60
-	veins_in_chunk = 3
 
 [silver]
 	register = true
@@ -305,7 +300,6 @@
 	vein_size = 7
 	min_height = -60
 	max_height = 60
-	veins_in_chunk = 3
 
 [cobalt]
 	register = true
@@ -313,7 +307,6 @@
 	vein_size = 7
 	min_height = -60
 	max_height = 60
-	veins_in_chunk = 3
 
 [uranium]
 	register = true
@@ -321,7 +314,6 @@
 	vein_size = 7
 	min_height = -60
 	max_height = 60
-	veins_in_chunk = 3
 
 [zinc]
 	register = true
@@ -329,7 +321,6 @@
 	vein_size = 7
 	min_height = 4
 	max_height = 60
-	veins_in_chunk = 3
 
 [boron]
 	register = true
@@ -337,7 +328,6 @@
 	vein_size = 7
 	min_height = -60
 	max_height = 60
-	veins_in_chunk = 3
 
 [lead]
 	register = true
@@ -345,5 +335,23 @@
 	vein_size = 7
 	min_height = 4
 	max_height = 60
-	veins_in_chunk = 3
+
+[nuggets]
+	steel = true
+	electrum = true
+	magnesium = true
+	cobalt = true
+	aluminum = true
+	lead = true
+	bronze = true
+	lithium = true
+	platinum = true
+	thorium = true
+	tin = true
+	beryllium = true
+	silver = true
+	uranium = true
+	zirconium = true
+	zinc = true
+	boron = true
 

--- a/config/NuclearCraft/turbine.toml
+++ b/config/NuclearCraft/turbine.toml
@@ -30,7 +30,7 @@
 	magnesium = ["turbine_bearing"]
 	beryllium = ["turbine_magnesium_coil"]
 	silver = ["turbine_magnesium_coil", "turbine_gold_coil"]
-	#Energy gen per mB of steam
-	#Range: 1 ~ 1000000
+	#Energy gen multiplier
+	#Range: 1.0 ~ 1000000.0
 	energy_gen = 1
 

--- a/kubejs/server_scripts/mods/NuclearCraft.js
+++ b/kubejs/server_scripts/mods/NuclearCraft.js
@@ -59,7 +59,7 @@ ServerEvents.recipes(event => {
         event.recipes.gtceu.centrifuge(fuelType + "decompdepleted")
             .itemInputs('nuclearcraft:depleted_fuel_' + fuelType)
             .itemOutputs(out, out2, out3, out4)
-            .duration(1600)
+            .duration(400)
             .EUt(GTValues.VHA[voltageTier])
     }
 

--- a/kubejs/server_scripts/mods/NuclearCraft.js
+++ b/kubejs/server_scripts/mods/NuclearCraft.js
@@ -54,42 +54,41 @@ ServerEvents.recipes(event => {
     decomp("californium_lecf_251", "nuclearcraft:fuel_californium_lecf_251", "8x nuclearcraft:californium_252", "nuclearcraft:californium_251");
     decomp("californium_hecf_251", "nuclearcraft:fuel_californium_hecf_251", "5x nuclearcraft:californium_252", "4x nuclearcraft:californium_251");
 
-    function decompdepleted(fuelType, out, out2, out3, out4) {
+    function decompdepleted(fuelType, out, out2, out3, out4, voltageTier) {
         
         event.recipes.gtceu.centrifuge(fuelType + "decompdepleted")
             .itemInputs('nuclearcraft:depleted_fuel_' + fuelType)
             .itemOutputs(out, out2, out3, out4)
-            .duration(3200)
-            .EUt(48)
+            .duration(1600)
+            .EUt(GTValues.VHA[voltageTier])
     }
 
 
-    decompdepleted('californium_hecf_251', '2x nuclearcraft:californium_251', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252')
-    decompdepleted('neptunium_len_236', 'nuclearcraft:neptunium_237', '4x nuclearcraft:plutonium_242', 'nuclearcraft:americium_242', '3x nuclearcraft:americium_243')
-    decompdepleted('thorium_tbu', '2x nuclearcraft:uranium_233', '8x gtceu:uranium_235_nugget', 'nuclearcraft:neptunium_236', '4x nuclearcraft:neptunium_237')
-    decompdepleted('uranium_leu_233', '4x nuclearcraft:plutonium_242', '4x gtceu:plutonium_nugget', '4x gtceu:plutonium_241_nugget', '3x nuclearcraft:americium_243')
-    decompdepleted('uranium_heu_233', '4x nuclearcraft:neptunium_236', 'nuclearcraft:neptunium_237', '2x nuclearcraft:plutonium_242', 'nuclearcraft:americium_243')
-    decompdepleted('uranium_leu_235', 'nuclearcraft:neptunium_237', '40x gtceu:uranium_nugget', '8x gtceu:plutonium_nugget', '8x gtceu:plutonium_241_nugget')
-    decompdepleted('uranium_heu_235', '2x nuclearcraft:neptunium_237', '20x gtceu:uranium_nugget', '4x gtceu:plutonium_nugget', '3x nuclearcraft:plutonium_242')
-    decompdepleted('neptunium_hen_236', 'nuclearcraft:plutonium_238', '16x gtceu:uranium_nugget', '8x gtceu:plutonium_nugget', '4x nuclearcraft:plutonium_242')
-    decompdepleted('plutonium_lep_239', '3x nuclearcraft:plutonium_242', 'nuclearcraft:curium_243', '8x gtceu:plutonium_nugget', '3x nuclearcraft:curium_246')
-    decompdepleted('plutonium_hep_239', 'nuclearcraft:americium_241', '3x nuclearcraft:americium_242', 'nuclearcraft:curium_245', '3x nuclearcraft:curium_246')
-    decompdepleted('plutonium_lep_241', 'nuclearcraft:plutonium_242', 'nuclearcraft:plutonium_242', 'nuclearcraft:americium_243', '6x nuclearcraft:curium_246')
-    decompdepleted('plutonium_hep_241', 'nuclearcraft:americium_241', 'nuclearcraft:curium_245', '3x nuclearcraft:curium_246', '3x nuclearcraft:curium_247')
-    decompdepleted('americium_lea_242', 'nuclearcraft:curium_243', 'nuclearcraft:curium_245', '5x nuclearcraft:curium_246', 'nuclearcraft:curium_247')
-    decompdepleted('americium_hea_242', '2x nuclearcraft:curium_245', '4x nuclearcraft:curium_246', 'nuclearcraft:curium_247', 'nuclearcraft:berkelium_247')
-    decompdepleted('curium_lecm_243', '4x nuclearcraft:curium_246', '2x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249')
-    decompdepleted('curium_hecm_243', '3x nuclearcraft:curium_246', '3x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249')
-    decompdepleted('curium_lecm_245', '5x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249', '2x nuclearcraft:californium_252')
-    decompdepleted('curium_hecm_245', '6x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249', 'nuclearcraft:californium_251')
-    decompdepleted('curium_lecm_247', '3x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_251', '4x nuclearcraft:californium_252')
-    decompdepleted('curium_hecm_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249', '3x nuclearcraft:californium_251', '3x nuclearcraft:californium_252')
-    decompdepleted('berkelium_leb_248', 'nuclearcraft:californium_249', 'nuclearcraft:californium_251', '3x nuclearcraft:californium_252', '3x nuclearcraft:californium_252')
-    decompdepleted('berkelium_heb_248', 'nuclearcraft:californium_250', 'nuclearcraft:californium_251', '3x nuclearcraft:californium_252', '3x nuclearcraft:californium_252')
-    decompdepleted('californium_lecf_249', '2x nuclearcraft:californium_250', 'nuclearcraft:californium_251', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252')
-    decompdepleted('californium_hecf_249', '4x nuclearcraft:californium_250', '2x nuclearcraft:californium_251', 'nuclearcraft:californium_252', 'nuclearcraft:californium_252')
-    decompdepleted('californium_lecf_251', 'nuclearcraft:californium_251', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252')
-
+    decompdepleted('thorium_tbu', '2x nuclearcraft:uranium_233', '8x gtceu:uranium_235_nugget', 'nuclearcraft:neptunium_236', '4x nuclearcraft:neptunium_237', GTValues.IV)
+    decompdepleted('uranium_leu_233', '4x nuclearcraft:plutonium_242', '4x gtceu:plutonium_nugget', '4x gtceu:plutonium_241_nugget', '3x nuclearcraft:americium_243', GTValues.IV)
+    decompdepleted('uranium_heu_233', '4x nuclearcraft:neptunium_236', 'nuclearcraft:neptunium_237', '2x nuclearcraft:plutonium_242', 'nuclearcraft:americium_243', GTValues.IV)
+    decompdepleted('uranium_leu_235', 'nuclearcraft:neptunium_237', '40x gtceu:uranium_nugget', '8x gtceu:plutonium_nugget', '8x gtceu:plutonium_241_nugget', GTValues.IV)
+    decompdepleted('uranium_heu_235', '2x nuclearcraft:neptunium_237', '20x gtceu:uranium_nugget', '4x gtceu:plutonium_nugget', '3x nuclearcraft:plutonium_242', GTValues.IV)
+    decompdepleted('neptunium_len_236', 'nuclearcraft:neptunium_237', '4x nuclearcraft:plutonium_242', 'nuclearcraft:americium_242', '3x nuclearcraft:americium_243', GTValues.LuV)
+    decompdepleted('neptunium_hen_236', 'nuclearcraft:plutonium_238', '16x gtceu:uranium_nugget', '8x gtceu:plutonium_nugget', '4x nuclearcraft:plutonium_242', GTValues.LuV)
+    decompdepleted('plutonium_lep_239', '3x nuclearcraft:plutonium_242', 'nuclearcraft:curium_243', '8x gtceu:plutonium_nugget', '3x nuclearcraft:curium_246', GTValues.LuV)
+    decompdepleted('plutonium_hep_239', 'nuclearcraft:americium_241', '3x nuclearcraft:americium_242', 'nuclearcraft:curium_245', '3x nuclearcraft:curium_246', GTValues.LuV)
+    decompdepleted('plutonium_lep_241', 'nuclearcraft:plutonium_242', 'nuclearcraft:plutonium_242', 'nuclearcraft:americium_243', '6x nuclearcraft:curium_246', GTValues.LuV)
+    decompdepleted('plutonium_hep_241', 'nuclearcraft:americium_241', 'nuclearcraft:curium_245', '3x nuclearcraft:curium_246', '3x nuclearcraft:curium_247', GTValues.LuV)
+    decompdepleted('americium_lea_242', 'nuclearcraft:curium_243', 'nuclearcraft:curium_245', '5x nuclearcraft:curium_246', 'nuclearcraft:curium_247', GTValues.LuV)
+    decompdepleted('americium_hea_242', '2x nuclearcraft:curium_245', '4x nuclearcraft:curium_246', 'nuclearcraft:curium_247', 'nuclearcraft:berkelium_247', GTValues.LuV)
+    decompdepleted('curium_lecm_243', '4x nuclearcraft:curium_246', '2x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249', GTValues.ZPM)
+    decompdepleted('curium_hecm_243', '3x nuclearcraft:curium_246', '3x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249', GTValues.ZPM)
+    decompdepleted('curium_lecm_245', '5x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249', '2x nuclearcraft:californium_252', GTValues.ZPM)
+    decompdepleted('curium_hecm_245', '6x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249', 'nuclearcraft:californium_251', GTValues.ZPM)
+    decompdepleted('curium_lecm_247', '3x nuclearcraft:berkelium_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_251', '4x nuclearcraft:californium_252', GTValues.ZPM)
+    decompdepleted('curium_hecm_247', 'nuclearcraft:berkelium_248', 'nuclearcraft:californium_249', '3x nuclearcraft:californium_251', '3x nuclearcraft:californium_252', GTValues.ZPM)
+    decompdepleted('berkelium_leb_248', 'nuclearcraft:californium_249', 'nuclearcraft:californium_251', '3x nuclearcraft:californium_252', '3x nuclearcraft:californium_252', GTValues.ZPM)
+    decompdepleted('berkelium_heb_248', 'nuclearcraft:californium_250', 'nuclearcraft:californium_251', '3x nuclearcraft:californium_252', '3x nuclearcraft:californium_252', GTValues.ZPM)
+    decompdepleted('californium_lecf_249', '2x nuclearcraft:californium_250', 'nuclearcraft:californium_251', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252', GTValues.ZPM)
+    decompdepleted('californium_hecf_249', '4x nuclearcraft:californium_250', '2x nuclearcraft:californium_251', 'nuclearcraft:californium_252', 'nuclearcraft:californium_252', GTValues.ZPM)
+    decompdepleted('californium_lecf_251', 'nuclearcraft:californium_251', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252', GTValues.ZPM)
+    decompdepleted('californium_hecf_251', '2x nuclearcraft:californium_251', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252', '2x nuclearcraft:californium_252', GTValues.ZPM)
 
 
     function cansolid(name, input) {

--- a/kubejs/server_scripts/mods/Solar_Flux.js
+++ b/kubejs/server_scripts/mods/Solar_Flux.js
@@ -176,21 +176,21 @@ ServerEvents.recipes(event => {
             'ABA'
         ], {
             A: 'kubejs:stabilized_plutonium',
-            B: 'kubejs:stabilized_curium',
+            B: 'kubejs:stabilized_americium',
             C: 'minecraft:glowstone'
         }
     )
     event.recipes.gtceu.mixer('kubejs:sunnarium_dust_mixer')
-        .inputFluids('gtceu:plutonium 144', 'gtceu:curium 72')
+        .inputFluids('gtceu:plutonium 144', 'gtceu:americium 72')
         .itemInputs('minecraft:glowstone_dust')
         .itemOutputs('2x gtceu:sunnarium_dust')
-        .duration(2000)
+        .duration(1800)
         .EUt(GTValues.VHA[GTValues.IV]);
     event.recipes.gtceu.mixer('kubejs:sunnarium_dust_mixer_alt')
-        .inputFluids('gtceu:plutonium_241 144', 'gtceu:curium 72')
+        .inputFluids('gtceu:plutonium_241 144', 'gtceu:americium 72')
         .itemInputs('minecraft:glowstone_dust')
         .itemOutputs('2x gtceu:sunnarium_dust')
-        .duration(2000)
+        .duration(1800)
         .EUt(GTValues.VHA[GTValues.IV]);
 
     event.remove({ id: 'gtceu:macerator/macerate_sunnarium_plate'})
@@ -204,15 +204,15 @@ ServerEvents.recipes(event => {
             'ABA'
         ], {
             A: 'kubejs:stabilized_neptunium',
-            B: 'kubejs:stabilized_americium',
+            B: 'kubejs:stabilized_curium',
             C: 'gtceu:sunnarium_dust'
         }
     )
     event.recipes.gtceu.mixer('kubejs:enriched_sunnarium_dust_mixer')
-        .inputFluids('gtceu:neptunium 288', 'gtceu:americium 144')
+        .inputFluids('gtceu:neptunium 288', 'gtceu:curium 144')
         .itemInputs('gtceu:sunnarium_dust')
         .itemOutputs('6x gtceu:enriched_sunnarium_dust')
-        .duration(2000)
+        .duration(2400)
         .EUt(GTValues.VHA[GTValues.LuV]);
 
     event.remove({ id: 'gtceu:macerator/macerate_enriched_sunnarium_plate'})

--- a/manifest.json
+++ b/manifest.json
@@ -211,7 +211,7 @@
       "required": true
     },
     {
-      "fileID": 5547335,
+      "fileID": 5889370,
       "projectID": 840010,
       "required": true
     },


### PR DESCRIPTION
Updates Nuclearcraft: Neoteric to the most recent beta, despite the developer's warning.
Also vastly increases fission fuels' FE output and lifetime now that it's possible, gates higher-tier nuclear fuels behind thermal centrifuge recipes, and rebalances Sunnarium to avoid conflicts with those tiered thermal centrifuge recipes.