### PR TITLE
HM Platline Tweak

### DIFF
--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -639,7 +639,7 @@ ServerEvents.recipes(event => {
             .outputFluids("minecraft:water 2000")
             .duration(300).EUt(30)
 
-        event.recipes.gtceu.chemical_reactor("ammonium_hexachloroiridiate_to_iridium")
+        event.recipes.gtceu.large_chemical_reactor("ammonium_hexachloroiridiate_to_iridium")
             .itemInputs("8x gtceu:ammonium_hexachloroiridiate_dust")
             .inputFluids("gtceu:hydrogen 12000")
             .itemOutputs("gtceu:iridium_dust")

--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -639,6 +639,13 @@ ServerEvents.recipes(event => {
             .outputFluids("minecraft:water 2000")
             .duration(300).EUt(30)
 
+        event.recipes.gtceu.chemical_reactor("ammonium_hexachloroiridiate_to_small_iridium")
+            .itemInputs("2x gtceu:ammonium_hexachloroiridiate_dust")
+            .inputFluids("gtceu:hydrogen 3000")
+            .itemOutputs("gtceu:small_iridium_dust")
+            .outputFluids("gtceu:hydrochloric_acid 4500", "gtceu:ammonia 500")
+            .duration(150).EUt(7680)
+
         event.recipes.gtceu.large_chemical_reactor("ammonium_hexachloroiridiate_to_iridium")
             .itemInputs("8x gtceu:ammonium_hexachloroiridiate_dust")
             .inputFluids("gtceu:hydrogen 12000")

--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -644,7 +644,7 @@ ServerEvents.recipes(event => {
             .inputFluids("gtceu:hydrogen 3000")
             .itemOutputs("gtceu:small_iridium_dust")
             .outputFluids("gtceu:hydrochloric_acid 4500", "gtceu:ammonia 500")
-            .duration(150).EUt(7680)
+            .duration(37.5).EUt(7680)
 
         event.recipes.gtceu.large_chemical_reactor("ammonium_hexachloroiridiate_to_iridium")
             .itemInputs("8x gtceu:ammonium_hexachloroiridiate_dust")


### PR DESCRIPTION
Changes Iridium recipe to LCR only, as its a common pitfall of players to try and use IV Chemical Reactor for this recipe, but the output buffer only hold 16b, not the 18b that this recipe generates.

Also adds a recipe for small iridium dust to IV chem reactor, so players do have the option to avoid a LCR. (xefyr's banger suggestion)