### PR TITLE
Add curios:charm tag to all GT batteries, not just those named battery

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/unification/other_tags.js
+++ b/kubejs/server_scripts/fixes_tweaks/unification/other_tags.js
@@ -1,6 +1,8 @@
 /** Random small tags that don't fit anywhere else */
 ServerEvents.tags("item", event => {
-    event.add("curios:charm", /^gtceu:.*_battery$/)
+    event.get("gtceu:batteries").getObjectIds().forEach(resourceLoc => {
+        event.add("curios:charm", resourceLoc.toString())
+    })
 })
 
 ServerEvents.tags("block", event => {


### PR DESCRIPTION
Previously, the curios:charm tag was added to items with "battery" in their item ID.
This expands that to all GT batteries, including the Tantalum Capacitor, Energy Crystal, Lapotronic Energy Orb, and so on.