### PR TITLE
More sensible LCR Sulfuric Acid

### DIFF
--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -274,7 +274,7 @@ ServerEvents.recipes(event => {
             .inputFluids("minecraft:water 4000")
             .circuit(24)
             .outputFluids("gtceu:sulfuric_acid 1000")
-            .duration(160).EUt(480)
+            .duration(40).EUt(480)
 
         // Fluoroantimonic Acid
         event.remove({ id: "gtceu:chemical_reactor/fluoroantimonic_acid" })
@@ -719,7 +719,6 @@ ServerEvents.recipes(event => {
             .inputFluids("gtceu:durene 250", "gtceu:oxygen 1500")
             .outputFluids("gtceu:pyromellitic_dianhydride 250", "minecraft:water 1500")
             .duration(400).EUt(480);
-
 
         event.recipes.gtceu.chemical_reactor("manganese_acetate")
             .itemInputs("gtceu:manganese_dust")

--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -274,7 +274,7 @@ ServerEvents.recipes(event => {
             .inputFluids("minecraft:water 4000")
             .circuit(24)
             .outputFluids("gtceu:sulfuric_acid 1000")
-            .duration(320).EUt(480)
+            .duration(160).EUt(480)
 
         // Fluoroantimonic Acid
         event.remove({ id: "gtceu:chemical_reactor/fluoroantimonic_acid" })
@@ -720,7 +720,7 @@ ServerEvents.recipes(event => {
             .outputFluids("gtceu:pyromellitic_dianhydride 250", "minecraft:water 1500")
             .duration(400).EUt(480);
 
- 
+
         event.recipes.gtceu.chemical_reactor("manganese_acetate")
             .itemInputs("gtceu:manganese_dust")
             .inputFluids("gtceu:acetic_acid 1000")

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -1036,5 +1036,5 @@ ServerEvents.recipes(event => {
         .inputFluids("minecraft:water 4000")
         .circuit(24)
         .outputFluids("gtceu:sulfuric_acid 1000")
-        .duration(160).EUt(480)
+        .duration(40).EUt(480)
 })

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -1027,4 +1027,14 @@ ServerEvents.recipes(event => {
     event.replaceInput({ output: "gtmutils:uev_64a_energy_converter" }, "gtceu:europium_hex_cable", "gtceu:activated_netherite_hex_wire")
     event.replaceInput({ output: "gtmutils:uiv_64a_energy_converter" }, "gtceu:europium_hex_cable", "gtceu:holmium_hex_wire")
     event.replaceInput({ output: "gtmutils:max_64a_energy_converter" }, "gtceu:europium_hex_cable", "gtceu:monium_hex_wire")
+
+    // LCR Sulfuric Acid being terrible fix
+    event.remove({ id: "gtceu:large_chemical_reactor/sulfuric_acid_from_sulfur" })
+
+    event.recipes.gtceu.large_chemical_reactor("sulfuric_acid_from_sulfur")
+        .itemInputs("gtceu:sulfur_dust")
+        .inputFluids("minecraft:water 4000")
+        .circuit(24)
+        .outputFluids("gtceu:sulfuric_acid 1000")
+        .duration(160).EUt(480)
 })


### PR DESCRIPTION
Reduce LCR Sulfuric Acid to 2s per operation at HV

Reasoning: Sulfur Trioxide 3-part recipe at HV takes 1.6s per 1b Sulfuric Acid due to perfect OC, but since the LCR recipe is based at HV it takes 16s to do the whole operation.


*Alternatively*, if we want to encourage players to consider making the 3-LCR process, we can modify this change to bring it down to 4s instead of 2s.
