### PR TITLE
Fix Certus Grinding

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -247,6 +247,14 @@ ServerEvents.recipes(event => {
         .duration(20)
         .EUt(480)
 
+    // Fix Regular Certus Grinding Recipe giving Charged Certus Dust sometimes due to using forge tags
+    event.remove({ id: "gtceu:macerator/macerate_certus_quartz_gem" })
+    event.recipes.gtceu.macerator("macerate_certus_quartz_gem")
+        .itemInputs(["gtceu:certus_quartz_gem"])
+        .itemOutputs("gtceu:certus_quartz_dust")
+        .duration(20)
+        .EUt(GTValues.VA[GTValues.ULV])
+
     // Matter Condenser
     event.remove({ id: "ae2:network/blocks/io_condenser" })
     event.shaped(Item.of("ae2:condenser"), [


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/60a87b45-6905-4ab7-b044-4da62ada6448)

Charge Certus Quartz and Certus Quartz both share a forge tag that causes the game to sometimes give Charged Certus Dust, and sometimes Certus Dust when macerating Certus Quartz.

This PR undefines the existing macerator recipe and redefines it.

This redefinition puts it in the Macerator tab, but I'd like to put it in the Part Grinding tab along with the other certus grinding recipes, how would I do that?