### PR TITLE
Restore alternative reciepe for oak drawers using only chests.

### DIFF
--- a/kubejs/server_scripts/mods/functionalstorage.js
+++ b/kubejs/server_scripts/mods/functionalstorage.js
@@ -1,8 +1,4 @@
 ServerEvents.recipes(event => {
-    //Remove bugged Oak Drawer recipes
-    event.remove({ id: /functionalstorage:oak_drawer_alternate/ })
-
-
     // Fluid Drawers
     event.replaceInput({ output: /fluid/, mod: 'functionalstorage'}, '#minecraft:planks', '#forge:plates/iron')
     event.replaceInput({ output: /fluid/, mod: 'functionalstorage'}, 'minecraft:bucket', 'gtceu:lv_hermetic_casing')


### PR DESCRIPTION
These were removed in #826 to fix #782. However, I think the behaviour is working (at least mostly) as intended. It is definitely intended that you can craft oak drawers without needing planks, shift clicking allowing crafting different recipes with the same output is slightly surprising.

This is a slightly cheaper, but avoids there being a micro-optimization of using 4x drawers instead of 1x drawers as crafting ingredients (since 4x drawers cost 9.25 planks vs 16 for 1x drawers). With these recipes, they can both cost 8 planks unless you want different textures.