### PR TITLE
Generate UUIDs deterministically

### DIFF
--- a/tools/build/codegen/credits/target.js
+++ b/tools/build/codegen/credits/target.js
@@ -1,12 +1,21 @@
 // @ts-check
 import Juke from "juke-build";
 import fs from "fs";
-import { randomUUID } from "crypto";
+import UUID from "uuid-1345";
 import { fileURLToPath } from "url";
 import z from "zod";
 
 import { readDatafileJSON } from "../../lib/json_datafile.js";
 import { fillTemplateFile, fillTemplates } from "../fill_templates.js";
+
+let UUIDcounter = -1;
+function randomUUID() {
+    UUIDcounter += 1;
+    return UUID.v5({
+        namespace: UUID.namespace.url,
+        name: `mcuuid://monifactory/credits/${UUIDcounter}`,
+    })
+}
 
 /**
  * @param {string} f

--- a/tools/build/package-lock.json
+++ b/tools/build/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "juke-build": "^0.9.0",
+        "uuid-1345": "^1.0.2",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -789,6 +790,12 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/macaddress": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.5.3.tgz",
+      "integrity": "sha512-vGBKTA+jwM4KgjGZ+S/8/Mkj9rWzePyGY6jManXPGhiWu63RYwW8dKPyk5koP+8qNVhPhHgFa1y/MJ4wrjsNrg==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -981,6 +988,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid-1345": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uuid-1345/-/uuid-1345-1.0.2.tgz",
+      "integrity": "sha512-bA5zYZui+3nwAc0s3VdGQGBfbVsJLVX7Np7ch2aqcEWFi5lsAEcmO3+lx3djM1npgpZI8KY2FITZ2uYTnYUYyw==",
+      "license": "MIT",
+      "dependencies": {
+        "macaddress": "^0.5.1"
       }
     },
     "node_modules/which": {

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "juke-build": "^0.9.0",
+    "uuid-1345": "^1.0.2",
     "zod": "^3.24.1"
   },
   "type": "module",


### PR DESCRIPTION
This ensures generated files are stable (byte for byte/same hash) across rebuilds, which improves reproducibility.