### PR TITLE
Make Fluxbore HV

### DIFF
--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -720,7 +720,6 @@ ServerEvents.recipes(event => {
             .outputFluids("gtceu:pyromellitic_dianhydride 250", "minecraft:water 1500")
             .duration(400).EUt(480);
 
- 
         event.recipes.gtceu.chemical_reactor("manganese_acetate")
             .itemInputs("gtceu:manganese_dust")
             .inputFluids("gtceu:acetic_acid 1000")

--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -699,17 +699,21 @@ ServerEvents.recipes(event => {
     event.replaceInput({ id: "thermal:tools/detonator" }, ["#forge:gears/signalum"], ["#gtceu:circuits/mv"])
 
     event.remove([{ id: "thermal:drill_head" }, { id: "thermal:flux_drill" }])
-    event.shaped("thermal:flux_drill", [
-        " A ",
-        "BCB",
-        "DED"
-    ], {
-        A: "gtceu:vanadium_steel_drill_head",
-        B: "#forge:ingots/silver",
-        C: "gtceu:lv_power_unit",
-        D: "#forge:ingots/tin",
-        E: "gtceu:iron_gear"
-    }).id("kubejs:flux_drill");
+
+    // Don't allow flux_drill in Expert Mode, and move it to HV for Hard Mode
+    if (!isExpertMode) {
+       event.shaped("thermal:flux_drill", [
+           " A ",
+           "BCB",
+           "DED"
+       ], {
+           A: "gtceu:stainless_steel_drill_head",
+           B: "#forge:ingots/silver",
+           C: "gtceu:mv_power_unit",
+           D: "#forge:ingots/tin",
+           E: "gtceu:iron_gear"
+       }).id("kubejs:flux_drill");
+    }
 
     event.remove([{ id: "thermal:saw_blade" }, { id: "thermal:flux_saw" }])
     event.shaped("thermal:flux_saw", [

--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -703,15 +703,15 @@ ServerEvents.recipes(event => {
     // Don't allow flux_drill in Expert Mode, and move it to HV
     if (!isExpertMode) {
         event.shaped("thermal:flux_drill", [
-           " A ",
-           "BCB",
-           "DED"
+            " A ",
+            "BCB",
+            "DED"
         ], {
-           A: "gtceu:stainless_steel_drill_head",
-           B: "#forge:ingots/silver",
-           C: "gtceu:mv_power_unit",
-           D: "#forge:ingots/tin",
-           E: "gtceu:iron_gear"
+            A: "gtceu:stainless_steel_drill_head",
+            B: "#forge:ingots/silver",
+            C: "gtceu:mv_power_unit",
+            D: "#forge:ingots/tin",
+            E: "gtceu:iron_gear"
         }).id("kubejs:flux_drill");
     }
 

--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -702,17 +702,17 @@ ServerEvents.recipes(event => {
 
     // Don't allow flux_drill in Expert Mode, and move it to HV for Hard Mode
     if (!isExpertMode) {
-       event.shaped("thermal:flux_drill", [
+        event.shaped("thermal:flux_drill", [
            " A ",
            "BCB",
            "DED"
-       ], {
+        ], {
            A: "gtceu:stainless_steel_drill_head",
            B: "#forge:ingots/silver",
            C: "gtceu:mv_power_unit",
            D: "#forge:ingots/tin",
            E: "gtceu:iron_gear"
-       }).id("kubejs:flux_drill");
+        }).id("kubejs:flux_drill");
     }
 
     event.remove([{ id: "thermal:saw_blade" }, { id: "thermal:flux_saw" }])


### PR DESCRIPTION
Removes fluxbore from expert mode, yall got drills at home already.

Moves fluxbore from *early* MV, to HV

Reasoning being, it's trivial to upgrade fluxbore to 9x9x1 the moment you make one, so it should be balanced between the MV drill (3x3x3) and HV drill (4x4x4)