### PR TITLE
More interesting supercon recipes

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -190,17 +190,19 @@ ServerEvents.recipes(event => {
     // Sculk Superconductor Wire
     event.recipes.gtceu.vacuum_freezer("sculk_superconductor")
         .itemInputs("gtceu:cryococcus_ingot")
-        .itemOutputs("gtceu:sculk_superconductor_ingot")
+        .itemOutputs("gtceu:sculk_superconductor_double_wire")
         .inputFluids(Fluid.of("gtceu:nether_star", 144))
         .duration(100)
-        .EUt(6000)
+        .EUt(GTValues.VA[GTValues.IV])
 
-    event.recipes.gtceu.vacuum_freezer("hyperdegenerate_darconite")
+    event.recipes.gtceu.electric_blast_furnace("hyperdegenerate_darconite")
         .itemInputs("gtceu:darconite_ingot")
-        .itemOutputs("gtceu:hyperdegenerate_darconite_ingot")
+        .notConsumable("gtceu:wire_extruder_mold")
+        .itemOutputs("gtceu:hyperdegenerate_darconite_double_wire")
         .inputFluids(Fluid.of("gtceu:hyperdegenerate_matter", 40))
         .duration(100)
-        .EUt(60000)
+        .EUt(GTValues.VA[GTValues.ZPM])
+        .blastFurnaceTemp(10600)
 
     // Chemical Reactor
 

--- a/kubejs/startup_scripts/gregtech_material_registry/endgame.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/endgame.js
@@ -71,11 +71,10 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
 
     event.create("sculk_superconductor")
-        .ingot().fluid()
         .element(GTElements.get("sculk_superconductor"))
         .color(0xffffff)
         .iconSet("shiny")
-        .flags(GTMaterialFlags.NO_SMELTING, GTMaterialFlags.NO_SMASHING)
+        .flags(GTMaterialFlags.NO_SMELTING, GTMaterialFlags.NO_SMASHING, GTMaterialFlags.NO_WORKING, GTMaterialFlags.DISABLE_DECOMPOSITION)
         .cableProperties(GTValues.V[GTValues.UHV], 8, 0, true)
 
     event.create("netherite_scrap")
@@ -100,6 +99,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0xffffff)
         .iconSet("sculk_alloy")
         .flags(GTMaterialFlags.EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, GTMaterialFlags.EXCLUDE_BLOCK_CRAFTING_RECIPES, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_ROUND, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_SMALL_GEAR, GTMaterialFlags.GENERATE_SPRING, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.NO_SMELTING, GTMaterialFlags.NO_WORKING)
+        .ignoredTagPrefixes([TagPrefix.dustTiny, TagPrefix.dustSmall, TagPrefix.dust])
 
     event.create("infinity")
         .ingot()

--- a/kubejs/startup_scripts/gregtech_material_registry/material_rework.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_rework.js
@@ -55,9 +55,9 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0x6442fb).secondaryColor(0x26872b)
         .iconSet("metallic") // "hyperdegenerate"
         .blastTemp(11000, "highest", GTValues.VHA[GTValues.UV], 800)
-        .components("3x darmstadtium", "4x cobalt", "2x nitrogen")
+        .components("3x darmstadtium", "4x cobalt", "2x nitrogen", "1x hyperdegenerate_matter")
         .cableProperties(GTValues.V[GTValues.UIV], 1, 0, true)
-        .flags(GTMaterialFlags.DISABLE_ALLOY_BLAST)
+        .flags(GTMaterialFlags.DISABLE_ALLOY_BLAST, GTMaterialFlags.NO_SMASHING, GTMaterialFlags.NO_WORKING, GTMaterialFlags.DISABLE_DECOMPOSITION)
 
     // UIV GT Supercon
     event.create("eltic_neptunium_antimony_terbium_germanium_carbide")


### PR DESCRIPTION
Switches the recipe for Sculk Superconductor back to making the wire directly in the freezer and gives Hyperdegenerate Darconite have a similar recipe in the EBF.

This is in response to some feedback that Moni's custom superconductors feel same-y later in the game, so this would serve to change up the manufacturing process a bit.