### PR TITLE
Add gregified recipe for flux dust

### DIFF
--- a/kubejs/server_scripts/mods/optionalCompats/fluxnetworks.js
+++ b/kubejs/server_scripts/mods/optionalCompats/fluxnetworks.js
@@ -4,6 +4,14 @@ if (Platform.isLoaded('fluxnetworks')) {
     ServerEvents.recipes(event => {
         event.replaceInput({ id: 'fluxnetworks:fluxconfigurator'}, 'minecraft:obsidian', 'enderio:infinity_rod');
 
+        // Flux Dust
+        event.recipes.gtceu.chemical_bath('fluxnetworks:flux_dust')
+            .itemInputs('1x gtceu:obsidian_dust')
+            .inputFluids('gtceu:redstone 144')
+            .itemOutputs('fluxnetworks:flux_dust')
+            .duration(40)
+            .EUt(16)
+
         //Flux Block
         event.shaped('fluxnetworks:flux_block', [
             'FFF',


### PR DESCRIPTION
Add a chemical bath recipe for flux dust from flux networks to avoid manual creation. Based off the original recipe of smashing obsidian into redstone
![image](https://github.com/user-attachments/assets/795681ba-b0e9-4e70-8707-85b47e52e82f)
