### PR TITLE
Massively Decrease Crafting Times for Endgame Casings

### DIFF
--- a/kubejs/server_scripts/gregtech/omnic_forge.js
+++ b/kubejs/server_scripts/gregtech/omnic_forge.js
@@ -21,13 +21,13 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.assembler("kubejs:omnic_matrix_machine_casing")
         .itemInputs("12x gtceu:omnium_plate", "2x gtceu:crystal_matrix_frame", "1x gtceu:zpm_field_generator", "2x #gtceu:circuits/uv")
         .itemOutputs("2x kubejs:omnic_matrix_machine_casing")
-        .duration(2000)
+        .duration(200)
         .EUt(65520)
 
     event.recipes.gtceu.omnic_forge("kubejs:omnic_matrix_machine_casing_forge")
         .itemInputs("6x gtceu:omnium_plate", "gtceu:crystal_matrix_frame", "gtceu:zpm_field_generator", "#gtceu:circuits/uv")
         .itemOutputs("2x kubejs:omnic_matrix_machine_casing")
-        .duration(1000)
+        .duration(100)
         .EUt(65520)
 
     event.recipes.gtceu.omnic_forge("kubejs:omnic_matrix_coil")
@@ -39,7 +39,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.omnic_forge("kubejs:netherite_casing")
         .itemInputs("8x gtceu:neutronium_plate", "8x gtceu:large_scale_assembler_casing", "2x gtceu:dense_activated_netherite_plate", "6x gtceu:tungsten_steel_rod")
         .itemOutputs("4x kubejs:dimensional_stabilization_netherite_casing")
-        .duration(2000)
+        .duration(100)
         .EUt(65520)
 
     event.recipes.gtceu.omnic_forge("kubejs:bioalloy_casing")


### PR DESCRIPTION
- Decreased craft time of Omnic Matrix Machine Casings from 100 seconds in Assembler to 10 seconds
- Decreased craft time of Omnic Matrix Machine Casings from 50 seconds in Omnic Forge to 5 seconds
- Decreased craft time of Dimensional Stabilization Netherite Casings from 100 seconds to 5 seconds

These were all unnecessarily long and thus have been decreased in craft time to still be slightly longer than other casings but are now much more reasonable.