### PR TITLE
Fix Custom Ore Vein Worldgen

### DIFF
--- a/kubejs/server_scripts/worldgen/oreVeins.js
+++ b/kubejs/server_scripts/worldgen/oreVeins.js
@@ -8,6 +8,7 @@ GTCEuServerEvents.oreVeins(event => {
     // Overworld veins
     event.add("overworld/uraninite", vein => {
         vein.weight(30)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("stone")
         vein.dimensions("minecraft:overworld")
@@ -26,6 +27,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("overworld/tetrahedrite", vein => {
         vein.weight(50)
+        vein.density(0.25)
         vein.clusterSize(40)
         vein.layer("stone")
         vein.dimensions("minecraft:overworld")
@@ -46,6 +48,7 @@ GTCEuServerEvents.oreVeins(event => {
     // Moon veins
     event.add("moon/diamond", vein => {
         vein.weight(20)
+        vein.density(0.25)
         vein.clusterSize(25)
         vein.layer("moon")
         vein.dimensions("ad_astra:moon")
@@ -64,6 +67,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("moon/gold", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(25)
         vein.layer("moon")
         vein.dimensions("ad_astra:moon")
@@ -84,6 +88,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("moon/manganese", vein => {
         vein.weight(30)
+        vein.density(0.25)
         vein.clusterSize(70)
         vein.layer("moon")
         vein.dimensions("ad_astra:moon")
@@ -108,6 +113,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("moon/molybdenum", vein => {
         vein.weight(20)
+        vein.density(0.25)
         vein.clusterSize(80)
         vein.layer("moon")
         vein.dimensions("ad_astra:moon")
@@ -131,6 +137,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("moon/quartz", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(45)
         vein.layer("moon")
         vein.dimensions("ad_astra:moon")
@@ -150,6 +157,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("moon/tungsten", vein => {
         vein.weight(45)
+        vein.density(0.25)
         vein.clusterSize(15)
         vein.layer("moon")
         vein.dimensions("ad_astra:moon")
@@ -168,6 +176,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("moon/tetrahedrite", vein => {
         vein.weight(30)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("moon")
         vein.dimensions("ad_astra:moon")
@@ -187,6 +196,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("moon/fluorite", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(25)
         vein.layer("moon")
         vein.dimensions("ad_astra:moon")
@@ -206,6 +216,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("moon/bauxite", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("moon")
         vein.dimensions("ad_astra:moon")
@@ -226,6 +237,7 @@ GTCEuServerEvents.oreVeins(event => {
     // Mars veins
     event.add("mars/tungstate", vein => {
         vein.weight(50)
+        vein.density(0.25)
         vein.clusterSize(35)
         vein.layer("mars")
         vein.dimensions("ad_astra:mars")
@@ -242,6 +254,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mars/iron", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(50)
         vein.layer("mars")
         vein.dimensions("ad_astra:mars")
@@ -266,6 +279,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mars/rare_earth_metal", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("mars")
         vein.dimensions("ad_astra:mars")
@@ -284,6 +298,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mars/copper", vein => {
         vein.weight(30)
+        vein.density(0.25)
         vein.clusterSize(45)
         vein.layer("mars")
         vein.dimensions("ad_astra:mars")
@@ -308,6 +323,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mars/zinc", vein => {
         vein.weight(45)
+        vein.density(0.25)
         vein.clusterSize(40)
         vein.layer("mars")
         vein.dimensions("ad_astra:mars")
@@ -331,6 +347,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mars/beryllium", vein => {
         vein.weight(30)
+        vein.density(0.25)
         vein.clusterSize(70)
         vein.layer("mars")
         vein.dimensions("ad_astra:mars")
@@ -347,6 +364,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mars/cassiterite", vein => {
         vein.weight(65)
+        vein.density(0.25)
         vein.clusterSize(60)
         vein.layer("mars")
         vein.dimensions("ad_astra:mars")
@@ -372,6 +390,7 @@ GTCEuServerEvents.oreVeins(event => {
     // Venus veins
     event.add("venus/tungstotitanate", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(50)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -389,6 +408,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("venus/sulfur", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(75)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -412,6 +432,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("venus/copper", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(60)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -436,6 +457,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("venus/iron", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(40)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -460,6 +482,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("venus/tricalcium_phosphate", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(45)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -479,6 +502,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("venus/galena", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(50)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -498,6 +522,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("venus/sheldonite", vein => {
         vein.weight(10)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -518,6 +543,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("venus/lubricant", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -538,6 +564,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("venus/nickel", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -558,6 +585,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("venus/dilithium", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(50)
         vein.layer("venus")
         vein.dimensions("ad_astra:venus")
@@ -578,6 +606,7 @@ GTCEuServerEvents.oreVeins(event => {
     // Mercury veins
     event.add("mercury/mercury", vein => {
         vein.weight(100)
+        vein.density(0.25)
         vein.clusterSize(60)
         vein.layer("mercury")
         vein.dimensions("ad_astra:mercury")
@@ -601,6 +630,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mercury/fluorite", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(25)
         vein.layer("mercury")
         vein.dimensions("ad_astra:mercury")
@@ -620,6 +650,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mercury/mineral_sands", vein => {
         vein.weight(60)
+        vein.density(0.25)
         vein.clusterSize(40)
         vein.layer("mercury")
         vein.dimensions("ad_astra:mercury")
@@ -639,6 +670,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mercury/lithium_salts", vein => {
         vein.weight(50)
+        vein.density(0.25)
         vein.clusterSize(40)
         vein.layer("mercury")
         vein.dimensions("ad_astra:mercury")
@@ -659,6 +691,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mercury/garnet_tin", vein => {
         vein.weight(70)
+        vein.density(0.25)
         vein.clusterSize(40)
         vein.layer("mercury")
         vein.dimensions("ad_astra:mercury")
@@ -678,6 +711,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mercury/platinum_group", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("mercury")
         vein.dimensions("ad_astra:mercury")
@@ -695,6 +729,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mercury/titanotungstate", vein => {
         vein.weight(50)
+        vein.density(0.25)
         vein.clusterSize(50)
         vein.layer("mercury")
         vein.dimensions("ad_astra:mercury")
@@ -712,6 +747,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("mercury/thorium", vein => {
         vein.weight(30)
+        vein.density(0.25)
         vein.clusterSize(50)
         vein.layer("mercury")
         vein.dimensions("ad_astra:mercury")
@@ -731,6 +767,7 @@ GTCEuServerEvents.oreVeins(event => {
     // Glacio Veins
     event.add("glacio/oilsands", vein => {
         vein.weight(20)
+        vein.density(0.25)
         vein.clusterSize(35)
         vein.layer("glacio")
         vein.dimensions("ad_astra:glacio")
@@ -749,6 +786,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("glacio/electrotine", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("glacio")
         vein.dimensions("ad_astra:glacio")
@@ -768,6 +806,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("glacio/osmiridium", vein => {
         vein.weight(30)
+        vein.density(0.25)
         vein.clusterSize(50)
         vein.layer("glacio")
         vein.dimensions("ad_astra:glacio")
@@ -789,6 +828,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("glacio/rare_earth_phosphate", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(30)
         vein.layer("glacio")
         vein.dimensions("ad_astra:glacio")
@@ -808,6 +848,7 @@ GTCEuServerEvents.oreVeins(event => {
     // Glacio Deepslate Veins
     event.add("glacio/sodalite", vein => {
         vein.weight(40)
+        vein.density(0.25)
         vein.clusterSize(100)
         vein.layer("glacio_deepslate")
         vein.dimensions("ad_astra:glacio")
@@ -825,6 +866,7 @@ GTCEuServerEvents.oreVeins(event => {
 
     event.add("glacio/pollucite", vein => {
         vein.weight(20)
+        vein.density(0.25)
         vein.clusterSize(50)
         vein.layer("glacio_deepslate")
         vein.dimensions("ad_astra:glacio")
@@ -845,6 +887,7 @@ GTCEuServerEvents.oreVeins(event => {
     let naqMaterial = !isHardMode ? GTMaterials.Naquadah : GTMaterials.get('snowchestite')
     event.add("glacio/naquadah", vein => {
         vein.weight(30)
+        vein.density(0.25)
         vein.clusterSize(60)
         vein.layer("glacio_deepslate")
         vein.dimensions("ad_astra:glacio")
@@ -864,6 +907,7 @@ GTCEuServerEvents.oreVeins(event => {
     // End Veins
     event.add("end/magnesite", vein => {
         vein.weight(20)
+        vein.density(0.25)
         vein.clusterSize(60)
         vein.layer(WorldGenLayers.ENDSTONE)
         vein.dimensions("minecraft:the_end")


### PR DESCRIPTION
Set a default density of `0.25` on custom ore veins so when `sqrt` is applied the previous(desired) value of `0.5` is set.

This will fix issue #1465.