### PR TITLE
Fission boiling fix

### DIFF
--- a/kubejs/server_scripts/mods/NuclearCraft.js
+++ b/kubejs/server_scripts/mods/NuclearCraft.js
@@ -474,6 +474,25 @@ ServerEvents.recipes(event => {
         ]
     })
 
+    // Fix fission boiling recipe
+    event.custom(
+        {
+            "type": "nuclearcraft:fission_boiling",
+            "heatRequired": 1.0,
+            "inputFluids": [
+                {
+                    "amount": 4,
+                    "tag": "minecraft:water"
+                }
+            ],
+            "outputFluids": [
+                {
+                    "amount": 640,
+                    "fluid": "gtceu:steam"
+                }
+            ]
+        }
+    ).id("nuclearcraft:fission_boiling/water-steam")
 });
 
 ServerEvents.tags("item", event => {

--- a/kubejs/server_scripts/nukelists.js
+++ b/kubejs/server_scripts/nukelists.js
@@ -21,6 +21,7 @@ ServerEvents.recipes(event => {
 
     let ignoreTypes = [
         { type: "nuclearcraft:fission_reactor_controller" },
+        { type: "nuclearcraft:fission_boiling" },
         { type: "nuclearcraft:isotope_separator" },
         { type: "nuclearcraft:fuel_reprocessor" },
         { type: "minecraft:crafting" },


### PR DESCRIPTION
Currently, the boiling mode for fission has a water boiling recipe that outputs NCN steam, which is nukelisted. JEI and EMI helpfully hide the recipe, but inputting water as a coolant results in a crash.

This overwrites that problematic recipe with one that outputs GT steam and follows the GT water-to-steam conversion ratio.