### PR TITLE
Rebalance Endsteel

### DIFF
--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -781,4 +781,19 @@ ServerEvents.recipes(event => {
     } else {
         event.replaceInput({ id: "enderio:conduit_probe" }, "enderio:energy_conduit", "gtceu:conductive_alloy_single_wire")
     }
+
+    // Make End Steel Craftable in HV
+    event.recipes.gtceu.chemical_bath("end_steel_ingot_cooling")
+        .inputFluids("minecraft:water 100")
+        .itemInputs("gtceu:hot_end_steel_ingot")
+        .itemOutputs("gtceu:end_steel_ingot")
+        .duration(200)
+        .EUt(GTValues.VHA[GTValues.HV])
+
+    event.recipes.gtceu.chemical_bath("end_steel_ingot_distilled_cooling")
+        .inputFluids("gtceu:distilled_water 100")
+        .itemInputs("gtceu:hot_end_steel_ingot")
+        .itemOutputs("gtceu:end_steel_ingot")
+        .duration(125)
+        .EUt(GTValues.VHA[GTValues.HV])
 })


### PR DESCRIPTION
Endsteel breaks the pattern of early-game superconductors provided by the other wires.

![image](https://github.com/user-attachments/assets/153e2c27-93d1-4db1-85fd-3d79ffd9b14a)

Due to the heat being 3600K gtceu generates the recipe as a hot ingot, which requires EV to cool, as these are EV Superconductors, they should be craftable in HV to match earlier wires.

This PR adds Chemical Bath Recipies to cool Hot End Steel Ingots roughly based on cooling Hot Black Steel, but set to HV chem bath