### PR TITLE
Fixed NCN fission reactors not working in 0.12.4

### DIFF
--- a/kubejs/startup_scripts/nukeLists/fluid.js
+++ b/kubejs/startup_scripts/nukeLists/fluid.js
@@ -46,35 +46,35 @@ global.fluidNukeList = [
     "systeams:steamiestest",
 ]
 
-StartupEvents.postInit(event => {
-    /**
-     * NuclearCraft is most easily dealt with by removing *everything* but a select few fluids
-     */
-    // Get all of the NuclearCraft fluids
-    let NCFluids = Fluid.getTypes().filter(id => id.includes("nuclearcraft"))
 
-    // NuclearCraft fluids to not nuke
-    let NCFluidsToKeep = [
-        "nuclearcraft:hydrated_gelatin",
-        "nuclearcraft:gelatin",
-        "nuclearcraft:sugar",
-        "nuclearcraft:marshmallow",
-        "nuclearcraft:cocoa_butter",
-        "nuclearcraft:pasteurized_milk",
-        "nuclearcraft:chocolate_liquor",
-        "nuclearcraft:unsweetened_chocolate",
-        "nuclearcraft:dark_chocolate",
-        "nuclearcraft:milk_chocolate",
-        "nuclearcraft:technical_water",
-        "nuclearcraft:high_pressure_steam",
-    ]
+/**
+ * NuclearCraft is most easily dealt with by removing *everything* but a select few fluids
+ */
+// Get all of the NuclearCraft fluids
+let NCFluids = Fluid.getTypes().filter(id => id.includes("nuclearcraft"))
 
-    // Add flowing fluid variants to the list of fluids to keep
-    NCFluidsToKeep.forEach(fluid => { NCFluidsToKeep.push(`${fluid}_flowing`) })
+// NuclearCraft fluids to not nuke
+let NCFluidsToKeep = [
+    "nuclearcraft:hydrated_gelatin",
+    "nuclearcraft:gelatin",
+    "nuclearcraft:sugar",
+    "nuclearcraft:marshmallow",
+    "nuclearcraft:cocoa_butter",
+    "nuclearcraft:pasteurized_milk",
+    "nuclearcraft:chocolate_liquor",
+    "nuclearcraft:unsweetened_chocolate",
+    "nuclearcraft:dark_chocolate",
+    "nuclearcraft:milk_chocolate",
+    "nuclearcraft:technical_water",
+    "nuclearcraft:high_pressure_steam",
+    "nuclearcraft:exhaust_steam",
+]
 
-    // Remove used fluids from the full list of NC fluids
-    let NCFluidsToRemove = NCFluids.filter((el) => !NCFluidsToKeep.includes(el))
+// Add flowing fluid variants to the list of fluids to keep
+NCFluidsToKeep.forEach(fluid => { NCFluidsToKeep.push(`${fluid}_flowing`) })
 
-    // Add all the unwanted NuclearCraft fluids to the nukeList
-    global.fluidNukeList = global.fluidNukeList.concat(NCFluidsToRemove)
-})
+// Remove used fluids from the full list of NC fluids
+let NCFluidsToRemove = NCFluids.filter((el) => !NCFluidsToKeep.includes(el))
+
+// Add all the unwanted NuclearCraft fluids to the nukeList
+global.fluidNukeList = global.fluidNukeList.concat(NCFluidsToRemove)


### PR DESCRIPTION
Hi!

This fixes a bug in release 0.12.4 where fission reactors don't work (they don't consume fuels, and hatches are even more broken than usual). Quite a few people have had new issues with NCN reactors since the last patch.

Exhaust steam seems to be necessary for NCN fission reactor to work, even with turbine disabled -> Added back to the nuke free list
Also, nuking fluids post startup actually prevents NCN from initializing correctly (if we can call NCN initialisations "correct"), and prevents the fission controller from consuming fuels, and makes hatches pull items from adjacent inventories.

No idea why NCN works like this, but I needed a quick fix for the server we're running with friends and this did the job.
This is a partial revert of this commit, no new code is added:
https://github.com/ThePansmith/Monifactory/commit/0a0a7fb7095a89f0f0f0d220e7826e5f15a382a0

Thanks!