### PR TITLE
Add Cable Facades mod

### DIFF
--- a/config/cable_facades-common.toml
+++ b/config/cable_facades-common.toml
@@ -1,7 +1,7 @@
 #List of blocks that are allowed to be covered. Supports '*' as a wildcard.
 blocks = ["pipez:*_pipe", "mekanism:*_cable", "mekanism:*_conductor", "mekanism:*_pipe", "mekanism:*_tube", "mekanism:*_transporter", "mekanism_extras:*_cable", "mekanism_extras:*_conductor", "mekanism_extras:*_pipe", "mekanism_extras:*_tube", "mekanism_extras:*_transporter", "thermal:*_duct", "thermal:*_duct_windowed", "computercraft:cable", "powah:energy_cable_*", "create:fluid_pipe", "pneumaticcraft:*_tube", "ppfluids:fluid_pipe", "prettypipes:pipe", "laserio:laser_*", "cyclic:*_pipe", "embers:*_pipe", "embers:item_extractor", "elementalcraft:elementpipe*", "gtceu:*wire", "gtceu:*cable", "gtceu:*pipe", "enderio:conduit", "xnet:connector", "xnet:netcable"]
 #List of blocks that are explicitly not allowed to be used as a cover. Supports '*' as a wildcard.
-not_allowed_blocks = []
+not_allowed_blocks = ["ae2:cable_bus"]
 #Whether the facade should be consumed when placed.
 consumeFacade = true
 

--- a/config/cable_facades-common.toml
+++ b/config/cable_facades-common.toml
@@ -1,0 +1,7 @@
+#List of blocks that are allowed to be covered. Supports '*' as a wildcard.
+blocks = ["pipez:*_pipe", "mekanism:*_cable", "mekanism:*_conductor", "mekanism:*_pipe", "mekanism:*_tube", "mekanism:*_transporter", "mekanism_extras:*_cable", "mekanism_extras:*_conductor", "mekanism_extras:*_pipe", "mekanism_extras:*_tube", "mekanism_extras:*_transporter", "thermal:*_duct", "thermal:*_duct_windowed", "computercraft:cable", "powah:energy_cable_*", "create:fluid_pipe", "pneumaticcraft:*_tube", "ppfluids:fluid_pipe", "prettypipes:pipe", "laserio:laser_*", "cyclic:*_pipe", "embers:*_pipe", "embers:item_extractor", "elementalcraft:elementpipe*", "gtceu:*wire", "gtceu:*cable", "gtceu:*pipe", "enderio:conduit", "xnet:connector", "xnet:netcable"]
+#List of blocks that are explicitly not allowed to be used as a cover. Supports '*' as a wildcard.
+not_allowed_blocks = []
+#Whether the facade should be consumed when placed.
+consumeFacade = true
+

--- a/manifest.json
+++ b/manifest.json
@@ -1014,6 +1014,11 @@
       "fileID": 4646817,
       "projectID": 296996,
       "required": true
+    },
+    {
+      "fileID": 5932078,
+      "projectID": 1140577,
+      "required": true
     }
   ]
 }


### PR DESCRIPTION
Resolves #1177.

Some complaints about LaserIO and EnderIO are that they don't have facades - this mod offers a solution.

The only issues I've noticed in some quick testing are:
1. Facade-covered Conduits appear as Sculk Superconductor Conduits in Jade
2. AE2 Cables/Busses bug out if a facade covering them is destroyed (they are blacklisted in the config for this reason)
3. Occasional Z-fighting