### PR TITLE
ExtendedAE Recipe Fixes

### DIFF
--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -720,7 +720,6 @@ ServerEvents.recipes(event => {
             .outputFluids("gtceu:pyromellitic_dianhydride 250", "minecraft:water 1500")
             .duration(400).EUt(480);
 
- 
         event.recipes.gtceu.chemical_reactor("manganese_acetate")
             .itemInputs("gtceu:manganese_dust")
             .inputFluids("gtceu:acetic_acid 1000")

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -1015,6 +1015,8 @@ ServerEvents.recipes(event => {
     event.remove({ id: "expatternprovider:epa_upgrade" })
     event.shapeless("expatternprovider:ex_pattern_access_part", ["#ae2:illuminated_panel", "ae2:logic_processor"]).id("kubejs:epp/epa_upgrade")
 
+    // ExtendedAE Silicon Block
+    event.remove({id:"expatternprovider:silicon_block"})
 
     // ME packing tape
     event.shapeless("expatternprovider:me_packing_tape", ["gtceu:basic_tape", "gtceu:fluix_dust"]).id("expatternprovider:tape")
@@ -1034,6 +1036,14 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.assembler("kubejs:epp/assembler_matrix_wall")
         .itemInputs("expatternprovider:assembler_matrix_frame", "gtceu:hv_electric_motor")
         .itemOutputs("expatternprovider:assembler_matrix_wall")
+        .duration(100)
+        .EUt(1920)
+
+    // Assembler Matrix Glass
+    event.remove({ id: "expatternprovider:assembler_matrix_glass" })
+    event.recipes.gtceu.assembler("kubejs:epp/assembler_matrix_glass")
+        .itemInputs("expatternprovider:assembler_matrix_frame", "gtceu:hv_electric_motor", "ae2:quartz_glass")
+        .itemOutputs("expatternprovider:assembler_matrix_glass")
         .duration(100)
         .EUt(1920)
 

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -1023,6 +1023,9 @@ ServerEvents.recipes(event => {
         .blastFurnaceTemp(1700)
         .EUt(480)
 
+    // Remove ExtendedAE Silicon Block
+    event.remove({id:"expatternprovider:silicon_block"})
+
     // 64A energy converters recipe fix
     event.replaceInput({ output: "gtmutils:uev_64a_energy_converter" }, "gtceu:europium_hex_cable", "gtceu:activated_netherite_hex_wire")
     event.replaceInput({ output: "gtmutils:uiv_64a_energy_converter" }, "gtceu:europium_hex_cable", "gtceu:holmium_hex_wire")

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -1023,9 +1023,6 @@ ServerEvents.recipes(event => {
         .blastFurnaceTemp(1700)
         .EUt(480)
 
-    // Remove ExtendedAE Silicon Block
-    event.remove({id:"expatternprovider:silicon_block"})
-
     // 64A energy converters recipe fix
     event.replaceInput({ output: "gtmutils:uev_64a_energy_converter" }, "gtceu:europium_hex_cable", "gtceu:activated_netherite_hex_wire")
     event.replaceInput({ output: "gtmutils:uiv_64a_energy_converter" }, "gtceu:europium_hex_cable", "gtceu:holmium_hex_wire")


### PR DESCRIPTION
Recipe was added in a recent ExtendedAE update that allows you to make a silicon block from ae silicon from certus dust.

Also gregifies Assembler Glass to be the same as Assembler wall, but requires a Quartz Glass