### PR TITLE
Avoid useless tag for iron and diamond gears.

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/unification/tags.js
+++ b/kubejs/server_scripts/fixes_tweaks/unification/tags.js
@@ -124,4 +124,11 @@ ServerEvents.recipes(event => {
     event.remove({ output: global.manualUnification })
     event.remove({ output: global.nuclearcraftFuelPattern })
     event.remove({ output: global.nuclearcraftMaterialPattern })
+
+    // Tags cannot be removed from items in HammerLib (see https://github.com/dragon-forge/HammerLib/issues/71).
+    // Thus, we replace the input of any recipe that uses one of the tags of those items with the corresponding GT item.
+    let hammerLibGears = ["iron", "diamond"]
+    hammerLibGears.forEach(material => {
+        event.replaceInput({ input: `#forge:gears/${material}` }, `#forge:gears/${material}`, `gtceu:${material}_gear`)
+    })
 })

--- a/kubejs/server_scripts/infinite_sources.js
+++ b/kubejs/server_scripts/infinite_sources.js
@@ -20,7 +20,7 @@ ServerEvents.recipes(event => {
                 'CWC',
                 'GSG'
             ], {
-                G: "#forge:gears/iron",
+                G: "gtceu:iron_gear",
                 B: "minecraft:bucket",
                 W: "watercollector:watercollector",
                 S: "enderio:fused_quartz",
@@ -33,7 +33,7 @@ ServerEvents.recipes(event => {
                 'PNP',
                 'GHG'
             ], {
-                G: "#forge:gears/iron",
+                G: "gtceu:iron_gear",
                 P: "#forge:plates/steel",
                 N: "#forge:pistons",
                 H: "minecraft:hopper"
@@ -46,7 +46,7 @@ ServerEvents.recipes(event => {
                 'CWC',
                 'GSG'
             ], {
-                G: "#forge:gears/iron",
+                G: "gtceu:iron_gear",
                 B: "minecraft:bucket",
                 W: "#enderio:fused_quartz",
                 S: "thermal:redstone_servo",
@@ -59,7 +59,7 @@ ServerEvents.recipes(event => {
                 'INI',
                 'GSG'
             ], {
-                G: "#forge:gears/iron",
+                G: "gtceu:iron_gear",
                 S: "thermal:redstone_servo",
                 P: "#forge:plates/steel",
                 I: "#forge:plates/invar",

--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -463,7 +463,7 @@ ServerEvents.recipes(event => {
         ' I '
     ], {
         I: '#forge:ingots/iron',
-        G: '#forge:gears/iron'
+        G: 'gtceu:iron_gear'
     }
     ).id('kubejs:yeta_wrench')
     event.remove({ output: 'enderio:void_chassis' })

--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -15,7 +15,7 @@ ServerEvents.recipes(event => {
     event.smelting('gtceu:sticky_resin', 'thermal:tar')
     event.replaceInput({ id: /thermal:*/ }, ['thermal:cured_rubber'], ['gtceu:rubber_plate'])
     //Unify Thermal dies
-    
+
     event.shaped('thermal:press_packing_2x2_die', [
         ' A ',
         'BCB',
@@ -650,7 +650,7 @@ ServerEvents.recipes(event => {
         A: 'minecraft:lava_bucket',
         B: '#chipped:bricks',
         C: 'thermal:machine_frame', // casing
-        D: '#forge:gears/iron',
+        D: 'gtceu:iron_gear',
         E: 'thermal:redstone_servo'
     }).id('kubejs:device_nullifier');
 
@@ -663,7 +663,7 @@ ServerEvents.recipes(event => {
         A: 'minecraft:hopper',
         B: '#forge:ingots/tin',
         C: 'enderio:vacuum_chest', // casing
-        D: '#forge:gears/iron',
+        D: 'gtceu:iron_gear',
         E: 'thermal:redstone_servo'
     }).id('kubejs:device_collector');
 
@@ -702,7 +702,7 @@ ServerEvents.recipes(event => {
         B: '#forge:ingots/silver',
         C: 'gtceu:lv_power_unit',
         D: '#forge:ingots/tin',
-        E: '#forge:gears/iron'
+        E: 'gtceu:iron_gear'
     }).id('kubejs:flux_drill');
 
     event.remove({ id: 'thermal:flux_saw' })
@@ -715,7 +715,7 @@ ServerEvents.recipes(event => {
         B: '#forge:ingots/silver',
         C: 'gtceu:lv_power_unit',
         D: '#forge:ingots/tin',
-        E: '#forge:gears/iron'
+        E: 'gtceu:iron_gear'
     }).id('kubejs:flux_saw');
 
     event.remove({ id: 'thermal:flux_capacitor' });


### PR DESCRIPTION
It is impossilbe to remove tags from HammerLib items with kubejs.

Since we don't use hammerlib items, instead replace references in recipes to tags those items use with the corresponding GT item instead.

See https://github.com/dragon-forge/HammerLib/issues/71.