### PR TITLE
[MMRework] Use Mixer Pattern for Microversium

### DIFF
--- a/kubejs/server_scripts/microverse/projectors.js
+++ b/kubejs/server_scripts/microverse/projectors.js
@@ -2,14 +2,13 @@
  * Recipes for crafting Microverse Projectors, Microversium, and Microversium casing.
  */
 ServerEvents.recipes(event => {
-    // Microversium Ingot
-    event.recipes.gtceu.electric_blast_furnace("kubejs:microversium_ingot")
-        .itemInputs("2x gtceu:steel_ingot", "minecraft:redstone", "minecraft:glowstone_dust")
-        .inputFluids("gtceu:deuterium 100")
-        .itemOutputs("gtceu:microversium_ingot")
-        .duration(600)
-        .blastFurnaceTemp(1700)
-        .EUt(120)
+    // Microversium Dust
+    event.recipes.gtceu.mixer("microversium")
+        .itemInputs("2x gtceu:steel_dust", "glowstone_dust", "redstone")
+        .inputFluids("gtceu:deuterium 1000")
+        .itemOutputs("5x gtceu:microversium_dust")
+        .duration(300)
+        .EUt(GTValues.VA[GTValues.MV])
 
     // Microverse Casing
     event.shaped("2x kubejs:microverse_casing", [


### PR DESCRIPTION
The EBF recipe was removed in the main branch of moni, but as the rework completely redoes the files, this change wasn't included.

This PR removes the direct-ebf recipe for microversium, in favor of the mixer -> ebf recipe to be consistent with other ebf recipes.