### PR TITLE
Update Quantum Coolant recipe

### DIFF
--- a/kubejs/server_scripts/gregtech/gtmutils.js
+++ b/kubejs/server_scripts/gregtech/gtmutils.js
@@ -2,9 +2,9 @@
 ServerEvents.recipes(event => {
     if (doQuantumCoolant) {
         event.recipes.gtceu.large_chemical_reactor("quantum_coolant")
-            .notConsumable("gtceu:uv_emitter")
+            .notConsumable("kubejs:neutron_emitter")
             .itemInputs("8x kubejs:quantum_flux", "8x kubejs:cryotheum_dust")
-            .inputFluids("gtceu:liquid_helium 1000")
+            .inputFluids("gtceu:liquid_helium 1000", "gtceu:pcb_coolant 500")
             .outputFluids("gtmutils:quantum_coolant 2000")
             .duration(80)
             .EUt(GTValues.VA[GTValues.LuV]);


### PR DESCRIPTION
Change the quantum coolant recipe to use a neutron emitter as its catalyst and involve PCB coolant in its production.