### PR TITLE
Added ExtendedAE to invtweaks override

### DIFF
--- a/config/invtweaks-client.toml
+++ b/config/invtweaks-client.toml
@@ -88,6 +88,10 @@
 		containerClass = "com.direwolf20.laserio.client.screens.*"
 		sortRange = ""
 
+	[[sorting.containerOverrides]]
+		containerClass = "com.glodblock.github.extendedae.client.gui.*"
+		sortRange = ""
+
 	#Categor(y/ies) for sorting
 	#
 	#name: the name of the category


### PR DESCRIPTION
Sorting ExtendedAE inventories isnt useful and can cause weird upgrade card stacking behavior. Added to the override list.