### PR TITLE
Copy Hardmode files before copying Expert mode config overrides as .bat version does

### DIFF
--- a/pack-mode-switcher.sh
+++ b/pack-mode-switcher.sh
@@ -70,6 +70,7 @@ case $MODE in
 
   E|e|expert|Expert)
 
+    cp -rf "$HARDMODE_CFG/." ${TARGET}
     cp -rf "$EXPERT_CFG/." ${TARGET}
 
     if [ -f "server.properties" ]; then


### PR DESCRIPTION
Without this step the second chapter in the questbook was still using normal mode quests.