### PR TITLE
Jetpacks localizations

### DIFF
--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -383,6 +383,18 @@
   "item.kubejs.uev_universal_circuit": "UEV Universal Circuit",
   "item.kubejs.uiv_universal_circuit": "UIV Universal Circuit",
 
+  "jetpack.conductiveiron.name": "Conductive Iron",
+  "jetpack.creative.name": "Creative",
+  "jetpack.darksoularium.name": "Dark Soularium",
+  "jetpack.electricalsteel.name": "Electrical Steel",
+  "jetpack.energetic.name": "Energetic",
+  "jetpack.fluxed.name": "Fluxed",
+  "jetpack.hardened.name": "Hardened",
+  "jetpack.leadstone.name": "Leadstone",
+  "jetpack.reinforced.name": "Reinforced",
+  "jetpack.resonant.name": "Resonant",
+  "jetpack.vibrant.name": "Vibrant",
+
   "__MISC_TOOLTIPS__.header": "=========================",
   "__MISC_TOOLTIPS__.flufff": "> Miscellaneous Tooltips<",
   "__MISC_TOOLTIPS__.footer": "=========================",


### PR DESCRIPTION
Creating a translation template for jetpack's crafting materials to support other languages. 
The reason I'm not putting it in the ironjetpacks folder is that if players use other translate resourcepacks, 
the language files in the same folder will be overwritten by the resourcepack. 

Since these crafting materials are custom to this pack, I think it's more appropriate to put them in the kubejs folder. 

Currently, the crafting material names for jetpack components cannot be translated yet, 
and we need to wait for this [PR](https://github.com/BlakeBr0/IronJetpacks/pull/108) to be merged.