### PR TITLE
Revamp PECA to be cheaper and more Gregic

### DIFF
--- a/kubejs/server_scripts/gregtech/PECA.js
+++ b/kubejs/server_scripts/gregtech/PECA.js
@@ -1,47 +1,49 @@
 ServerEvents.recipes(event => {
     event.recipes.gtceu.chemical_reactor("sodium_cyanide")
-        .inputFluids('gtceu:hydrogen_cyanide 500')
+        .inputFluids('gtceu:hydrogen_cyanide 1000')
         .itemInputs('gtceu:sodium_hydroxide_dust')
-        .outputFluids('minecraft:water 500')
+        .outputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:sodium_cyanide_dust')
         .duration(50)
         .EUt(GTValues.VHA[GTValues.IV])
 
     event.recipes.gtceu.chemical_reactor("chloroacetatic_mixture")
         .notConsumableFluid('gtceu:acetic_anhydride 500')
-        .inputFluids('gtceu:acetic_acid 1000', 'gtceu:chlorine 2000')
-        .outputFluids('gtceu:chloroacetic_mixture 3000')
+        .inputFluids('gtceu:acetic_acid 1000', 'gtceu:chlorine 3000')
+        .outputFluids('gtceu:chloroacetic_mixture 1000')
         .duration(20)
         .EUt(GTValues.VA[GTValues.UV])
 
     event.recipes.gtceu.distillation_tower("chloroacetate_distillation")
-        .inputFluids('gtceu:chloroacetic_mixture 1000')
+        .inputFluids('gtceu:chloroacetic_mixture 2000')
         .itemOutputs('gtceu:small_chloroacetate_dust')
-        .outputFluids('gtceu:dichloroacetate 200', 'gtceu:trichloroacetate 100', 'gtceu:hydrochloric_acid 450')
+        .outputFluids('gtceu:dichloroacetate 500', 'gtceu:trichloroacetate 250', 'gtceu:hydrochloric_acid 1000')
         .duration(200)
-        .EUt(GTValues.VHA[GTValues.HV])
+        .EUt(GTValues.VHA[GTValues.EV])
 
     event.recipes.gtceu.large_chemical_reactor("cyanoacetic_acid")
-        .itemInputs('2x gtceu:chloroacetate_dust', '2x gtceu:sodium_cyanide_dust', '1x gtceu:soda_ash_dust')
-        .inputFluids('gtceu:hydrochloric_acid 700', 'minecraft:water 700')
-        .itemOutputs('2x gtceu:cyanoacetic_acid_dust')
+        .itemInputs('gtceu:chloroacetate_dust', 'gtceu:sodium_cyanide_dust')
+        .inputFluids('gtceu:hydrochloric_acid 1000', 'gtceu:oxygen 500')
+        .itemOutputs('gtceu:cyanoacetic_acid_dust', 'gtceu:sodium_hydroxide_dust')
+        .outputFluids('gtceu:chlorine 2000')
         .duration(600)
-        .EUt(GTValues.VA[GTValues.LuV])
+        .EUt(GTValues.VA[GTValues.IV])
 
     event.recipes.gtceu.chemical_reactor("ethyl_cyanoacetate")
         .notConsumableFluid('gtceu:fluoroantimonic_acid 2000')
         .inputFluids('gtceu:ethanol 1000')
         .itemInputs('gtceu:cyanoacetic_acid_dust')
-        .outputFluids('gtceu:ethyl_cyanoacetate 500')
+        .outputFluids('gtceu:ethyl_cyanoacetate 1000', "minecraft:water 1000")
         .duration(360)
-        .EUt(GTValues.VA[GTValues.HV])
+        .EUt(GTValues.VA[GTValues.LuV])
 
     event.recipes.gtceu.chemical_reactor("uncracked_ethyl_cyanoacrylate")
         .inputFluids('gtceu:ethyl_cyanoacetate 1000', 'gtceu:formaldehyde 1000')
         .outputFluids('gtceu:uncracked_ethyl_cyanoacrylate 1000', 'minecraft:water 1000')
         .duration(320)
-        .EUt(GTValues.VA[GTValues.LuV])
+        .EUt(GTValues.VA[GTValues.HV])
 
+    //Cracking recipes - CR
     event.recipes.gtceu.chemical_reactor('ethyl_cyanoacrylate_hydro')
         .inputFluids('gtceu:uncracked_ethyl_cyanoacrylate 500', 'gtceu:hydrogen 3000')
         .outputFluids('gtceu:ethyl_cyanoacrylate 250')
@@ -54,13 +56,33 @@ ServerEvents.recipes(event => {
         .duration(240)
         .EUt(GTValues.VA[GTValues.LV])
 
-    // Needs to be LCR to fit all the fluids
-    event.recipes.gtceu.large_chemical_reactor('polyethyl_cyanoacrylate')
-        .notConsumableFluid('gtceu:dimethyl_sulfoxide 500')
-        .inputFluids('gtceu:ethyl_cyanoacrylate 1000', 'gtceu:acetone 3000', 'gtceu:air 750')
+    //Cracking recipes - Cracker
+    event.recipes.gtceu.cracker('ethyl_cyanoacrylate_hydro')
+        .inputFluids('gtceu:uncracked_ethyl_cyanoacrylate 1000', 'gtceu:hydrogen 6000')
+        .outputFluids('gtceu:ethyl_cyanoacrylate 1000')
+        .duration(160)
+        .EUt(GTValues.VA[GTValues.HV])
+
+    event.recipes.gtceu.cracker('ethyl_cyanoacrylate_steam')
+        .inputFluids('gtceu:uncracked_ethyl_cyanoacrylate 1000', 'gtceu:steam 1000')
+        .outputFluids('gtceu:ethyl_cyanoacrylate 1000')
+        .duration(240)
+        .EUt(GTValues.VA[GTValues.HV])
+
+    // Polymerization recipe
+    event.recipes.gtceu.chemical_reactor('polyethyl_cyanoacrylate')
+        .chancedFluidInput('gtceu:dimethyl_sulfoxide 500', 200, -40)
+        .inputFluids('gtceu:ethyl_cyanoacrylate 144', 'minecraft:water 1000')
         .itemOutputs('gtceu:polyethyl_cyanoacrylate_dust')
-        .outputFluids('gtceu:acetone 1600')
-        .duration(3000)
+        .duration(300)
+        .EUt(GTValues.VA[GTValues.LuV])
+
+    // Polymerization recipe with distilled water
+    event.recipes.gtceu.chemical_reactor('polyethyl_cyanoacrylate_distilled')
+        .chancedFluidInput('gtceu:dimethyl_sulfoxide 500', 200, -40)
+        .inputFluids('gtceu:ethyl_cyanoacrylate 96', 'gtceu:distilled_water 1000')
+        .itemOutputs('gtceu:polyethyl_cyanoacrylate_dust')
+        .duration(300)
         .EUt(GTValues.VA[GTValues.LuV])
 
     //Dimethyl sulfoxide (catalyst) chain below

--- a/kubejs/startup_scripts/gregtech_material_registry/chemicals.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/chemicals.js
@@ -101,7 +101,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     event.create('sodium_cyanide')
         .dust()
         .color(0x7FB4C7)
-        .components('1x sodium', '1x carbon', '1x oxygen')
+        .components('1x sodium', '1x carbon', '1x nitrogen')
 
     event.create('chloroacetic_mixture')
         .fluid()
@@ -188,7 +188,6 @@ GTCEuStartupEvents.materialModification(() => {
     GTMaterials.get('tetraethyllead').setFormula('Pb(CH3CH2)4')
 
     // PECA intermediates
-    GTMaterials.get('sodium_cyanide').setFormula('NaCN')
     GTMaterials.get('chloroacetate').setFormula('ClCH2CO2H')
     GTMaterials.get('dichloroacetate').setFormula('Cl2CH2CO2H')
     GTMaterials.get('trichloroacetate').setFormula('Cl3CH2CO2H')


### PR DESCRIPTION
PECA was one of my earlier contributions to Monifactory, and I've since grown in my understanding of Gregic processing lines, stoichiometry, and progression. On top of some fixes to the stoichiometry, this changes some of the line's recipes to be (roughly) 10x cheaper than it was so endgame players might choose to use it in place of PBI. The one exception to this is the catalyst, which now has a very small chance to be consumed each recipe decreasing each tier, returning to non-consumption at UIV.