### PR TITLE
Update GTMUtils to 1.1.11

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1061,7 +1061,7 @@
       "required": true
     },
     {
-      "fileID": 6475237,
+      "fileID": 6478617,
       "projectID": 1235020,
       "required": true
     },


### PR DESCRIPTION
Fixes Jade problems with saying the structure is formed even when it's not (to the extent possible), and removes unnecessary tooltip about avoiding building the PTERB with the terminal.