### PR TITLE
Posttankmats tweaks and fixes

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -3,7 +3,7 @@ ServerEvents.recipes(event => {
         .inputFluids('gtceu:uranium_hexafluoride 1000')
         .chancedInput('gtceu:neutron_reflector', 100, 0)
         .outputFluids('gtceu:enriched_uranium_hexafluoride 50', 'gtceu:depleted_uranium_hexafluoride 450', 'gtceu:fluorine 800')
-        .chancedOutput('gtceu:small_actinium_dust', 100, 500)
+        .chancedOutput('gtceu:small_actinium_dust', 1000, 400)
         .duration(160)
         .EUt(GTValues.VHA[GTValues.ZPM])
 

--- a/kubejs/server_scripts/gregtech/Post_UV_Components.js
+++ b/kubejs/server_scripts/gregtech/Post_UV_Components.js
@@ -199,7 +199,7 @@ ServerEvents.recipes(event => {
 
     // Motors
     event.recipes.gtceu.assembly_line('uhv_motor')
-        .itemInputs('gtceu:magnetic_terbium_rod', '8x gtceu:long_actinium_rod', '8x gtceu:actinium_ring', '16x gtceu:actinium_round', '64x gtceu:fine_ruthenium_trinium_americium_neutronate_wire', '64x gtceu:fine_ruthenium_trinium_americium_neutronate_wire', '32x gtceu:fine_ruthenium_trinium_americium_neutronate_wire', '2x gtceu:europium_single_cable')
+        .itemInputs('gtceu:long_magnetic_terbium_rod', '8x gtceu:long_actinium_rod', '8x gtceu:actinium_ring', '16x gtceu:actinium_round', '64x gtceu:fine_ruthenium_trinium_americium_neutronate_wire', '64x gtceu:fine_ruthenium_trinium_americium_neutronate_wire', '32x gtceu:fine_ruthenium_trinium_americium_neutronate_wire', '2x gtceu:europium_single_cable')
         .inputFluids('gtceu:soldering_alloy 5760', 'gtceu:lubricant 2000', 'gtceu:crystal_matrix 1152', 'gtceu:naquadria 576')
         .itemOutputs('gtceu:uhv_electric_motor')
         .duration(600)

--- a/kubejs/server_scripts/gregtech/discharger.js
+++ b/kubejs/server_scripts/gregtech/discharger.js
@@ -49,7 +49,7 @@ ServerEvents.recipes(event => {
     Discharge('bathyal_solar', '2x solarflux:sp_custom_bathyal', ['kubejs:bathyal_energy_core', '2x solarflux:sp_8', '4x enderio:cryolobus_conduit', '2x gtceu:cryolobus_block'], 20000000)
     Discharge('cryococcus_block', '5x gtceu:cryococcus_block', ['5x gtceu:cryolobus_block', '4x kubejs:bathyal_energy_core', '2x kubejs:warden_heart'], 40000000)
     Discharge('hadal_warp_engine', 'kubejs:hadal_warp_engine', ['gtceu:cryococcus_frame', 'kubejs:warp_engine', 'gtceu:cryococcus_plate', '2x gtceu:cryolobus_plate', 'kubejs:hadal_energy_core', 'gtceu:zpm_field_generator', 'kubejs:abyssal_energy_core', 'kubejs:hadal_shard'], 40000000)
-    Discharge('sculk_bioalloy', 'gtceu:sculk_bioalloy_block', ['9x kubejs:animated_bioalloy_pulp', '18x gtceu:electrotine_dust', '1x kubejs:warden_heart', 'kubejs:abyssal_core'], 10000000)
+    Discharge('sculk_bioalloy', 'gtceu:sculk_bioalloy_block', ['9x kubejs:animated_bioalloy_pulp', '18x gtceu:electrotine_dust', '1x kubejs:warden_heart', '2x kubejs:abyssal_energy_core'], 10000000)
 
     event.recipes.gtceu.charger(`kubejs:sculk_core_charge`)
         .itemInputs(['4x gtceu:cryolobus_ingot', '4x gtceu:tungsten_carbide_ingot', 'minecraft:sculk_catalyst'])

--- a/kubejs/startup_scripts/gregtech_crafting_components.js
+++ b/kubejs/startup_scripts/gregtech_crafting_components.js
@@ -123,12 +123,12 @@ GTCEuStartupEvents.craftingComponents(event => {
     electricCoilMap[GTValues.UIV] = UnificationEntry(TagPrefix.wireGtHex, GTMaterials.get('holmium'))
     event.modifyUnificationEntry(CraftingComponent.COIL_ELECTRIC, electricCoilMap)
 
-    // Magnetic Rods (Uses Samarium for UV+, two tiers after the same for Nomi)
+    // Magnetic Rods
     let magneticRodMap = {};
-    magneticRodMap[GTValues.UV] = UnificationEntry(TagPrefix.rod, GTMaterials.Samarium)
-    magneticRodMap[GTValues.UHV] = UnificationEntry(TagPrefix.rod, GTMaterials.Terbium)
-    magneticRodMap[GTValues.UEV] = UnificationEntry(TagPrefix.rodLong, GTMaterials.Terbium)
-    magneticRodMap[GTValues.UIV] = UnificationEntry(TagPrefix.rodLong, GTMaterials.Terbium)
+    magneticRodMap[GTValues.UV] = UnificationEntry(TagPrefix.rodLong, GTMaterials.SamariumMagnetic)
+    magneticRodMap[GTValues.UHV] = UnificationEntry(TagPrefix.rodLong, GTMaterials.get('magnetic_terbium'))
+    magneticRodMap[GTValues.UEV] = UnificationEntry(TagPrefix.rodLong, GTMaterials.get('magnetic_terbium'))
+    magneticRodMap[GTValues.UIV] = UnificationEntry(TagPrefix.rodLong, GTMaterials.get('magnetic_terbium'))
     event.modifyUnificationEntry(CraftingComponent.STICK_MAGNETIC, magneticRodMap)
 
     // Distillation Rods
@@ -138,15 +138,15 @@ GTCEuStartupEvents.craftingComponents(event => {
     distillationRodMap[GTValues.UIV] = UnificationEntry(TagPrefix.spring, GTMaterials.get('eltz'))
     event.modifyUnificationEntry(CraftingComponent.STICK_DISTILLATION, distillationRodMap)
 
-    // Electromagnetic Rods (Uses Samarium for UV+, two tiers after the same for Nomi)
+    // Electromagnetic Rods
     let electromagneticRodMap = {};
     electromagneticRodMap[GTValues.IV] = UnificationEntry(TagPrefix.rod, GTMaterials.Neodymium)
-    electromagneticRodMap[GTValues.LuV] = UnificationEntry(TagPrefix.rodLong, GTMaterials.Neodymium)
-    electromagneticRodMap[GTValues.ZPM] = UnificationEntry(TagPrefix.rodLong, GTMaterials.Neodymium)
+    electromagneticRodMap[GTValues.LuV] = UnificationEntry(TagPrefix.rod, GTMaterials.Samarium)
+    electromagneticRodMap[GTValues.ZPM] = UnificationEntry(TagPrefix.rod, GTMaterials.Samarium)
     electromagneticRodMap[GTValues.UV] = UnificationEntry(TagPrefix.rod, GTMaterials.Samarium)
-    electromagneticRodMap[GTValues.UHV] = UnificationEntry(TagPrefix.rod, GTMaterials.Samarium)
-    electromagneticRodMap[GTValues.UEV] = UnificationEntry(TagPrefix.rodLong, GTMaterials.Terbium)
-    electromagneticRodMap[GTValues.UIV] = UnificationEntry(TagPrefix.rodLong, GTMaterials.Terbium)
+    electromagneticRodMap[GTValues.UHV] = UnificationEntry(TagPrefix.rod, GTMaterials.Terbium)
+    electromagneticRodMap[GTValues.UEV] = UnificationEntry(TagPrefix.rod, GTMaterials.Terbium)
+    electromagneticRodMap[GTValues.UIV] = UnificationEntry(TagPrefix.rod, GTMaterials.Terbium)
     event.modifyUnificationEntry(CraftingComponent.STICK_ELECTROMAGNETIC, electromagneticRodMap)
 
     // Chem reactor pipe ingredient

--- a/kubejs/startup_scripts/gregtech_material_registry/chemicals.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/chemicals.js
@@ -151,6 +151,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .polymer()
         .color(0x708787)
         .components('1x nitrogen', '6x carbon', '7x hydrogen', '2x oxygen')
+        .fluidPipeProperties(3000, 12000, true, true, true, false)
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.STICKY)
 
     // Dimethyl sulfoxide sub-chain (PECA catalyst)

--- a/kubejs/startup_scripts/gregtech_material_registry/endgame.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/endgame.js
@@ -66,7 +66,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .color(0x4C484C)
         .iconSet('dull')
         .cableProperties(GTValues.V[GTValues.UEV], 16, 0, true)
-        .fluidPipeProperties(120000, 96000, true, true, true, true)
+        .fluidPipeProperties(11000, 8500, true, false, true, true)
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.GENERATE_SPRING)
 
     event.create('sculk_bioalloy')

--- a/kubejs/startup_scripts/gregtech_material_registry/missing_material_forms.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/missing_material_forms.js
@@ -34,7 +34,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     GTMaterials.Holmium.setProperty($PropertyKey.INGOT, new $IngotProperty())
     GTMaterials.Holmium.setProperty($PropertyKey.WIRE, new $WireProperty(33554432, 64, 0, true))
-    GTMaterials.Holmium.setProperty($PropertyKey.FLUID_PIPE, new $FluidPipeProperty(120000, 128000, true, true, true, true))
+    GTMaterials.Holmium.setProperty($PropertyKey.FLUID_PIPE, new $FluidPipeProperty(10000, 18000, true, false, true, true))
     GTMaterials.Holmium.setProperty($PropertyKey.BLAST, new $BlastProperty(12500, 'highest', 1000000, 1000, -1, -1));
     GTMaterials.Holmium.addFlags(GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.GENERATE_SPRING)
 


### PR DESCRIPTION
Commit names are self-explanatory.
Magnetic Terbium Rod was changed to long version in the UHV motor recipe because the recipe before Terbium was implemented was incorrect due to some mistakes I left in the file