### PR TITLE
Omnic Forge Tweaks

### DIFF
--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -143,7 +143,6 @@ ItemEvents.tooltip(tooltip => {
 
     parallelMultis.forEach(multi => {
         tooltip.addAdvanced(`gtceu:${multi}`, (item, adv, text) => {
-            text.add(1, Text.translatable("gtceu.multiblock.parallelizable.tooltip"))
             text.add(2, Text.translatable(`gtceu.multiblock.${multi}.description`))
         })
     })
@@ -162,6 +161,9 @@ ItemEvents.tooltip(tooltip => {
         text.add(5, Text.translatable("gtceu.machine.electric_blast_furnace.tooltip.2"))
     })
 
+    tooltip.addAdvanced("gtceu:omnic_forge", (item, adv, text) => {
+        text.add(1, Text.translatable("gtceu.multiblock.parallelizable.tooltip"))
+    })
 
     // Parallel hatches
     tooltip.add("gtceu:uhv_uhv_parallel_hatch", Text.translatable("gtceu.giga_parallel_hatch.desc"))

--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -720,7 +720,6 @@ ServerEvents.recipes(event => {
             .outputFluids("gtceu:pyromellitic_dianhydride 250", "minecraft:water 1500")
             .duration(400).EUt(480);
 
- 
         event.recipes.gtceu.chemical_reactor("manganese_acetate")
             .itemInputs("gtceu:manganese_dust")
             .inputFluids("gtceu:acetic_acid 1000")

--- a/kubejs/server_scripts/gregtech/omnic_forge.js
+++ b/kubejs/server_scripts/gregtech/omnic_forge.js
@@ -19,7 +19,7 @@ ServerEvents.recipes(event => {
     })
 
     event.recipes.gtceu.assembler("kubejs:omnic_matrix_machine_casing")
-        .itemInputs("12x gtceu:omnium_plate", "2x gtceu:crystal_matrix_frame", "2x gtceu:zpm_field_generator", "2x #gtceu:circuits/uv")
+        .itemInputs("12x gtceu:omnium_plate", "2x gtceu:crystal_matrix_frame", "1x gtceu:zpm_field_generator", "2x #gtceu:circuits/uv")
         .itemOutputs("2x kubejs:omnic_matrix_machine_casing")
         .duration(2000)
         .EUt(65520)

--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -780,7 +780,7 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
             .where("D", Predicates.frames(GTMaterials.get("cryolobus")))
             .where("G", Predicates.blocks(GTBlocks.FUSION_GLASS.get()))
             .where("O", Predicates.blocks("kubejs:omnic_matrix_machine_casing"))
-            .where("C", Predicates.blocks("kubejs:omnic_matrix_machine_casing")
+            .where("C", Predicates.blocks("kubejs:omnic_matrix_machine_casing").setMaxGlobalLimited(124)
                 .or(Predicates.autoAbilities(definition.getRecipeTypes()))
                 .or(Predicates.abilities(PartAbility.PARALLEL_HATCH).setMaxGlobalLimited(1))
             )


### PR DESCRIPTION
Currently there is no minimum casings limit, resulting in many players building the structure out of input busses instead of omnic casing.

This was discussed to be partially due to the high ZPM Field Generator cost of the casings.

This PR enforces a minimum casings of 124 (10 less than max), and reduces ZPM field generator cost from 2 to 1

Also adds parallelable tooltip to controller. I do this in a lil bit of a jank way because I don't know how yall handle localizable entries.