### PR TITLE
Add GTM Utilities config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !/config/lostcities/profiles/monidefault.json
 !/mods/systeams*
 !/mods/ExtendedCrafting*
+!/config/gtmutils.yaml
 
 /mods/.index
 /mods/.connector

--- a/config/gtmutils.yaml
+++ b/config/gtmutils.yaml
@@ -1,0 +1,17 @@
+features:
+  # Whether the Sterile Cleaning Maintenance Hatch is enabled.
+  sterileHatchEnabled: false
+
+  # Whether the 64A energy converters are enabled.
+  converters64aEnabled: true
+
+  # Whether the Omni-breaker is enabled.
+  omnibreakerEnabled: true
+
+  # What tier the Omni-breaker is, if enabled. (ULV = 0, LV = 1, MV = 2, ...)
+  # (Unless the default recipe is overridden, can only support LV to IV!)
+  omnibreakerTier: 5
+
+  # The energy capacity of the Omni-breaker.
+  omnibreakerEnergyCapacity: 40960000
+


### PR DESCRIPTION
Adds GTM utilities config, with all values default except disabling the sterile cleaning hatch.