### PR TITLE
Fixes Eltz line stoichimetry 

### DIFF
--- a/kubejs/server_scripts/gregtech/eltz.js
+++ b/kubejs/server_scripts/gregtech/eltz.js
@@ -71,7 +71,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.electric_blast_furnace('eltz_ingot_blasting')
         .itemInputs('gtceu:flawless_eltic_actinate_gem', '8x #forge:dusts/pulsating_alloy')
-        .itemOutputs('1x gtceu:eltz_ingot', '4x gtceu:actinium_iron_oxide_dust')
+        .itemOutputs('1x gtceu:eltz_ingot', '2x gtceu:actinium_iron_oxide_dust')
         .duration(1540)
         .blastFurnaceTemp(13600)
         .EUt(GTValues.VA[GTValues.UEV])

--- a/kubejs/startup_scripts/gregtech_material_registry/endgame.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/endgame.js
@@ -113,7 +113,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     event.create('actinium_iron_oxide')
         .dust()
         .color(0xC3D1FF)    //Old actinium color for fun
-        .components('1x actinium', '2x iron', '3x oxygen')
+        .components('1x actinium', '4x iron', '3x oxygen')
 
     event.create('monium')
         .ingot()


### PR DESCRIPTION
Actinium Iron oxide formula changed
AcFe2O3 --> AcFe4O3

Blasting eltic actinate now gives 2 actinium iron oxide instead of 4, reflecting changes