### PR TITLE
Alternate AE2 recipes for printed silicon, again

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -418,6 +418,31 @@ ServerEvents.recipes(event => {
             "item": "ae2:printed_silicon"
         }
     }).id('kubejs:ae2/silicon_print')
+    const wafers = [
+        ['gtceu:', 'silicon_wafer'],
+        ['gtceu:', 'phosphorus_wafer'],
+        ['gtceu:', 'naquadah_wafer'],
+        ['gtceu:', 'neutronium_wafer'],
+        ['kubejs:', 'universe_wafer']
+    ]
+    wafers.forEach((wafer, index) => {
+        event.custom({
+            "type": "ae2:inscriber",
+            "ingredients": {
+                "middle": {
+                    "item": (wafer[0] + wafer[1])
+                },
+                "top": {
+                    "item": "ae2:silicon_press"
+                }
+            },
+            "mode": "inscribe",
+            "result": {
+                "item": "ae2:printed_silicon",
+                "count": 2**index
+            }
+        }).id('kubejs:ae2/' + wafer[1] + '_print')
+    })
 
     event.remove({ id: 'ae2:inscriber/logic_processor' })
     event.custom({
@@ -812,6 +837,15 @@ ServerEvents.recipes(event => {
         .itemOutputs("4x ae2:printed_silicon")
         .duration(10)
         .EUt(2048)
+
+    wafers.forEach((wafer, tier) => {
+        event.recipes.gtceu.forming_press("ae2_printed_" + wafer[1] + "greg")
+            .notConsumable("ae2:silicon_press")
+            .itemInputs("4x " + wafer[0] + wafer[1])
+            .itemOutputs(Item.of("ae2:printed_silicon", 4*(2**tier)))
+            .duration(10)
+            .EUt(2048)
+    })
 
     event.recipes.gtceu.forming_press("ae2_printed_engineering_greg")
         .notConsumable("ae2:engineering_processor_press")


### PR DESCRIPTION
Pulls in the GregTech Wafers recipe for AE2 Printed Silicon from 29364c3 by @Xefyr0, which was missed in fa61955 pulling most of #1200.

Silicon, phosphorus, naquadah, neutronium and universe wafers make 1, 2, 4, 8 and 16 printed silicons each in AE2 inscribers and GregTech forming presses.