### PR TITLE
Add a Programmed Circuit to the Ender Chest assembler recipe to avoid conflicts with the Flux Core

### DIFF
--- a/kubejs/server_scripts/mods/optionalCompats/fluxnetworks.js
+++ b/kubejs/server_scripts/mods/optionalCompats/fluxnetworks.js
@@ -22,7 +22,6 @@ if (Platform.isLoaded('fluxnetworks')) {
             .itemInputs('1x minecraft:ender_eye', '4x minecraft:obsidian', '4x fluxnetworks:flux_dust', '1x gtceu:luv_sensor', '1x gtceu:luv_emitter', '4x enderio:cryolobus_conduit')
             .EUt(GTValues.VA[GTValues.LuV])
             .duration(200)
-            .circuit(1)
 
         //Flux Controller
         event.shaped('fluxnetworks:flux_controller', [

--- a/kubejs/server_scripts/mods/optionalCompats/fluxnetworks.js
+++ b/kubejs/server_scripts/mods/optionalCompats/fluxnetworks.js
@@ -22,6 +22,7 @@ if (Platform.isLoaded('fluxnetworks')) {
             .itemInputs('1x minecraft:ender_eye', '4x minecraft:obsidian', '4x fluxnetworks:flux_dust', '1x gtceu:luv_sensor', '1x gtceu:luv_emitter', '4x enderio:cryolobus_conduit')
             .EUt(GTValues.VA[GTValues.LuV])
             .duration(200)
+            .circuit(1)
 
         //Flux Controller
         event.shaped('fluxnetworks:flux_controller', [

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -968,5 +968,14 @@ ServerEvents.recipes(event => {
         .itemOutputs('minecraft:pearlescent_froglight')
         .duration(20)
         .EUt(15)
+    
+    // Vanilla Ender Chest
+    event.remove({ output: 'minecraft:ender_chest', type: 'gregtech:assembler' })
+    event.recipes.gtceu.assembler('ender_chest')
+        .itemInputs('8x minecraft:obsidian','minecraft:ender_eye')
+        .itemOutputs('minecraft:ender_chest')
+        .duration(100)
+        .EUt(4)
+        .circuit(1)
 })
  

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -970,7 +970,7 @@ ServerEvents.recipes(event => {
         .EUt(15)
     
     // Vanilla Ender Chest
-    event.remove({ output: 'minecraft:ender_chest', type: 'gregtech:assembler' })
+    event.remove({ id: 'gtceu:assembler/ender_chest' })
     event.recipes.gtceu.assembler('ender_chest')
         .itemInputs('8x minecraft:obsidian','minecraft:ender_eye')
         .itemOutputs('minecraft:ender_chest')


### PR DESCRIPTION
When bulk crafting, the machine may occasionally prioritize using the ingredients to craft Ender Chests.

![image](https://github.com/user-attachments/assets/b4df39c9-c42c-41d5-9daf-2d9d22dee444)
![image](https://github.com/user-attachments/assets/c645e862-4b26-4cda-960e-312d3fb6bbdc)
