### PR TITLE
Add a way to reprocess Rotten Flesh into Mincemeat and Fermented Biomass

### DIFF
--- a/kubejs/assets/gtceu/lang/en_us.json
+++ b/kubejs/assets/gtceu/lang/en_us.json
@@ -373,6 +373,7 @@
     "curios.identifier.gtceu_magnet": "Magnet",
     "item.gtceu.wetware_processor_mainframe.tooltip.0": "§7No Mouth, and Must Scream",
     "material.gtceu.rhodium_plated_palladium": "Rhodium Plated Lumium-Palladium",
+    "material.gtceu.rotten_meat": "Tainted Meat",
     "__HM_MISC__.header": "============",
     "__HM_MISC__.flufff": "> HM Misc. <",
     "__HM_MISC__.footer": "============",

--- a/kubejs/server_scripts/fleshline.js
+++ b/kubejs/server_scripts/fleshline.js
@@ -1,0 +1,19 @@
+/**
+ * Processing line to reprocess Rotten Flesh into other useful products
+ */
+ServerEvents.recipes(event => {
+    event.recipes.gtceu.macerator("rotten_meat")
+        .itemInputs("minecraft:rotten_flesh")
+        .itemOutputs("gtceu:rotten_meat_dust", "gtceu:tiny_bone_dust")
+        .duration(102)
+        .EUt(2)
+
+    // This recipe violates the conservation of mass because the waste sludge gets voided automatically! :D
+    event.recipes.gtceu.chemical_bath("sanitize_rotten_meat")
+        .itemInputs("16x gtceu:rotten_meat_dust", "gtceu:iodine_dust")
+        .inputFluids("gtceu:distilled_water 8000")
+        .itemOutputs("6x gtceu:meat_dust")
+        .outputFluids("gtceu:fermented_biomass 500")
+        .duration(1600)
+        .EUt(GTValues.VA[GTValues.HV])
+})

--- a/kubejs/startup_scripts/gregtech_material_registry/misc.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/misc.js
@@ -229,6 +229,11 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_DENSE)
         .components("6x trinium", "2x naquadah", "1x carbon")
         .blastTemp(8747, "higher", 131072, 1200)
+
+    event.create("rotten_meat")
+        .dust(1)
+        .color(0xe8543a).secondaryColor(0x684a09).iconSet(GTMaterialIconSet.SAND)
+        .ignoredTagPrefixes([TagPrefix.dustTiny, TagPrefix.dustSmall])
 })
 
 GTCEuStartupEvents.materialModification(event => {


### PR DESCRIPTION
This adds a short 2-step process that turns Rotten Flesh, Distilled Water, and Iodine dust into Tiny piles of Bonemeal, Fermented Biomass, and Mince meat.

It would serve as an alternative to grinding up copious amounts of Fish to get enough Mincemeat for Wetware.
It would also cover the need described in #877.