### PR TITLE
Endsteel Balancing pt2

### DIFF
--- a/kubejs/startup_scripts/gregtech_material_registry/enderio.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/enderio.js
@@ -61,7 +61,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .ingot().fluid()
         .color(0xd6d980).iconSet("metallic")
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR)
-        .blastTemp(3600, "mid", 480, 900)
+        .blastTemp(2700, "mid", 480, 900)
         .toolStats(new ToolProperty(4.0, 3.5, 1024, 3, []))
         .cableProperties(2048, 1, 0, true)
         .components("dark_steel", "endstone", "vibrant_alloy")


### PR DESCRIPTION
Adjusts the temperature for End Steel, so that it does not require a Nichrome Coil

Nichrome Coil is only obtainable with a Vacuum Freezer

Avoiding a Vacuum Freezer is the aspect that will allow End Steel to be craftable in HV

See #1711 for rationale 