### PR TITLE
Misc create-related fixes

### DIFF
--- a/kubejs/server_scripts/mods/optionalCompats/create.js
+++ b/kubejs/server_scripts/mods/optionalCompats/create.js
@@ -105,13 +105,6 @@ if (Platform.isLoaded('create')) {
             .duration(200)
             .EUt(7)
 
-        event.recipes.gtceu.mixer("kubejs:dough")
-            .itemInputs('gtceu:wheat_dust')
-            .inputFluids(Fluid.of('minecraft:water', 1000))
-            .itemOutputs('create:dough')
-            .duration(200)
-            .EUt(7)
-
         event.recipes.gtceu.extractor("kubejs:extract_bar_of_chocolate")
             .itemInputs('create:bar_of_chocolate')
             .outputFluids(Fluid.of('create:chocolate', 250))

--- a/kubejs/server_scripts/mods/optionalCompats/create_steamandrails.js
+++ b/kubejs/server_scripts/mods/optionalCompats/create_steamandrails.js
@@ -169,7 +169,7 @@ if (Platform.isLoaded('railways')) {
 		};
 		{
 			/* normal tracks */{
-				// normalTrackRecipes('#create:sleepers', 'create:track', 'minecraft:iron_nugget', 1);
+				normalTrackRecipes('#create:sleepers', 'create:track', 'minecraft:iron_nugget', 1);
 				normalTrackRecipes('minecraft:acacia_slab', 'railways:track_acacia', 'minecraft:iron_nugget', 1);
 				normalTrackRecipes('minecraft:birch_slab', 'railways:track_birch', 'minecraft:iron_nugget', 1);
 				normalTrackRecipes('minecraft:dark_oak_slab', 'railways:track_dark_oak', 'minecraft:iron_nugget', 1);


### PR DESCRIPTION
Fix andesite track being uncraftable when Create: Steam 'n' Rails is installed.
Remove create dough recipe as it conflicted with gregtech's, and gregtech's dough cannot be replaced with create's.