### PR TITLE
Move GregTech ore prospector buttons to the top bar. [Hard/Expert]

### DIFF
--- a/config-overrides/expert/gtceu.yaml
+++ b/config-overrides/expert/gtceu.yaml
@@ -565,7 +565,7 @@ compat:
 
     # Whether to put buttons on a separate toolbar on the right instead of the map type toolbar in JourneyMap.
     # Default: true
-    rightToolbar: true
+    rightToolbar: false
 
   # Whether to hide facades of all blocks in JEI and creative search menu.
   # Default: true

--- a/config-overrides/hardmode/gtceu.yaml
+++ b/config-overrides/hardmode/gtceu.yaml
@@ -565,7 +565,7 @@ compat:
 
     # Whether to put buttons on a separate toolbar on the right instead of the map type toolbar in JourneyMap.
     # Default: true
-    rightToolbar: true
+    rightToolbar: false
 
   # Whether to hide facades of all blocks in JEI and creative search menu.
   # Default: true


### PR DESCRIPTION
Otherwise, they overlap the FTB Chunks buttons on the right.

This is syncing the changes from #1162 to the other modes.