### PR TITLE
Add P2P attunement tags to extended-pattern items

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/unification/tags.js
+++ b/kubejs/server_scripts/fixes_tweaks/unification/tags.js
@@ -88,6 +88,11 @@ ServerEvents.tags("item", event => {
     event.remove("forge:storage_blocks/beryllium", "nuclearcraft:beryllium_block");
     event.remove("forge:storage_blocks/graphite", "nuclearcraft:graphite_block");
 
+    // AE2 P2P Attunements
+    event.add("mae2:p2p_attunements/pattern_p2p_tunnel", "expatternprovider:pattern_modifier");
+    event.add("mae2:p2p_attunements/pattern_p2p_tunnel", "expatternprovider:ex_pattern_provider");
+    event.add("mae2:p2p_attunements/pattern_p2p_tunnel", "expatternprovider:ex_pattern_provider_part");
+
     unifyChisel(event);
 })
 


### PR DESCRIPTION
Small QOL fix to prevent needing to carry a blank pattern or regular pattern provider for P2P attunement.

Adds the `mae2:p2p_attunements/pattern_p2p_tunnel` tag to the Pattern Modifier, and Extended Pattern Provided (Block and Part).