### PR TITLE
Fix Glowstone Tags

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/unification/other_tags.js
+++ b/kubejs/server_scripts/fixes_tweaks/unification/other_tags.js
@@ -6,4 +6,5 @@ ServerEvents.tags("item", event => {
 })
 
 ServerEvents.tags("block", event => {
+    event.add("minecraft:mineable/pickaxe", "minecraft:glowstone")
 })


### PR DESCRIPTION
Adds pickaxe tag to glowstone, so we can finally mine it fast like we want to.

https://github.com/user-attachments/assets/e1052d7d-5968-4c42-a8f0-2b4caac1d93a

