### PR TITLE
Laserio Cards Tweaks

### DIFF
--- a/kubejs/server_scripts/mods/laserio.js
+++ b/kubejs/server_scripts/mods/laserio.js
@@ -112,89 +112,31 @@ ServerEvents.recipes(event => {
                 "BBB",
                 "AAA"
             ], {
-                A: "#moni:overclocker_metal_plate",
+                A: "gtceu:iron_plate",
                 B: `gtceu:${value[1]}_double_wire`
             }).id(`kubejs:${value[0]}_card`)
 
-    event.recipes.gtceu.assembler("kubejs:conductive_card")
-        .itemInputs("3x gtceu:conductive_alloy_single_wire", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_1")
-        .duration(80)
-        .EUt(16)
+            event.recipes.gtceu.assembler(`kubejs:${value[0]}_card`)
+                .itemInputs(`3x gtceu:${value[1]}_double_wire`, "6x gtceu:iron_plate")
+                .itemOutputs(`4x laserio:energy_overclocker_card_tier_${index + 1}`)
+                .duration(80)
+                .EUt(GTValues.VHA[Math.floor(index / 2) + 1])
+        } else {
+            event.shaped(`3x laserio:energy_overclocker_card_tier_${index + 1}`, [
+                "AAA",
+                "BCB",
+                "AAA"
+            ], {
+                A: "gtceu:iron_plate",
+                B: `gtceu:${value[1]}_double_wire`,
+                C: `laserio:energy_overclocker_card_tier_${index}`
+            }).id(`kubejs:${value[0]}_card`)
 
-    // Energetic Alloy
-    event.shaped("3x laserio:energy_overclocker_card_tier_2", [
-        "AAA",
-        "BCB",
-        "AAA"
-    ], {
-        A: "gtceu:iron_plate",
-        B: "gtceu:energetic_alloy_single_wire",
-        C: "laserio:energy_overclocker_card_tier_1"
-    }).id("kubejs:energetic_card")
-
-    event.recipes.gtceu.assembler("kubejs:energetic_card")
-        .itemInputs("2x gtceu:energetic_alloy_single_wire", "laserio:energy_overclocker_card_tier_1", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_2")
-        .duration(80)
-        .EUt(16)
-
-    // Vibrant Alloy
-    event.shaped("3x laserio:energy_overclocker_card_tier_3", [
-        "AAA",
-        "BCB",
-        "AAA"
-    ], {
-        A: "gtceu:iron_plate",
-        B: "gtceu:vibrant_alloy_single_wire",
-        C: "laserio:energy_overclocker_card_tier_2"
-    }).id("kubejs:vibrant_card")
-
-    event.recipes.gtceu.assembler("kubejs:vibrant_card")
-        .itemInputs("2x gtceu:vibrant_alloy_single_wire", "laserio:energy_overclocker_card_tier_2", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_3")
-        .duration(80)
-        .EUt(16)
-
-    // Endsteel
-    event.recipes.gtceu.assembler("kubejs:endsteel_card")
-        .itemInputs("2x gtceu:end_steel_single_wire", "laserio:energy_overclocker_card_tier_3", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_4")
-        .duration(80)
-        .EUt(16)
-
-    // Lumium
-    event.recipes.gtceu.assembler("kubejs:lumium_card")
-        .itemInputs("2x gtceu:lumium_single_wire", "laserio:energy_overclocker_card_tier_4", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_5")
-        .duration(80)
-        .EUt(16)
-
-    // Signalum
-    event.recipes.gtceu.assembler("kubejs:signalum_card")
-        .itemInputs("2x gtceu:signalum_single_wire", "laserio:energy_overclocker_card_tier_5", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_6")
-        .duration(80)
-        .EUt(16)
-
-    // Enderium
-    event.recipes.gtceu.assembler("kubejs:enderium_card")
-        .itemInputs("2x gtceu:enderium_single_wire", "laserio:energy_overclocker_card_tier_6", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_7")
-        .duration(80)
-        .EUt(16)
-
-    // Cryolobus
-    event.recipes.gtceu.assembler("kubejs:cryolobus_card")
-        .itemInputs("2x gtceu:cryolobus_single_wire", "laserio:energy_overclocker_card_tier_7", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_8")
-        .duration(80)
-        .EUt(16)
-
-    // Sculk Superconductor
-    event.recipes.gtceu.assembler("kubejs:sculk_superconductor_card")
-        .itemInputs("2x gtceu:sculk_superconductor_single_wire", "laserio:energy_overclocker_card_tier_8", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_9")
-        .duration(80)
-        .EUt(16)
+            event.recipes.gtceu.assembler(`kubejs:${value[0]}_card`)
+                .itemInputs(`2x gtceu:${value[1]}_double_wire`, `laserio:energy_overclocker_card_tier_${index}`, "6x gtceu:iron_plate")
+                .itemOutputs(`4x laserio:energy_overclocker_card_tier_${index + 1}`)
+                .duration(80)
+                .EUt(GTValues.VHA[Math.floor(index / 2) + 1])
+        }
+    })
 })

--- a/kubejs/server_scripts/mods/laserio.js
+++ b/kubejs/server_scripts/mods/laserio.js
@@ -18,7 +18,7 @@ ServerEvents.recipes(event => {
 
     const Cards = [
         ["item", "gtceu:pulsating_alloy_plate"],
-        ["fluid", "gtceu:iron_plate"],
+        ["fluid", "gtceu:lazurite_plate"],
         ["energy", "gtceu:gold_plate"],
         ["redstone", "gtceu:red_alloy_plate"]
     ]
@@ -93,16 +93,28 @@ ServerEvents.recipes(event => {
 
 
     // Energy Overclockers  //
+    let overclocker_mats = [
+        ["conductive", "conductive_alloy"],
+        ["energetic", "energetic_alloy"],
+        ["vibrant", "vibrant_alloy"],
+        ["endsteel", "end_steel"],
+        ["lumium", "lumium"],
+        ["signalum", "signalum"],
+        ["enderium", "enderium"],
+        ["cryolobus", "cryolobus"],
+        ["sculk_superconductor", "sculk_superconductor"]
+    ]
 
-    // Conductive Iron
-    event.shaped("3x laserio:energy_overclocker_card_tier_1", [
-        "AAA",
-        "BBB",
-        "AAA"
-    ], {
-        A: "gtceu:iron_plate",
-        B: "gtceu:conductive_alloy_single_wire"
-    }).id("kubejs:conductive_card")
+    overclocker_mats.forEach((value, index) => {
+        if(index == 0) {
+            event.shaped(`3x laserio:energy_overclocker_card_tier_${index + 1}`, [
+                "AAA",
+                "BBB",
+                "AAA"
+            ], {
+                A: "#moni:overclocker_metal_plate",
+                B: `gtceu:${value[1]}_double_wire`
+            }).id(`kubejs:${value[0]}_card`)
 
     event.recipes.gtceu.assembler("kubejs:conductive_card")
         .itemInputs("3x gtceu:conductive_alloy_single_wire", "6x gtceu:iron_plate")


### PR DESCRIPTION
Essentially the same as in #1894.
The primary change here is that the wires used in overclockers double in thickness.
Even after this change, it's important to note that the ingots for those wires are still less than 1/3 the total ingot cost for any tier of overclocker. The remaining 2/3 is Iron.
Again, it is also important to point out that LaserIO overclockers can cover arbitrarily large distances through node chaining for the same cost of a single conduit block.

This PR also swaps out the Iron plate in the Fluid Card recipe for Lazurite, because Lazurite is obtainable from the same Overworld vein necessary to make GT fluid filters and matches the blue on the item texture.