### PR TITLE
Add AE2 Network Analyser

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -1205,7 +1205,7 @@ ServerEvents.recipes(event => {
     event.shapeless("betterp2p:advanced_memory_card", ["ae2:memory_card", "ae2:network_tool"])
 
     // Network Analyser
-    event.remove({ id:'ae2netanalyser:analyser'})
+    event.remove({ id:"ae2netanalyser:analyser"})
     event.shaped(Item.of("ae2netanalyser:network_analyser"), [
         "R R",
         "DSD",

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -1203,4 +1203,17 @@ ServerEvents.recipes(event => {
 
     // BetterP2P
     event.shapeless("betterp2p:advanced_memory_card", ["ae2:memory_card", "ae2:network_tool"])
+
+    // Network Analyser
+    event.remove({ id:'ae2netanalyser:analyser'})
+    event.shaped(Item.of("ae2netanalyser:network_analyser"), [
+        "R R",
+        "DSD",
+        "FDF"
+    ], {
+        R: "gtceu:electrical_steel_rod",
+        D: "gtceu:dark_steel_plate",
+        F: "gtceu:fluix_plate",
+        S: "gtceu:mv_sensor"
+    }).id("kubejs:ae2netanalyser/network_analyser")
 })

--- a/manifest.json
+++ b/manifest.json
@@ -96,6 +96,11 @@
       "required": true
     },
     {
+      "fileID": 5107131,
+      "projectID": 961856,
+      "required": true
+    },
+    {
       "fileID": 5613251,
       "projectID": 1017786,
       "required": true


### PR DESCRIPTION
Adds the ae2 network analyser mod (suggestion #1553) and gives the network analyser a monified recipe.
Even though channels are disabled in Monifactory, the network analyser is still a useful tool to have for visualizing where your network's cables are being run. I think that this mod would be a good addition to Monifactory for all players. The mod is also made by the same developer as Extended AE.

![image](https://github.com/user-attachments/assets/ba0f3113-cb03-4ce5-8f3f-ca7494282808)