### PR TITLE
Slight Retiering

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -132,10 +132,10 @@ ServerEvents.recipes(event => {
         "CDC",
         "AAA"
     ], {
-        A: "gtceu:naquadah_alloy_plate",
-        B: "gtceu:zpm_robot_arm",
+        A: "gtceu:rhodium_plated_palladium_plate",
+        B: "gtceu:luv_robot_arm",
         C: "#gtceu:circuits/zpm",
-        D: "gtceu:zpm_machine_hull",
+        D: "gtceu:luv_machine_hull",
     }).id("kubejs:ae2/requster")
 
     // Quantum Ring
@@ -373,8 +373,14 @@ ServerEvents.recipes(event => {
         B: "gtceu:electrical_steel_plate",
         C: "ae2:calculation_processor"
     }).id("kubejs:ae2/advanced_card")
+
+    // Network Memory Card
     event.remove({ id: "ae2:tools/network_memory_card" })
     event.shapeless("ae2:memory_card", ["#gtceu:circuits/hv", "ae2:basic_card"]).id("kubejs:ae2/memory_card")
+
+    // Crafting Card
+    event.remove({ id: "ae2:materials/cardcrafting"})
+    event.shapeless("ae2:crafting_card", ["minecraft:crafting_table", "ae2:basic_card", "#gtceu:circuits/ev"])
 
     // Level Emitter
     event.remove({ id: "ae2:network/parts/level_emitter" })

--- a/kubejs/server_scripts/mods/laserio.js
+++ b/kubejs/server_scripts/mods/laserio.js
@@ -66,8 +66,8 @@ ServerEvents.recipes(event => {
             "FFF"
         ], {
             F: "gtceu:electrum_flux_plate",
-            E: "gtceu:luv_emitter",
-            C: "#gtceu:circuits/luv",
+            E: "gtceu:ev_emitter",
+            C: "#gtceu:circuits/iv",
             R: "gtceu:red_alloy_plate"
         }).id("laserio:laser_connector_advanced")
     }

--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -299,7 +299,7 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
 
         // Helical Fusion Reactor
         event.create("helical_fusion_reactor", "multiblock")
-            .machine((holder) => new FusionReactorMachine(holder, GTValues.UHV))
+            .machine((holder) => new FusionReactorMachine(holder, GTValues.UEV))
             .rotationState(RotationState.ALL)
             .recipeTypes(GTRecipeTypes.FUSION_RECIPES)
             .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, MachineModifiers.FUSION_REACTOR])


### PR DESCRIPTION
Changes the tiers of a few things.

1. Move Advanced (crossdimensional) LaserIO Connector 1.5 tiers earlier, to late EV
2. Move Crafting card 1 tier later, to EV
3. Move Requester 1 tier earlier, to LuV
4. Change Helical Fusion Reactor's internal tier to UEV. Resolves #1454.