### PR TITLE
ModernFix config changes

### DIFF
--- a/config/modernfix-mixins.properties
+++ b/config/modernfix-mixins.properties
@@ -96,4 +96,6 @@
 #
 # User overrides go here.
 mixin.feature.branding=false
+mixin.perf.dynamic_resources=true
 mixin.perf.faster_item_rendering=true
+mixin.perf.worldgen_allocation=true


### PR DESCRIPTION
This PR enables two settings in ModernFix, `mixin.perf.dynamic_resources` and `mixin.perf.worldgen_allocation` 

The first one was already enabled with #814 but it was reverted because it broke CTM for some GTCEu Modern blocks. This has been fixed in the latest release of ModernFix (5.20.0) so it should be safe to re-enable it again. It greatly reduces RAM usage and shortens loading times

The second one (according to embeddedt) "Reduces the allocation rate during worldgen to put less pressure on the garbage collector". It might very slightly reduce lagspikes during world generation, which is always a plus.