### PR TITLE
Allow elevators and travel anchors in cleanroom floors.

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/unification/other_tags.js
+++ b/kubejs/server_scripts/fixes_tweaks/unification/other_tags.js
@@ -1,3 +1,8 @@
+// Random small tags that don't fit anywhere else
 ServerEvents.tags('item', event => {
-    // Random small tags that don't fit anywhere else
+})
+
+ServerEvents.tags('block', event => {
+    event.add('gtceu:cleanroom_floors', 'enderio:travel_anchor');
+    event.add('gtceu:cleanroom_floors', '#elevatorid:elevators');
 })


### PR DESCRIPTION
This will be added in GT 1.5.5. The tag won't hurt before then.

I tested this against 1.20.1-1.5.5 SNAPSHOT 20241206, and it worked (with a [minor issue](https://github.com/GregTechCEu/GregTech-Modern/pull/2466/files#r1874342908) which will hopefully be fixed before the release.