### PR TITLE
Re-add SophStorage Packing Tape

### DIFF
--- a/kubejs/server_scripts/mods/Sophisticated_Storage.js
+++ b/kubejs/server_scripts/mods/Sophisticated_Storage.js
@@ -11,9 +11,6 @@ ServerEvents.recipes(event => {
     event.remove({ id: "sophisticatedstorage:xp_pump_upgrade" })
     event.remove({ id: "sophisticatedbackpacks:xp_pump_upgrade" })
 
-    // There is dupe glitch involving this.
-    event.remove({ id: "sophisticatedstorage:packing_tape" })
-
     // Remove Limited barrels
     event.remove({ id: /^sophisticatedstorage:.*limited.+barrel.+$/ })
     event.remove({ output: /^sophisticatedstorage:limited_barrel.+$/ })


### PR DESCRIPTION
I cannot re-create the dupe glitch shown [here.](https://discord.com/channels/914926812948234260/1229854271613436066/1305928403316113428)

If possible I would like a second opinion, since crafting directly from favorites doesn't seem to work as expected.
However, this could be me or Crafting Station: JEI Edition or both.

This would resolve #1277.