### PR TITLE
Give flux recipes unique recipes ids so that they don't shuffle around and cause emi / ae2 issues

### DIFF
--- a/kubejs/server_scripts/aa_planet_resources.js
+++ b/kubejs/server_scripts/aa_planet_resources.js
@@ -30,7 +30,7 @@ ServerEvents.recipes(event => {
         ], {
             A: planetResources[2],
             B: `kubejs:${planetResources[1]}`
-        })
+        }).id(`kubejs:quantum_flux_from_${planetResources[2]}`)
     })
 
     // Rock dust centrifuging

--- a/kubejs/server_scripts/aa_planet_resources.js
+++ b/kubejs/server_scripts/aa_planet_resources.js
@@ -30,7 +30,7 @@ ServerEvents.recipes(event => {
         ], {
             A: planetResources[2],
             B: `kubejs:${planetResources[1]}`
-        }).id(`kubejs:quantum_flux_from_${planetResources[2]}`)
+        }).id(`kubejs:quantum_flux_from_${planetResources[1]}`)
     })
 
     // Rock dust centrifuging

--- a/kubejs/server_scripts/aa_planet_resources.js
+++ b/kubejs/server_scripts/aa_planet_resources.js
@@ -13,24 +13,33 @@ ServerEvents.recipes(event => {
     ]
 
     regolithDustResources.forEach((planetResources, fluxCount) => {
+        let planetDust = `kubejs:${planetResources[1]}`
+        let planetGem = planetResources[2]
+
         // Planetary dust maceration recipe
         planetResources[0].forEach(rocksToMacerate => {
             event.recipes.gtceu.macerator(rocksToMacerate)
                 .itemInputs(`ad_astra:${rocksToMacerate}`)
-                .itemOutputs(`kubejs:${planetResources[1]}`)
+                .itemOutputs(planetDust)
                 .duration(200)
                 .EUt(GTValues.VHA[GTValues.HV])
         })
 
         // Recipes to make quantum flux from planets' rock dusts
-        event.shaped(`${fluxCount + 1}x kubejs:quantum_flux`, [
+        event.shaped(Item.of("kubejs:quantum_flux", fluxCount + 1), [
             " B ",
             "BAB",
             " B "
         ], {
-            A: planetResources[2],
-            B: `kubejs:${planetResources[1]}`
+            A: planetGem,
+            B: planetDust
         }).id(`kubejs:quantum_flux_from_${planetResources[1]}`)
+
+        event.recipes.gtceu.mixer(`quantum_flux_from_${planetResources[1]}`)
+            .itemInputs(Item.of(planetDust, 4), planetGem)
+            .itemOutputs(Item.of("kubejs:quantum_flux", fluxCount + 1))
+            .duration(100)
+            .EUt(480)
     })
 
     // Rock dust centrifuging

--- a/kubejs/server_scripts/aa_planet_resources.js
+++ b/kubejs/server_scripts/aa_planet_resources.js
@@ -39,7 +39,7 @@ ServerEvents.recipes(event => {
             .itemInputs(Item.of(planetDust, 4), planetGem)
             .itemOutputs(Item.of("kubejs:quantum_flux", fluxCount + 1))
             .duration(100)
-            .EUt(480)
+            .EUt(GTValues.VA[GTValues.HV])
     })
 
     // Rock dust centrifuging


### PR DESCRIPTION
For some reason, the flux recipes don't always get given the same recipe ids, sometimes they'll trade ids around between relogs which causes issues with EMI and AE2. This pull request fixes that.

This pull request also adds mixer versions of the quantum flux crafting recipes for people who want to automate it using gregtech machines instead