### PR TITLE
[v13] Re-balance AE Channels

### DIFF
--- a/config-overrides/expert/ae2/common.json
+++ b/config-overrides/expert/ae2/common.json
@@ -6,7 +6,7 @@
     "tinyTntBlockDamage_comment": "Enables the ability of Tiny TNT to break blocks.",
     "tinyTntBlockDamage": true,
     "channels_comment": "Changes the channel capacity that cables provide in AE2.",
-    "channels": "default",
+    "channels": "x2",
     "spatialAnchorEnableRandomTicks_comment": "Whether Spatial Anchors should force random chunk ticks and entity spawning.",
     "spatialAnchorEnableRandomTicks": true
   },


### PR DESCRIPTION
I can accept reasoning for HM to have infinite channels instead of x4

I can't accept EM getting just 1x channels. I believe this will actively discourage players from passiving and encourage more on-demand crafting.

I have been playtesting the pack with x2 Expert Channels for over a week now, and have found that it becomes something that I have to consider when planning my automation lines, but it doesn't become an active hinderance.

Example: Assembler Automation, some require fluids and some don't, this line just barely hit 16 channels on one line without becoming a pain to manage.

![image](https://github.com/user-attachments/assets/0a7f4ccc-f58b-4f2d-b783-a07fe48d5ffe)

As I now have to use multiple subnets, I have to connect these subnets to my main network, at MV this is just barely manageable without needing dense cable everywhere, if my system grows any larger I will have to invest in the more robust infrastructure.

![image](https://github.com/user-attachments/assets/0fa943b8-d6b6-467f-88ea-f382684b3983)

