### PR TITLE
Fix Extended AE Wall Recipe

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -1048,6 +1048,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.assembler("kubejs:epp/assembler_matrix_wall")
         .itemInputs("expatternprovider:assembler_matrix_frame", "gtceu:hv_electric_motor")
         .itemOutputs("expatternprovider:assembler_matrix_wall")
+        .circuit(1)
         .duration(100)
         .EUt(1920)
 
@@ -1056,6 +1057,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.assembler("kubejs:epp/assembler_matrix_glass")
         .itemInputs("expatternprovider:assembler_matrix_frame", "gtceu:hv_electric_motor", "ae2:quartz_glass")
         .itemOutputs("expatternprovider:assembler_matrix_glass")
+        .circuit(2)
         .duration(100)
         .EUt(1920)
 


### PR DESCRIPTION
Adds circuits to matrix wall and matrix glass recipes.

Currently the matrix wall is not craftable due to this conflict.