### PR TITLE
Remove modifier bonuses from Exoskeletons

### DIFF
--- a/kubejs/startup_scripts/skeleton_legs.js
+++ b/kubejs/startup_scripts/skeleton_legs.js
@@ -17,11 +17,11 @@ StartupEvents.registry("item", event => {
 })
 
 const ExoskeletonLegsEffects = [
-    {itemID: "lv_exoskeleton_legs", step_height_change: 0.5, movement_speed_boost: 0.2},
-    {itemID: "mv_exoskeleton_legs", step_height_change: 0.5, movement_speed_boost: 0.4},
-    {itemID: "hv_exoskeleton_legs", step_height_change: 0.5, movement_speed_boost: 0.6},
-    {itemID: "ev_exoskeleton_legs", step_height_change: 0.5, movement_speed_boost: 0.8},
-    {itemID: "iv_exoskeleton_legs", step_height_change: 0.5, movement_speed_boost: 1.0}
+    {itemID: "lv_exoskeleton_legs", step_height_change: 0.0, movement_speed_boost: 0.0},
+    {itemID: "mv_exoskeleton_legs", step_height_change: 0.0, movement_speed_boost: 0.0},
+    {itemID: "hv_exoskeleton_legs", step_height_change: 0.0, movement_speed_boost: 0.0},
+    {itemID: "ev_exoskeleton_legs", step_height_change: 0.0, movement_speed_boost: 0.0},
+    {itemID: "iv_exoskeleton_legs", step_height_change: 0.0, movement_speed_boost: 0.0}
 ]
 
 const step_modifier_UUID = UUID.fromString("9397bcb0-29f3-4bb2-8b4e-d46db405e777");


### PR DESCRIPTION
The way that the item targeting works here causes this script to stack its effects with the new gtexoskeleton mod resulting in doubled speed bonuses and doubled height bonuses.