### PR TITLE
Change the ore density buff to not nerf veins that are already dense

### DIFF
--- a/kubejs/server_scripts/worldgen/oreVeins.js
+++ b/kubejs/server_scripts/worldgen/oreVeins.js
@@ -881,7 +881,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     // Increase vein density
     event.modifyAll((id, vein) => {
-        vein.density(0.5)
+        vein.density(sqrt(vein.getDensity()))
         vein.discardChanceOnAirExposure(0.3)
     })
 })


### PR DESCRIPTION
Monifactory's ore vein density "buff" sets all veins' density to a flat 0.5, which is helpful in many cases but _nerfs_ veins with a density above 0.5.

This PR changes that buff to instead favor veins with very low density, and only weakly increase those veins with already high densities.

**Veins above 0.5 density:**
End Scheelite (0.7)
Nether Banded Iron (1.0)
Nether Beryllium (0.75)
Nether Manganese (0.75)
Nether Tetrahedrite (1.0)
Overworld Cassiterite (1.0)
Overworld Copper-tin (1.0)
Overworld Garnet (0.75)
Overworld Iron (1.0)
Overworld Copper (1.0)
Overworld Lapis (0.75)
Overworld Manganese (0.75)