### PR TITLE
refactor coremod multis to match monilabs 0.2.x

### DIFF
--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -143,7 +143,6 @@ GTCEuStartupEvents.registry("gtceu:recipe_type", event => {
         .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, FillDirection.LEFT_TO_RIGHT)
         .setSound(GTSoundEntries.ELECTROLYZER)
 
-    const MoniRecipeTypes = Java.loadClass("net.neganote.monilabs.gtbridge.MoniRecipeTypes")
     MoniRecipeTypes.createPrismaCRecipeType("chromatic_processing")
     MoniRecipeTypes.createPrismaCRecipeType("chromatic_transcendence")
 })
@@ -899,12 +898,8 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
             "gtceu:block/multiblock/gcym/blast_alloy_smelter", false)
 
     // Coremod multis
-    const MoniRecipeTypes = Java.loadClass("net.neganote.monilabs.gtbridge.MoniRecipeTypes")
-    const MoniMachines = Java.loadClass("net.neganote.monilabs.common.machine.MoniMachines")
 
     // Prismatic Crucible
-    const PrismaticCrucibleMachine = Java.loadClass("net.neganote.monilabs.common.machine.multiblock.PrismaticCrucibleMachine")
-    const PrismaticCrucibleRenderer = Java.loadClass("net.neganote.monilabs.client.renderer.PrismaticCrucibleRenderer")
     event.create("prismatic_crucible", "multiblock")
         .machine((holder) => new PrismaticCrucibleMachine(holder))
         .rotationState(RotationState.ALL)
@@ -946,12 +941,11 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
         .renderer(() => new PrismaticCrucibleRenderer("kubejs:block/netherite/casing", "gtceu:block/multiblock/processing_array"))
 
     // Omnic Synthesizer
-    const OmnicSynthesizerMachine = Java.loadClass("net.neganote.monilabs.common.machine.multiblock.OmnicSynthesizerMachine")
     event.create("omnic_synthesizer", "multiblock")
         .machine((holder) => new OmnicSynthesizerMachine(holder))
         .recipeTypes(MoniRecipeTypes.OMNIC_SYNTHESIZER_RECIPES)
         .appearanceBlock(GCYMBlocks.CASING_ATOMIC)
-        .recipeModifiers([OmnicSynthesizerMachine.recipeModifier(), GTRecipeModifiers.OC_NON_PERFECT])
+        .recipeModifiers([MoniRecipeModifiers.omnicSynthRecipeModifier(), GTRecipeModifiers.OC_NON_PERFECT])
         .pattern(definition => FactoryBlockPattern.start()
             .aisle("#CCCCC#", "#CCCCC#", "#CGGGC#", "#CGGGC#", "#CGGGC#", "#CGGGC#", "#CGGGC#", "#CCCCC#", "#CCCCC#")
             .aisle("CCCCCCC", "CHMMMHC", "CH###HC", "CH###HC", "CH###HC", "CH###HC", "CH###HC", "CHMMMHC", "CCCCCCC")
@@ -981,7 +975,6 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
             "gtceu:block/multiblock/fusion_reactor")
 
     // Omnidimensional Power Singularity
-    const CreativeEnergyMultiMachine = Java.loadClass("net.neganote.monilabs.common.machine.multiblock.CreativeEnergyMultiMachine")
     event.create("omnidimensional_power_singularity", "multiblock")
         .machine((holder) => new CreativeEnergyMultiMachine(holder))
         .appearanceBlock(() => Block.getBlock("kubejs:dimensional_stabilization_netherite_casing"))
@@ -1019,7 +1012,6 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
             "gtceu:block/multiblock/processing_array")
 
     // Creative Data Multi
-    const CreativeDataMultiMachine = Java.loadClass("net.neganote.monilabs.common.machine.multiblock.CreativeDataMultiMachine")
     event.create("creative_data_multi", "multiblock")
         .machine((holder) => new CreativeDataMultiMachine(holder))
         .recipeTypes([MoniRecipeTypes.CREATIVE_DATA_RECIPES])


### PR DESCRIPTION
don't need to manually load monilabs classes anymore, coremod recipe modifiers are in their own class now