### PR TITLE
Add back randomness into veins' spawn locations

### DIFF
--- a/config-overrides/expert/gtceu.yaml
+++ b/config-overrides/expert/gtceu.yaml
@@ -119,7 +119,7 @@ worldgen:
 
     # The maximum random offset (in blocks) from the grid for generating an ore vein.
     # Default: 12
-    oreVeinRandomOffset: 0
+    oreVeinRandomOffset: 4
 
     # Prevents regular vanilla ores from being generated outside GregTech ore veins
     # Default: true

--- a/config-overrides/hardmode/gtceu.yaml
+++ b/config-overrides/hardmode/gtceu.yaml
@@ -119,7 +119,7 @@ worldgen:
 
     # The maximum random offset (in blocks) from the grid for generating an ore vein.
     # Default: 12
-    oreVeinRandomOffset: 0
+    oreVeinRandomOffset: 4
 
     # Prevents regular vanilla ores from being generated outside GregTech ore veins
     # Default: true

--- a/config-overrides/normal/gtceu.yaml
+++ b/config-overrides/normal/gtceu.yaml
@@ -119,7 +119,7 @@ worldgen:
 
     # The maximum random offset (in blocks) from the grid for generating an ore vein.
     # Default: 12
-    oreVeinRandomOffset: 0
+    oreVeinRandomOffset: 4
 
     # Prevents regular vanilla ores from being generated outside GregTech ore veins
     # Default: true

--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -119,7 +119,7 @@ worldgen:
 
     # The maximum random offset (in blocks) from the grid for generating an ore vein.
     # Default: 12
-    oreVeinRandomOffset: 0
+    oreVeinRandomOffset: 4
 
     # Prevents regular vanilla ores from being generated outside GregTech ore veins
     # Default: true


### PR DESCRIPTION
This is so GTM's Journeymap integration's indicators aren't perfectly overlapped, causing issues with overlapping text when moused over