### PR TITLE
Alternate recipe for AE2 printed silicon in Expert Mode

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -403,21 +403,51 @@ ServerEvents.recipes(event => {
     }).id("kubejs:ae2/calculation_processor_print")
 
     event.remove({ id: "ae2:inscriber/silicon_print" })
-    event.custom({
-        "type": "ae2:inscriber",
-        "ingredients": {
-            "middle": {
-                "item": "ae2:silicon"
+    const wafers = [
+        ["gtceu:", "silicon_wafer"],
+        ["gtceu:", "phosphorus_wafer"],
+        ["gtceu:", "naquadah_wafer"],
+        ["gtceu:", "neutronium_wafer"],
+        ["kubejs:", "universe_wafer"]
+    ]
+    if (isExpertMode) {
+        // Use only Greg wafers for printed silicon in EM
+        wafers.forEach((wafer, index) => {
+            event.custom({
+                "type": "ae2:inscriber",
+                "ingredients": {
+                    "middle": {
+                        "item": (wafer[0] + wafer[1])
+                    },
+                    "top": {
+                        "item": "ae2:silicon_press"
+                    }
+                },
+                "mode": "inscribe",
+                "result": {
+                    "item": "ae2:printed_silicon",
+                    "count": 2 ** index
+                }
+            }).id("kubejs:ae2/" + wafer[1] + "_print")
+        })
+    } else {
+        // Use AE2 silicon in other modes
+        event.custom({
+            "type": "ae2:inscriber",
+            "ingredients": {
+                "middle": {
+                    "item": "ae2:silicon"
+                },
+                "top": {
+                    "item": "ae2:silicon_press"
+                }
             },
-            "top": {
-                "item": "ae2:silicon_press"
+            "mode": "inscribe",
+            "result": {
+                "item": "ae2:printed_silicon"
             }
-        },
-        "mode": "inscribe",
-        "result": {
-            "item": "ae2:printed_silicon"
-        }
-    }).id("kubejs:ae2/silicon_print")
+        }).id("kubejs:ae2/silicon_print")
+    }
 
     event.remove({ id: "ae2:inscriber/logic_processor" })
     event.custom({
@@ -806,12 +836,23 @@ ServerEvents.recipes(event => {
 
 
     // Greg circuits
-    event.recipes.gtceu.forming_press("ae2_printed_silicon_greg")
-        .notConsumable("ae2:silicon_press")
-        .itemInputs("4x ae2:silicon")
-        .itemOutputs("4x ae2:printed_silicon")
-        .duration(10)
-        .EUt(2048)
+    if (isExpertMode) {
+        wafers.forEach((wafer, tier) => {
+            event.recipes.gtceu.forming_press("ae2_printed_" + wafer[1] + "greg")
+                .notConsumable("ae2:silicon_press")
+                .itemInputs("4x " + wafer[0] + wafer[1])
+                .itemOutputs(Item.of("ae2:printed_silicon", 4 * (2 ** tier)))
+                .duration(10)
+                .EUt(2048)
+        })
+    } else {
+        event.recipes.gtceu.forming_press("ae2_printed_silicon_greg")
+            .notConsumable("ae2:silicon_press")
+            .itemInputs("4x ae2:silicon")
+            .itemOutputs("4x ae2:printed_silicon")
+            .duration(10)
+            .EUt(2048)
+    }
 
     event.recipes.gtceu.forming_press("ae2_printed_engineering_greg")
         .notConsumable("ae2:engineering_processor_press")


### PR DESCRIPTION
Reopen of #1512, sorry for the mess.

Pulls in the GregTech Wafers recipe for AE2 Printed Silicon from 29364c3 by @Xefyr0, which was missed in fa61955 pulling most of #1200, and makes said recipes only in Expert Mode.

Also disables the AE2 silicon recipe in Expert Mode.

Silicon, phosphorus, naquadah, neutronium and universe wafers make 1, 2, 4, 8 and 16 printed silicons each in AE2 inscribers and GregTech forming presses. The problem with more output is that, universe wafers would make more than 64 silicons per recipe in gregtech forming presses, and it wouldn't work cuz there's only one output slot (can we have more?)