### PR TITLE
Update FTB Quests to 2001.4.13

### DIFF
--- a/config/ftbquests/quests/data.snbt
+++ b/config/ftbquests/quests/data.snbt
@@ -6,6 +6,7 @@
 	default_reward_team: false
 	detection_delay: 20
 	disable_gui: false
+	drop_book_on_death: false
 	drop_loot_crates: false
 	emergency_items: [
 		{ Count: 1, id: "telepastries:overworld_cake" }
@@ -22,6 +23,7 @@
 	}
 	pause_game: false
 	progression_mode: "flexible"
+	show_lock_icons: true
 	title: "&9Monifactory"
 	version: 13
 }

--- a/manifest.json
+++ b/manifest.json
@@ -571,7 +571,7 @@
       "required": true
     },
     {
-      "fileID": 6167056,
+      "fileID": 6431737,
       "projectID": 289412,
       "required": true
     },


### PR DESCRIPTION
Adds padlock icon to quests that can't be completed yet due to missing dependencies, and mutually exclusive quests.