### PR TITLE
slightly un-nerf void oil

### DIFF
--- a/kubejs/server_scripts/worldgen/fluidVeins.js
+++ b/kubejs/server_scripts/worldgen/fluidVeins.js
@@ -12,7 +12,7 @@ GTCEuServerEvents.fluidVeins(event => {
         vein.maximumYield(250)
         vein.depletionAmount(1)
         vein.depletionChance(50)
-        vein.depletedYield(3)
+        vein.depletedYield(20)
     })
 
     


### PR DESCRIPTION
This changes the void oil's depleted yield to be closer to GT veins' depleted yields.