### PR TITLE
Don't require a player to have three singularties at once for infinite wireless quest.

### DIFF
--- a/config/ftbquests/quests/chapters/matterenergy.snbt
+++ b/config/ftbquests/quests/chapters/matterenergy.snbt
@@ -811,6 +811,7 @@
 					count: 3L
 					id: "65D3CCCAFE21F394"
 					item: "ae2:singularity"
+					optional_task: true
 					type: "item"
 				}
 				{


### PR DESCRIPTION
I hadn't looked at the quest, and so had crafted entangled singularties with my first singularity. Since the singularties are intermediate steps, just make that task optional.