### PR TITLE
Change starry diamond block name to starry diamatine

### DIFF
--- a/kubejs/startup_scripts/registry/block_registry.js
+++ b/kubejs/startup_scripts/registry/block_registry.js
@@ -205,7 +205,7 @@ StartupEvents.registry("block", event => {
 
     // Misc
     event.create("starry_diamond_block")
-        .displayName("Starry Diamond Block")
+        .displayName("Starry Diamatine Block")
         .soundType("metal")
         .resistance(6).hardness(5)
         .tagBlock("mineable/pickaxe").requiresTool(true)


### PR DESCRIPTION
Starry diamond blocks are made of diamatine, so it makes no sense to have it be called diamond. This PR changes only the lang entry to prevent breaking changes