### PR TITLE
Exclude FancyMenu and Drippy Loading Screen server-side

### DIFF
--- a/tools/build/index.js
+++ b/tools/build/index.js
@@ -277,6 +277,8 @@ export const BuildServerTarget = new Juke.Target({
         && !fillet.includes("embeddiumplus")
         && !fillet.includes("citresewn")
         && !fillet.includes("legendarytooltips")
+        && !fillet.includes("fancymenu")
+        && !fillet.includes("drippyloadingscreen")
         && fillet.includes(".jar")
             )
         })


### PR DESCRIPTION
While setting up a container for my server, I noticed that these mods (attempt to) create directories in /.
This is relatively harmless, but they are not useful server-side so might as well.
Clients are not affected by this issue.

See: https://github.com/Keksuccino/FancyMenu/issues/1056