### PR TITLE
Fluid drawer unnerf

### DIFF
--- a/config/functionalstorage/functionalstorage-common.toml
+++ b/config/functionalstorage/functionalstorage-common.toml
@@ -28,8 +28,7 @@
 	NETHERITE_MULTIPLIER = 12
 	#How much should the fluid storage be divided by for any given Storage Upgrade
 	#Range: > 1
-	FLUID_DIVISOR = 2
+	FLUID_DIVISOR = 1
 	#How much should the range be divided by for any given Storage Upgrade
 	#Range: > 1
 	RANGE_DIVISOR = 1
-


### PR DESCRIPTION
The original fluid drawer nerf was motivated by the fact that Functional Storage's fluid storage was overpowered compared to GregTech fluid storage, since Functional Storage drawers exponentially increase in capacity when multiple upgrades are present on one drawer.
However, after comparing these two options to nearly all available mods that offer both item and fluid storage, it was revealed that GregTech's fluid storage is abysmal by comparison, and should not have been used as a reference point.

Consider how each mod's item storage solution compares to its fluid storage in solution in capacity:
AE2 1k storage cells: 256B = 127 stacks (32 items per bucket)
AE2 Sky Stone Tank/Chest: 16B = 27 slots (108 items per bucket)
Functional Storage un-upgraded drawer: 32B = 2048 items **(64 items per bucket)**
GT Super Chests/Tanks: 1mB = 1 item **(1000 items per bucket)**
GT I/O busses & hatches: 8B=1 slot (16 items per bucket)
GT Advanced Buffer: 4*64B = 16 slots (4 items per bucket)
SophStorage Backpacks: 2B=1 slot (32 items per bucket)
Ender Tanks/Chests: 32B = 9 slots (18 items per bucket)

With this in mind, Functional Storage's item/bucket ratio of its storage media is quite near the average, and should not have been nerfed.

**This is to say nothing of the potency of the upgrades themselves, which should remain nerfed due to their exponential growth when multiple are applied to the same container.**