### PR TITLE
Fixed  text for LV Circuits

### DIFF
--- a/kubejs/assets/bountiful/lang/en_us.json
+++ b/kubejs/assets/bountiful/lang/en_us.json
@@ -1,3 +1,4 @@
 {
-    "bountiful.decree.engineer.name": "Engineer"
+    "bountiful.decree.engineer.name": "Engineer",
+    "bountiful.entry.all_obj_lv_circuit": "LV Circuits"
 }


### PR DESCRIPTION
There is a missing text for LV Circuits on Bountiful board
![Image](https://github.com/user-attachments/assets/14e3137f-4ad3-408e-9093-8d1cd8145993)

I'm not 100% sure that way how it was done in this PR is correct, please fix if there is proper way.
I assume it supposed to originally take translation from `kubejs/assets/emi/lang/en_us.json`

This is how it looks after applying this patch
![image](https://github.com/user-attachments/assets/a4041229-9203-4d4e-a6a8-e9b5768d00b6)
