### PR TITLE
Move GregTech ore prospector buttons to the top bar.

### DIFF
--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -565,7 +565,7 @@ compat:
 
     # Whether to put buttons on a separate toolbar on the right instead of the map type toolbar in JourneyMap.
     # Default: true
-    rightToolbar: true
+    rightToolbar: false
 
   # Whether to hide facades of all blocks in JEI and creative search menu.
   # Default: true


### PR DESCRIPTION
Otherwise, they overlap the FTB Chunks buttons on the right.