### PR TITLE
Tone down LBB buff

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -1026,12 +1026,12 @@ ServerEvents.recipes(event => {
     // Balance is based on adjusting to be an improvement over singeblock boilers
     // High Pressure Steam Boiler consumes 1 coal in 960s, produces 15mb/t, total production = 288,000 mb steam
     // By Defualt: Large Bronze Boiler consumes 1 coal in 1s, producing 800mb/t, total production = 16,000 mb steam
-    // This is a factor of 18x, we chose x20 for balancing to make Large Boilers 11.1% more efficient as a bonus for the extra cost.
+    // This is a factor of 18x, we chose x16 for balancing to make Large Boilers 11.1% less efficient as a tradeoff for the extra speed.
     event.findRecipes({ id: /^gtceu:large_boiler\/.*/, type: "gtceu:large_boiler" }).forEach(large_boiler_recipe => {
 
         let recipe_duration = large_boiler_recipe.json.getAsJsonPrimitive("duration").asInt
 
         large_boiler_recipe.json.remove("duration")
-        large_boiler_recipe.json.add("duration", recipe_duration * 20)
+        large_boiler_recipe.json.add("duration", recipe_duration * 16)
     })
 })


### PR DESCRIPTION
Midori's LBB buff PR buffed Large Boilers to be 11% _more_ efficient than High Pressure Steam Boilers (made of steel). this means that they would be a direct upgrade to all singleblock boilers.

This PR slightly tones down that buff so that Large boilers are 11% _less_ efficient instead, as a tradeoff for being several hundred times faster at producing steam.