### PR TITLE
Cleanup Ad-Astra fluids.

### DIFF
--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -271,8 +271,7 @@ JEIEvents.hideFluids(event => {
     })
 
     // Hide Ad Astra fluids
-    let AAUseless = ['ad_astra:oxygen', 'ad_astra:hydrogen', 'ad_astra:oil', 'ad_astra:fuel', 'ad_astra:cryo_fuel']
-    AAUseless.forEach(liquid => { event.hide(liquid) })
+    Fluid.getTypes().filter(id=>id.includes("ad_astra")).forEach(id => event.hide(id))
 
     //Hide Thermal fluids
     event.hide("thermal:creosote")

--- a/kubejs/server_scripts/fixes_tweaks/unification/tags.js
+++ b/kubejs/server_scripts/fixes_tweaks/unification/tags.js
@@ -119,10 +119,10 @@ ServerEvents.tags('fluid', event => {
     event.removeAllTagsFrom('thermal:glowstone')
     event.removeAllTagsFrom('thermal:redstone')
     event.removeAllTagsFrom('cofh_core:experience')
-    
+
+    Fluid.getTypes().filter(id=>id.includes("ad_astra")).forEach(id => event.removeAllTagsFrom(id))
     // Rocket Fuels
-    const fuels = ['ad_astra:fuel', 'ad_astra:cryo_fuel', 'gtceu:diesel'];
-    event.removeAllTagsFrom(fuels)
+    event.removeAll('ad_astra:fuel');
     event.add('ad_astra:fuel', 'gtceu:rocket_fuel')
 
 })


### PR DESCRIPTION
- Remove tags from Ad Astra fluids, so that they don't cause useless tags to appear for e.g. oxygen and hydrogen.
- Don't remove *all* tags from diesel, as that prevents it from being used in generators.