### PR TITLE
Add mod "Grass Slabs, Carpets & Stairs".

### DIFF
--- a/config/quark-common.toml
+++ b/config/quark-common.toml
@@ -1593,7 +1593,7 @@
 	[client.greener_grass]
 		"Affect Leaves" = true
 		"Affect Water" = false
-		"Block List" = ["minecraft:large_fern", "minecraft:tall_grass", "minecraft:grass_block", "minecraft:fern", "minecraft:grass", "minecraft:potted_fern", "minecraft:sugar_cane", "environmental:giant_tall_grass", "valhelsia_structures:grass_block"]
+		"Block List" = ["minecraft:large_fern", "minecraft:tall_grass", "minecraft:grass_block", "minecraft:fern", "minecraft:grass", "minecraft:potted_fern", "minecraft:sugar_cane", "environmental:giant_tall_grass", "valhelsia_structures:grass_block", "grassslabs:grass_carpet", "grassslabs:grass_slab", "grassslabs:grass_stairs"]
 		"Leaves List" = ["minecraft:spruce_leaves", "minecraft:birch_leaves", "minecraft:oak_leaves", "minecraft:jungle_leaves", "minecraft:acacia_leaves", "minecraft:dark_oak_leaves", "atmospheric:rosewood_leaves", "atmospheric:morado_leaves", "atmospheric:yucca_leaves", "autumnity:maple_leaves", "environmental:willow_leaves", "environmental:hanging_willow_leaves", "minecraft:vine"]
 
 		[client.greener_grass.color_matrix]

--- a/manifest.json
+++ b/manifest.json
@@ -1034,6 +1034,11 @@
       "fileID": 5969656,
       "projectID": 1005914,
       "required": true
+    },
+    {
+      "fileID": 5091889,
+      "projectID": 565833,
+      "required": true
     }
   ]
 }


### PR DESCRIPTION
This was suggested by the author of FramedBlocks to get nicer textures on grass slabs. (See https://github.com/XFactHD/FramedBlocks/issues/141#issuecomment-1267701201).

https://www.curseforge.com/minecraft/mc-mods/grass-slabs-carpets-stairs

With FramedBlocks: 
![image](https://github.com/user-attachments/assets/8827cf7c-852e-45c6-9720-2f80c9331fc5)
With new mod (note the block sides of the slabs:
![image](https://github.com/user-attachments/assets/aa1b8b13-df8a-43cd-8b34-e57b25bd6fc5)

With dirt paths (impossible with framed blocks):
![image](https://github.com/user-attachments/assets/0c2b4f93-c09a-49e2-844a-87434ee69ce8)

I also filed https://github.com/tinytransfem/Grass_Slabs/issues/16 for the inconsistent grass block textures. 
