### PR TITLE
Allow any type of rubber in thermal recipes.

### DIFF
--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -16,7 +16,7 @@ ServerEvents.recipes(event => {
 
     // Unify Thermal with GT rubber
     event.smelting('gtceu:sticky_resin', 'thermal:tar')
-    event.replaceInput({ id: /thermal:*/ }, ['thermal:cured_rubber'], ['gtceu:rubber_plate'])
+    event.replaceInput({ id: /thermal:*/ }, ['thermal:cured_rubber'], ['#forge:rubber_plates'])
     // Unify Thermal dies
 
     event.shaped('thermal:press_packing_2x2_die', [


### PR DESCRIPTION
This is particularly useful for the alchemical quiver used in the T2.5MM (from #1477).