### PR TITLE
Require both infinite cobble and water cells for quest.

### DIFF
--- a/config/ftbquests/quests/chapters/matterenergy.snbt
+++ b/config/ftbquests/quests/chapters/matterenergy.snbt
@@ -1132,6 +1132,7 @@
 							}
 						}
 					}
+					match_nbt: true
 					type: "item"
 				}
 				{
@@ -1146,6 +1147,7 @@
 							}
 						}
 					}
+					match_nbt: true
 					type: "item"
 				}
 			]


### PR DESCRIPTION
Since the items differ only by NBT, we need to match NBT on them.