### PR TITLE
make microverse projectors only need MV output buses

### DIFF
--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -57,7 +57,7 @@ GTCEuStartupEvents.registry("gtceu:recipe_type", event => {
     event.create("microverse")
         .category("multiblock")
         .setEUIO("in")
-        .setMaxIOSize(9, 12, 3, 0)
+        .setMaxIOSize(9, 9, 3, 0)
         .setSlotOverlay(false, false, GuiTextures.SOLIDIFIER_OVERLAY)
         .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, FillDirection.LEFT_TO_RIGHT)
         .setSound(GTSoundEntries.COOLING);


### PR DESCRIPTION
Since MM yields were reduced with 0.12, no mission ever needs more than 9 output slots. This means that the minimum size output bus is now MV, not HV