### PR TITLE
Removing description5 from Aluminium quest

### DIFF
--- a/config/ftbquests/quests/chapters/the_factory.snbt
+++ b/config/ftbquests/quests/chapters/the_factory.snbt
@@ -1591,8 +1591,6 @@
 				"{moni.quest.3AB0402B19DD5BA8.description3}"
 				""
 				"{moni.quest.3AB0402B19DD5BA8.description4}"
-				""
-				"{moni.quest.3AB0402B19DD5BA8.description5}"
 			]
 			id: "3AB0402B19DD5BA8"
 			rewards: [{


### PR DESCRIPTION
Originally, in this commit description was shortened https://github.com/ThePansmith/Monifactory/commit/e74812318c1dba5c411f6b0e992882e64e461963 but never updated in quest config.

This is how it currently looks in-game
![Image](https://github.com/user-attachments/assets/1c4bdacd-839c-477b-abb5-51a531ca72ad)