### PR TITLE
Tweak Various Microminer Recipes to push back some line skips, buffed Fusion MK3

### DIFF
--- a/config/ftbquests/quests/chapters/late_game.snbt
+++ b/config/ftbquests/quests/chapters/late_game.snbt
@@ -789,7 +789,7 @@
 				""
 				"You can also get tons of this from &6Platinum Group Sludge&r."
 				""
-				"&2Osmiridium 80/20 Ore and Iridosmine 80/20 Ore&r is available renewably from the Tier Four and Tier Six micro miners, as well as semi-renewably from the Tier Five micro miner."
+				"&2Osmiridium 80/20 Ore and Iridosmine 80/20 Ore&r are available renewably from the Tier Six micro miner, as well as semi-renewably from the Tier Five micro miner."
 			]
 			id: "025092551C0A20B6"
 			rewards: [{

--- a/config/ftbquests/quests/chapters/late_game.snbt
+++ b/config/ftbquests/quests/chapters/late_game.snbt
@@ -179,14 +179,6 @@
 			y: 8.25d
 		}
 		{
-			id: "26C607D68B1B1404"
-			linked_quest: "1C1B1E1BBFA079F5"
-			shape: "hexagon"
-			size: 1.5d
-			x: 1.5d
-			y: 8.75d
-		}
-		{
 			id: "69230B4A261BC806"
 			linked_quest: "53EC3831D66769CA"
 			shape: "hexagon"
@@ -309,7 +301,7 @@
 				""
 				"All of the Tier Four missions require &68 Quantum Flux&r and a stack of &6Petrotheum Dust&r."
 				""
-				"This miner is the first convenient source of &6Osmium&r and &6Iridium&r, via a mission requiring &6Wither Realm Data&r."
+				"This miner is the first convenient source of &6Sheldonite&r, the best choice for creating &6Platinum Group Sludge&r, via a mission requiring &6Wither Realm Data&r."
 				""
 				"A &6Composition Sensor&r instead directs the miner to obtain &6Dense Oilsands Ore&r, equivalent to &232&r stacks of &6End Oilsands Ore&r, and 32 &6Compressed Infinity Dust Blocks&r, equivalent to 2592 &6Infinity Dust&r."
 				""
@@ -626,7 +618,7 @@
 		{
 			dependencies: [
 				"6DC635766CD40FFF"
-				"1C1B1E1BBFA079F5"
+				"044553423097C3C7"
 			]
 			description: [
 				"Coming into &9Ludicrous Voltage&r, many new advanced materials will be required to craft items and components. Most of these materials require &6RTM Alloy Coils&r."
@@ -780,10 +772,7 @@
 			y: 18.25d
 		}
 		{
-			dependencies: [
-				"15DBB22E3DC0AFB7"
-				"1C1B1E1BBFA079F5"
-			]
+			dependencies: ["044553423097C3C7"]
 			description: [
 				"&6Iridium&r is an advanced material used for Micro Miners, and for alloying with &6Osmium&r into &6Osmiridium&r."
 				""
@@ -2857,6 +2846,45 @@
 			title: "&9Quintessence Infuser"
 			x: 27.75d
 			y: 19.875d
+		}
+		{
+			dependencies: [
+				"595F205B551A53C9"
+				"15DBB22E3DC0AFB7"
+			]
+			description: [
+				"&2A rudimentary version of Platinum Group Sludge (PGS) processing existed in the base pack. Here, it is a strong source of the Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum - as well as Gold. All of these elements will be used in IV-tier and above materials."
+				""
+				"&rYou will need to treat certain ores with &9Nitric Acid&r to yield &6PGS&r - &6Sheldonite&r is the best. Then, using an &3HV+ Centrifuge&r and &9Aqua Regia&r, break it down into the PGS salts, and reduce those salts to the metals."
+				""
+				"&9This is not optional - Platinum Group sludge processing is necessary to get your first &6Iridium&9 and &6Osmium&9.&r However, you can get &6Ruthenium&r and &6Rhodium&r from &6Laurite&r and &6Cuprorhodsite&r in the Microverse before then."
+			]
+			icon: "gtceu:platinum_dust"
+			id: "044553423097C3C7"
+			rewards: [{
+				count: 2
+				id: "400B871C9C2B5830"
+				item: "kubejs:moni_quarter"
+				type: "item"
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			subtitle: "Is this that \"Gregtech PGS\" people refer to?"
+			tasks: [
+				{
+					id: "1CA9B9FE385B774C"
+					item: "gtceu:ruthenium_dust"
+					type: "item"
+				}
+				{
+					id: "18237021D2F3D527"
+					item: "gtceu:rhodium_dust"
+					type: "item"
+				}
+			]
+			title: "&2Platinum Group Processing"
+			x: 1.5d
+			y: 3.0d
 		}
 	]
 	title: "Late Game"

--- a/config/ftbquests/quests/chapters/late_game.snbt
+++ b/config/ftbquests/quests/chapters/late_game.snbt
@@ -1445,13 +1445,11 @@
 			description: [
 				"&2There are 3 materials you will need from processing Naquadah: Enriched Naquadah (Nq+), Naquadria (Nq*), and Trinium (Ke). "
 				""
-				"There are 3 different ways to process Naquadah, each resulting in different materials.&r"
+				"There are 2 different ways to process Naquadah, each resulting in different materials.&r"
 				""
-				"First is by &9processing ores&r from the &6Tier Five Micro Miner&r. &6Naquadah Ore&r yields &6Enriched Naquadah&r (through the &3Magnetic Separator&r) and &6Kaemanite Ore&r yields &6Trinium&r."
+				"The first option is to &9process ores&r from the &6Tier Five Micro Miner&r. &6Naquadah Ore&r yields &6Enriched Naquadah&r (through the &3Magnetic Separator&r) and &6Kaemanite Ore&r yields &6Trinium&r."
 				""
-				"Second is by combining &6Naquadah Dust&r with certain heavy elements and Ender IO crystal grains. This can provide &6Enriched Naquadah&r and &6Naquadria&r."
-				""
-				"Finally, you can do the full CEu processing of &6Naquadah Dust&r with &9Fluoroantimonic Acid&r, the strongest acid known to man. This is a decently involved process, but not only does it yield all 2 other Nq materials, it also grants byproducts of &6Titanium, Sulfur, Indium, Phosphorus, Barium, and Gallium&r. "
+				"The second option is to do the full CEu processing of &6Naquadah Dust&r with &9Fluoroantimonic Acid&r, the strongest acid known to man. This is a decently involved process, but not only does it yield all 2 other Nq materials, it also grants byproducts of &6Titanium, Sulfur, Indium, Phosphorus, Barium, and Gallium&r. "
 			]
 			icon: "gtceu:naquadria_dust"
 			id: "0508D3CCB6C876A3"
@@ -1503,7 +1501,7 @@
 				""
 				"&6Enriched Naquadah&r is meant to be used in as-of-yet-unimplemented CEu-native reactors. It's used in small amounts for &3Trinium Coil blocks&r, or in Moni reactors, though Naquadria is better for that purpose."
 				""
-				"At least it's the easiest to obtain, and you can get it by mixing, the full Naquadah chain, or by passing Purified Naquadah Dust through an Electromagnetic Separator."
+				"At least it's the easiest to obtain, and you can get it by the full Naquadah processing chain or by passing &6Purified Naquadah Dust&r through an &3Electromagnetic Separator&r."
 			]
 			id: "41FA85A3920EB334"
 			rewards: [{

--- a/config/ftbquests/quests/chapters/mid_game.snbt
+++ b/config/ftbquests/quests/chapters/mid_game.snbt
@@ -1133,7 +1133,7 @@
 				""
 				"&rYou will need to treat certain ores with &9Nitric Acid&r to yield &6PGS&r - &6Sheldonite&r is the best. Then, using an &3HV+ Centrifuge&r and &9Aqua Regia&r, break it down into the PGS salts, and reduce those salts to the metals."
 				""
-				"This is still optional, and you can get &6Ruthenium&r and &6Rhodium&r from &6Osmiridium 80/20 Ore&r and &6Iridosmine 80/20 Ore&r from Microverse adventures instead."
+				"&9This is not optional - Platinum Group sludge processing is necessary to get your first &6Iridium&9 and &6Osmium&9.&r However, you can get &6Ruthenium&r and &6Rhodium&r from &6Laurite&r and &6Cuprorhodsite&r in the Microverse before then."
 			]
 			icon: "gtceu:platinum_dust"
 			id: "1C1B1E1BBFA079F5"

--- a/config/ftbquests/quests/chapters/mid_game.snbt
+++ b/config/ftbquests/quests/chapters/mid_game.snbt
@@ -1127,42 +1127,6 @@
 			y: -4.5d
 		}
 		{
-			dependencies: ["595F205B551A53C9"]
-			description: [
-				"&2A rudimentary version of Platinum Group Sludge (PGS) processing existed in the base pack. Here, it is a strong source of the Platinum Group Metals - Ruthenium, Rhodium, Palladium, Osmium, Iridium, and Platinum - as well as Gold. All of these elements will be used in IV-tier and above materials."
-				""
-				"&rYou will need to treat certain ores with &9Nitric Acid&r to yield &6PGS&r - &6Sheldonite&r is the best. Then, using an &3HV+ Centrifuge&r and &9Aqua Regia&r, break it down into the PGS salts, and reduce those salts to the metals."
-				""
-				"&9This is not optional - Platinum Group sludge processing is necessary to get your first &6Iridium&9 and &6Osmium&9.&r However, you can get &6Ruthenium&r and &6Rhodium&r from &6Laurite&r and &6Cuprorhodsite&r in the Microverse before then."
-			]
-			icon: "gtceu:platinum_dust"
-			id: "1C1B1E1BBFA079F5"
-			rewards: [{
-				count: 2
-				id: "79E180C05B68E313"
-				item: "kubejs:moni_quarter"
-				type: "item"
-			}]
-			shape: "hexagon"
-			size: 1.5d
-			subtitle: "Is this that \"Gregtech PGS\" people refer to?"
-			tasks: [
-				{
-					id: "1185F72BA982FE56"
-					item: "gtceu:ruthenium_dust"
-					type: "item"
-				}
-				{
-					id: "42B1F1F92647E29C"
-					item: "gtceu:rhodium_dust"
-					type: "item"
-				}
-			]
-			title: "&2Platinum Group Processing"
-			x: 38.0d
-			y: 3.0d
-		}
-		{
 			dependencies: ["5357A16B5BF62C96"]
 			description: [
 				"There are several paths to &9Acetic Acid&r... probably the simplest is combining &9Oxygen&r, &9Hydrogen&r, and &6Carbon&r, but one of the several other methods may appeal to you more, especially if you have a &3Distillation Tower&r."

--- a/config/ftbquests/quests/chapters/progression.snbt
+++ b/config/ftbquests/quests/chapters/progression.snbt
@@ -778,13 +778,14 @@
 		{
 			dependencies: [
 				"3B3F46345D39CAE2"
-				"1C1B1E1BBFA079F5"
 				"544E87F5E356FE10"
 			]
 			description: [
 				"&6RTM Alloy&r is an alloy of &6Ruthenium&r, &6Tungsten&r and &6Molybdenum&r."
 				""
 				"This alloy is cooked in an &3Electric Blast Furnace&r and cooled in a &3Vacuum Freezer&r."
+				""
+				"&6Ruthenium&r can be processed from &6Laurite&r, or &6Platinum Group Sludge&r, if you wish to start that chain early."
 			]
 			disable_toast: true
 			id: "5D0A642048AF909B"

--- a/kubejs/server_scripts/_hardmode/hardmode_missions.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_missions.js
@@ -312,26 +312,5 @@ ServerEvents.recipes(event => {
             )
             .duration(450*20)
             .EUt(250000)
-
-    event.recipes.gtceu.advanced_microverse_ii('kubejs:t_nine_second')
-        .itemInputs(
-            'kubejs:microminer_t9',
-            '8x gtceu:neutron_reflector',
-            '4x gtceu:cryococcus_block',
-            'kubejs:stellar_creation_data'
-        )
-        .itemOutputs(
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget'
-        )
-        .duration(3000)
-        .EUt(250000)
     }
 })

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -182,16 +182,6 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(7500)
 
-
-    event.recipes.gtceu.advanced_microverse('kubejs:t_four_first')
-        .itemInputs('kubejs:microminer_t4', '8x kubejs:quantum_flux', '4x kubejs:wither_realm_data', '64x kubejs:petrotheum_dust')
-        .itemOutputs(
-            '64x gtceu:iridosmineyes_ore',
-            '64x gtceu:iridosmineyes_ore',
-            '16x gtceu:osmiridiumyes_ore')
-        .duration(800)
-        .EUt(3750)
-
     event.recipes.gtceu.advanced_microverse('kubejs:t_four_second')
         .itemInputs('kubejs:microminer_t4', '8x kubejs:quantum_flux', 'kubejs:gem_sensor', '64x kubejs:petrotheum_dust')
         .itemOutputs(

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -150,7 +150,6 @@ ServerEvents.recipes(event => {
         .duration(800)
         .EUt(2000)
 })
-//ALL OF THE ABOVE IS DONE
 
 // Advanced Microverse Projector Recipes
 ServerEvents.recipes(event => {
@@ -164,6 +163,22 @@ ServerEvents.recipes(event => {
         )
         .duration(600)
         .EUt(7500)
+
+        event.recipes.gtceu.advanced_microverse('kubejs:t_four_first')
+        .itemInputs('kubejs:microminer_t4', '8x kubejs:quantum_flux', '4x kubejs:wither_realm_data', '64x kubejs:petrotheum_dust')
+        .itemOutputs(
+            '64x gtceu:raw_cooperite',
+            '64x gtceu:raw_cooperite',
+            '64x gtceu:raw_cooperite',
+            '64x gtceu:raw_cooperite',
+            '64x gtceu:raw_cooperite',
+            '64x gtceu:raw_cooperite',
+            '64x gtceu:platinum_group_sludge_dust',
+            '64x gtceu:rock_salt_dust',
+            '64x gtceu:rock_salt_dust'
+        )
+        .duration(800)
+        .EUt(3750)
 
     event.recipes.gtceu.advanced_microverse('kubejs:t_four_second')
         .itemInputs('kubejs:microminer_t4', '8x kubejs:quantum_flux', 'kubejs:gem_sensor', '64x kubejs:petrotheum_dust')
@@ -440,15 +455,8 @@ ServerEvents.recipes(event => {
             'kubejs:stellar_creation_data'
         )
         .itemOutputs(
-            '64x gtceu:neutronium_nugget', 
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget', 
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget', 
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget', 
-            '64x gtceu:neutronium_nugget',
-            '64x gtceu:neutronium_nugget'
+            '64x gtceu:neutronium_ingot',
+            '32x gtceu:neutronium_ingot'
         )
         .duration(3000)
         .EUt(250000)

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -1,23 +1,6 @@
 // Small Microverse Projector Recipes
 ServerEvents.recipes(event => {
 
-    if (isNormalMode) { // Normal mode-specific recipes
-        event.recipes.gtceu.advanced_microverse_ii('kubejs:t_nine_second')
-            .itemInputs(
-                'kubejs:microminer_t9',
-                '8x gtceu:neutron_reflector',
-                '4x gtceu:cryococcus_block',
-                'kubejs:stellar_creation_data'
-            )
-            .itemOutputs(
-                '64x gtceu:neutronium_ingot',
-                '64x gtceu:neutronium_ingot',
-                '32x gtceu:neutronium_ingot'
-            )
-            .duration(3000)
-            .EUt(250000)
-    }
-
     event.recipes.gtceu.basic_microverse('kubejs:t_one_first')
         .itemInputs('kubejs:microminer_t1', 'kubejs:ultra_dense_hydrogen')
         .itemOutputs('kubejs:stellar_creation_data')
@@ -446,6 +429,27 @@ ServerEvents.recipes(event => {
             '64x kubejs:stellar_creation_data'
         )
         .itemOutputs('kubejs:universe_creation_data')
+        .duration(3000)
+        .EUt(250000)
+
+    event.recipes.gtceu.advanced_microverse_ii('kubejs:t_nine_second')
+        .itemInputs(
+            'kubejs:microminer_t9', 
+            '8x gtceu:neutron_reflector', 
+            '4x gtceu:cryococcus_block', 
+            'kubejs:stellar_creation_data'
+        )
+        .itemOutputs(
+            '64x gtceu:neutronium_nugget', 
+            '64x gtceu:neutronium_nugget',
+            '64x gtceu:neutronium_nugget', 
+            '64x gtceu:neutronium_nugget',
+            '64x gtceu:neutronium_nugget', 
+            '64x gtceu:neutronium_nugget',
+            '64x gtceu:neutronium_nugget', 
+            '64x gtceu:neutronium_nugget',
+            '64x gtceu:neutronium_nugget'
+        )
         .duration(3000)
         .EUt(250000)
 

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -292,21 +292,6 @@ ServerEvents.recipes(event => {
     }
     ).id('gtceu:shaped/casing_assembly_line')
 
-    // Mixer naquadah enrichment
-    event.recipes.gtceu.mixer("mixer_enriched_naquadah")
-        .itemInputs("2x gtceu:naquadah_dust", "4x enderio:grains_of_infinity", "kubejs:grains_of_innocence", "enderio:pulsating_powder")
-        .inputFluids("gtceu:pulsating_alloy 576", "gtceu:neptunium 144")
-        .itemOutputs("gtceu:enriched_naquadah_dust")
-        .duration(400)
-        .EUt(8000)
-
-    event.recipes.gtceu.mixer("mixer_naquadria")
-        .itemInputs("2x gtceu:naquadah_dust", "enderio:prescient_powder", "4x enderio:vibrant_powder", "enderio:ender_crystal_powder")
-        .inputFluids("gtceu:enderium 576", "gtceu:curium 144")
-        .itemOutputs("gtceu:naquadria_dust")
-        .duration(400)
-        .EUt(30000)
-
     //Netherstar Crafting
     event.shaped('kubejs:nether_star_south', [
         "ADA",

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -737,6 +737,15 @@ ServerEvents.recipes(event => {
     .duration(320)
     .EUt(-2048)
 
+    // Neutronium Buff
+    event.remove({ id: "gtceu:fusion_reactor/americium_and_naquadria_to_neutronium_plasma" })
+    event.recipes.gtceu.fusion_reactor('neutronium_buffed')
+    .inputFluids('gtceu:americium 128', 'gtceu:naquadah 128')
+    .outputFluids('gtceu:neutronium 32')
+    .duration(130)
+    .EUt(98304)
+    .fusionStartEU(600000000)
+
     //Resonant Clathrate
     event.recipes.gtceu.chemical_reactor('resonant_clathrate')
     .itemInputs('minecraft:quartz')


### PR DESCRIPTION
There have been plenty of discussions about this, but some persons have been concerned with the ease in which players can skip certain processing lines, citing the argument that by avoiding these challenges, they arrive at the endgame ill-prepared for the difficulty spike it presents.


This PR offers a solutions for some of these, each separated into an individual commit for easy cherry-picking:

1. Discourage players from skipping Platline by removing the T4MM mission that returns Osmiridium.
Without this mission, all ores that yield Osmium and Iridium in reasonable amounts are gated behind T5MM (itself made of Iridium) or Platline.
Note that this leaves Chalcocite/Cuprorhodsite (Ruthenium ores) as-is.

2. Discourage players from skipping Naqline by removing the mixer recipes for Enriched Naquadah/Naquadria.
Without this mission, there is no other source of Enriched Naquadah/Naquadria before doing Naqline.
Note that this leaves Kaemanite (Trinium ore) as-is.

3. Discourage players from skipping Mk3 fusion (NM only) by reverting the buff for the T9MM mission that returns Neutronium.
I have read messages from a group of players who cited Mk3 fusion to be useless given the presence of this mission. Given that Mk3 is so close to Creative Tank _and is otherwise useless due to Tank,_ then this may be intended behaviour so as to be rid of what may amount to an annoying obstacle. Otherwise, this would make players use Mk3 fusion once more.