### PR TITLE
Tweaks to Creative Datas 

### DIFF
--- a/config/ftbquests/quests/chapters/end_game.snbt
+++ b/config/ftbquests/quests/chapters/end_game.snbt
@@ -328,7 +328,7 @@
 			]
 			id: "27EBB5AAF8A40F3D"
 			shape: "hexagon"
-			size: 1.0d
+			size: 1.5d
 			tasks: [{
 				id: "624B7498A1144A6F"
 				item: "kubejs:microminer_t10"
@@ -473,6 +473,7 @@
 				"{moni.quest.4CF399EC00A65E3A.description2}"
 			]
 			id: "4CF399EC00A65E3A"
+			size: 1.5d
 			tasks: [{
 				id: "639C72FD2123C478"
 				item: "kubejs:creative_storage_data"
@@ -501,7 +502,7 @@
 			y: -26.75d
 		}
 		{
-			dependencies: ["1D00150456DEF379"]
+			dependencies: ["0DE1BF1648CAF6D6"]
 			description: ["{moni.quest.1C861E0C62D5B97D.description1}"]
 			id: "1C861E0C62D5B97D"
 			size: 1.5d
@@ -511,8 +512,8 @@
 				type: "item"
 			}]
 			title: "{moni.quest.1C861E0C62D5B97D.title}"
-			x: 33.25d
-			y: -16.0d
+			x: 52.5d
+			y: -18.0d
 		}
 		{
 			dependencies: [

--- a/config/ftbquests/quests/chapters/end_game.snbt
+++ b/config/ftbquests/quests/chapters/end_game.snbt
@@ -484,7 +484,7 @@
 			y: -4.75d
 		}
 		{
-			dependencies: ["1B1D3A66B847D129"]
+			dependencies: ["13578427FD9CC2CE"]
 			description: [
 				"{moni.quest.19084E91F357C8C2.description1}"
 				""
@@ -498,7 +498,7 @@
 				type: "item"
 			}]
 			title: "{moni.quest.19084E91F357C8C2.title}"
-			x: 41.75d
+			x: 45.75d
 			y: -26.75d
 		}
 		{
@@ -674,7 +674,7 @@
 				type: "item"
 			}]
 			title: "{moni.quest.73A44214C2B44D53.title}"
-			x: 45.75d
+			x: 41.75d
 			y: -26.75d
 		}
 		{

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -502,21 +502,6 @@ ServerEvents.recipes(event => {
         .itemOutputs('kubejs:creative_storage_data')
         .duration(3000)
         .EUt(1000000)
-
-    event.recipes.gtceu.advanced_microverse_ii('kubejs:t_ten_third')
-        .itemInputs(
-            'kubejs:microminer_t10',
-            'kubejs:infinity_catalyst',
-            '8x gtceu:network_switch',
-            '8x gtceu:data_bank',
-            '16x gtceu:advanced_data_access_hatch',
-            '16x gtceu:computation_receiver_hatch',
-            '64x kubejs:stellar_creation_data'
-        )
-        .itemOutputs('kubejs:creative_computation_data')
-        .duration(3000)
-        .EUt(1000000)
-
 })
 
 // Advanced Microverse III
@@ -623,6 +608,21 @@ ServerEvents.recipes(event => {
             '64x kubejs:quasi_stable_neutron_star')
         .duration(600)
         .EUt(1000000)
+
+        event.recipes.gtceu.advanced_microverse_iii('kubejs:t_eleven_forth')
+        .itemInputs(
+            'kubejs:microminer_t11',
+            '16x gtceu:holmium_block',
+            '8x gtceu:network_switch',
+            '8x gtceu:data_bank',
+            '16x gtceu:advanced_data_access_hatch',
+            '16x gtceu:computation_receiver_hatch',
+            '64x kubejs:stellar_creation_data'
+        )
+        .itemOutputs('kubejs:creative_computation_data')
+        .duration(3000)
+        .EUt(8000000)
+
 
     event.recipes.gtceu.advanced_microverse_iii('kubejs:t_twelve_first')
         .itemInputs('kubejs:microminer_t12', '64x gtceu:infinity_ingot', '4x kubejs:universe_creation_data')

--- a/kubejs/server_scripts/gregtech/microverse_recipes.js
+++ b/kubejs/server_scripts/gregtech/microverse_recipes.js
@@ -583,12 +583,6 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(180000)
 
-    event.recipes.gtceu.advanced_microverse_iii('kubejs:t_eleven_second')
-        .itemInputs('kubejs:microminer_t11', '4x gtceu:max_battery', '2x solarflux:sp_custom_infinity', 'gtceu:uiv_4096a_laser_source_hatch', '4x kubejs:universe_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data') // could be increased
-        .itemOutputs('kubejs:creative_energy_data')
-        .duration(1200)
-        .EUt(8000000)
-
     event.recipes.gtceu.advanced_microverse_iii('kubejs:t_eleven_third')
         .itemInputs(
             'kubejs:microminer_t11',
@@ -635,6 +629,12 @@ ServerEvents.recipes(event => {
         .itemOutputs('4x kubejs:causality_exempt_monic_heavy_plating')
         .duration(800)
         .EUt(128000000)
+
+    event.recipes.gtceu.advanced_microverse_iii('kubejs:t_twelve_third')
+        .itemInputs('kubejs:microminer_t12', '16x gtceu:eltz_block', '4x gtceu:max_battery', '2x solarflux:sp_custom_infinity', 'gtceu:uiv_4096a_laser_source_hatch', '4x kubejs:universe_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data', '64x kubejs:stellar_creation_data') // could be increased
+        .itemOutputs('kubejs:creative_energy_data')
+        .duration(1200)
+        .EUt(32000000)
 })
 
 // Microversium

--- a/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
+++ b/kubejs/server_scripts/gregtech/subatomic_digital_assembler.js
@@ -35,6 +35,7 @@ ServerEvents.recipes(event => {
     sda_print('creative_storage_data', 3, 'gtceu:uev_quantum_chest', 32)
     sda_print('creative_storage_data', 4, 'gtceu:uev_quantum_tank', 32)
     sda_print('creative_computation_data', 1, 'gtceu:creative_data_access_hatch', 256)
+    sda_print('creative_computation_data', 2, 'gtceu:creative_computation_provider', 256)
     sda_print('creative_energy_data', 1, 'enderio:creative_power', 256)
     sda_print('creative_energy_data', 2, 'ae2:creative_energy_cell', 256)
     sda_print('creative_energy_data', 3, 'gtceu:creative_energy', 256)


### PR DESCRIPTION
Readded creative computation provider printing, creative computation data now requires T11 MM
Creative Energy Data now requires T12 MM (it already required UIV circuits, etc)