### PR TITLE
Fix moderators in fission reactors and show them in EMI

### DIFF
--- a/config/NuclearCraft/materials.toml
+++ b/config/NuclearCraft/materials.toml
@@ -222,7 +222,7 @@
 	magnesium = false
 	cobalt = false
 	aluminum = false
-	graphite = false
+	graphite = true
 	lead = false
 	bronze = false
 	californium250 = false
@@ -232,7 +232,7 @@
 	americium241 = false
 	plutonium238 = false
 	tin = false
-	beryllium = false
+	beryllium = true
 	uranium238 = false
 	silver = false
 	uranium = false

--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -242,7 +242,7 @@ JEIEvents.addItems(event => {
     event.add('enderio:reinforced_obsidian_block')
 
     //NuclearCraft
-    event.add(['nuclearcraft:tough_alloy_ingot', 'nuclearcraft:hard_carbon_ingot', 'nuclearcraft:ferroboron_ingot', 'nuclearcraft:rhodochrosite_dust', 'nuclearcraft:beryllium_block', 'nuclearcraft:graphite_block'])
+    event.add(['nuclearcraft:tough_alloy_ingot', 'nuclearcraft:hard_carbon_ingot', 'nuclearcraft:ferroboron_ingot', 'nuclearcraft:rhodochrosite_dust'])
 })
 
 JEIEvents.hideFluids(event => {

--- a/kubejs/server_scripts/fixes_tweaks/unification/tags.js
+++ b/kubejs/server_scripts/fixes_tweaks/unification/tags.js
@@ -87,6 +87,11 @@ ServerEvents.tags('item', event => {
     // For stonecutting Marble
     event.add('moni:marble', /^(gtceu:(marble|polished_marble|marble_bricks|cracked_marble_bricks|chiseled_marble|marble_tile|marble_small_tile|marble_windmill_a|marble_windmill_b|small_marble_bricks|square_marble_bricks))$/)
 
+    // We're making these Nuclearcraft storage blocks function solely as moderators, so they should not have the tags
+    event.remove('forge:storage_blocks', ['nuclearcraft:beryllium_block', 'nuclearcraft:graphite_block']);
+    event.remove('forge:storage_blocks/beryllium', 'nuclearcraft:beryllium_block');
+    event.remove('forge:storage_blocks/graphite', 'nuclearcraft:graphite_block');
+
     unifyChisel(event);
 })
 
@@ -97,6 +102,11 @@ ServerEvents.tags('block', event => {
     event.add('minecraft:bamboo_plantable_on', compacted_sand);
     event.add('minecraft:azalea_grows_on', compacted_sand);
     event.add('framedblocks:camo_sustain_plant', compacted_sand);
+
+    // We're making these Nuclearcraft storage blocks function solely as moderators, so they should not have the tags
+    event.remove('forge:storage_blocks', ['nuclearcraft:beryllium_block', 'nuclearcraft:graphite_block']);
+    event.remove('forge:storage_blocks/beryllium', 'nuclearcraft:beryllium_block');
+    event.remove('forge:storage_blocks/graphite', 'nuclearcraft:graphite_block');
 
     unifyChisel(event);
 })

--- a/kubejs/startup_scripts/_initial.js
+++ b/kubejs/startup_scripts/_initial.js
@@ -50,6 +50,8 @@ global.manualUnification = [
     'extendedcrafting:nether_star_block',
 ];
 global.UnificationExcludedItems = [
+    'nuclearcraft:beryllium_block',
+    'nuclearcraft:graphite_block',
     'nuclearcraft:hard_carbon_ingot',
     'nuclearcraft:ferroboron_ingot',
     'nuclearcraft:tough_alloy_ingot',


### PR DESCRIPTION
Enabling the blocks in NC's config allows them to show in EMI, so the (non-working) manual addition is no longer needed.

I made the script only remove the `storage_blocks` tags from moderators so that they now work with heat sinks which require them, like the glowstone heat sink.