### PR TITLE
Fix PackagedExCrafting/PackagedExExCrafting file IDs in manifest.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -221,12 +221,12 @@
       "required": true
     },
     {
-      "fileID": 5846811,
+      "fileID": 5846805,
       "projectID": 322861,
       "required": true
     },
     {
-      "fileID": 5568986,
+      "fileID": 5846811,
       "projectID": 1028872,
       "required": true
     },


### PR DESCRIPTION
It looks like #1155 may incorrectly changed one of the entries twice. This updates both mods to the latest version.

I haven't tested this beyond running the download script (which is how I noticed the issue.