### PR TITLE
Remove complex SMDs from circuit themes below Crystal

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/pterb_retier.js
+++ b/kubejs/server_scripts/fixes_tweaks/pterb_retier.js
@@ -3,7 +3,7 @@
  * - Replaces UV components with LuV components.
  */
 ServerEvents.recipes(event => {
-    event.remove({ id: "gtceu:assembly_line/pterb" })
+    event.remove({ id: "gtceu:pterb" })
     event.remove({ id: "gtceu:research_station/1_x_gtceu_active_transformer" })
 
     event.recipes.gtceu.assembly_line("pterb")

--- a/kubejs/server_scripts/gregtech/tiered_recipes.js
+++ b/kubejs/server_scripts/gregtech/tiered_recipes.js
@@ -82,7 +82,7 @@ function parseRecipe(recipe) {
             let c = i.content
             let [val] = c.value
             return {
-                id: "tag" in val ? "gtceu:" + val.tag.split(":")[1] : val.fluid,
+                id: "tag" in val ? "gtceu:" + val.tag.split(":", 2)[1] : val.fluid,
                 amount: c.amount
             }
         })
@@ -200,7 +200,8 @@ function generateAlternatives(event, javaRecipe) {
     if(!(typeof recipe === "object" && typeof recipe.duration === "number"))
         return
 
-    let machineName = recipeId.split(":")[1].split("/")[0]
+    let machineName = recipeId.split(":", 2)[1].split("/", 2)[0]
+    let recipeName = recipeId.split(machineName + "/")[1]
 
     // Soldering alloy tiers
     if(recipe.inputs?.fluid && recipe.inputs.fluid.some(i =>
@@ -225,7 +226,7 @@ function generateAlternatives(event, javaRecipe) {
             }, solderEfficiency, 2)
             r.register(
                 event,
-                recipeId + "/" + solderId.split(":",2)[1],
+                recipeName + "/" + solderId.split(":", 2)[1],
                 machineName,
             )
         }
@@ -235,7 +236,8 @@ function generateAlternatives(event, javaRecipe) {
     if(recipe.inputs?.item && recipe.inputs.item.some(i =>
         i.content.type === "gtceu:sized" &&
         "item" in i.content.ingredient &&
-        i.content.ingredient.item.startsWith("gtceu:advanced_smd_")
+        i.content.ingredient.item.startsWith("gtceu:advanced_smd_") &&
+        !recipeName.match(/^mainframe_iv|((nano|quantum)_(processor|assembly|computer|mainframe))/)   // Don't add Complex SMDs to nano- or quantum- processors
     )) {
         // Advanced SMD recipes take twice as fast to make than Simple SMDs
         // Here we follow this convention:
@@ -251,7 +253,7 @@ function generateAlternatives(event, javaRecipe) {
                 inp.amount /= 4
             }
         }, 4, 2, 16)
-        r.register(event, recipeId + "/complex_smd", machineName)
+        r.register(event, recipeName + "/complex_smd", machineName)
     }
 }
 

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -624,7 +624,7 @@ ServerEvents.recipes(event => {
 
 
     event.remove({ id: "gtceu:shaped/mega_blast_furnace" })
-    event.recipes.gtceu.assembly_line("kubejs:assembly_line/mega_blast_furnace")
+    event.recipes.gtceu.assembly_line("kubejs:mega_blast_furnace")
         .itemInputs("gtceu:electric_blast_furnace", "4x #gtceu:circuits/zpm", "4x gtceu:luv_field_generator", "4x gtceu:naquadah_alloy_spring", "4x gtceu:dense_naquadah_alloy_plate", "4x gtceu:uranium_rhodium_dinaquadide_quadruple_wire")
         .inputFluids("gtceu:soldering_alloy 9216")
         .itemOutputs("gtceu:mega_blast_furnace")
@@ -633,7 +633,7 @@ ServerEvents.recipes(event => {
         .stationResearch(b => b.researchStack("gtceu:electric_blast_furnace").CWUt(16, 64000).EUt(30720))
 
     event.remove({ id: "gtceu:shaped/mega_vacuum_freezer" })
-    event.recipes.gtceu.assembly_line("kubejs:assembly_line/mega_vacuum_freezer")
+    event.recipes.gtceu.assembly_line("kubejs:mega_vacuum_freezer")
         .itemInputs("gtceu:vacuum_freezer", "4x #gtceu:circuits/zpm", "4x gtceu:luv_field_generator", "4x gtceu:naquadah_normal_fluid_pipe", "4x gtceu:dense_naquadah_alloy_plate", "4x gtceu:uranium_rhodium_dinaquadide_quadruple_wire")
         .inputFluids("gtceu:soldering_alloy 9216")
         .itemOutputs("gtceu:mega_vacuum_freezer")
@@ -698,8 +698,8 @@ ServerEvents.recipes(event => {
     event.replaceOutput({ id: "gtceu:macerator/macerate_cleaning_maintenance_hatch" }, "gtceu:yttrium_barium_cuprate_dust", "2x gtceu:graphene_dust")
 
     // ZPM Field Gen
-    event.remove({ id: "gtceu:assembly_line/field_generator_zpm" })
-    event.recipes.gtceu.assembly_line("kubejs:assembly_line/zpm_field_generator")
+    event.remove({ id: "gtceu:field_generator_zpm" })
+    event.recipes.gtceu.assembly_line("kubejs:zpm_field_generator")
         .itemInputs("gtceu:naquadah_alloy_frame", "6x gtceu:naquadah_alloy_plate", "gtceu:quantum_star", "2x gtceu:zpm_emitter", "2x #gtceu:circuits/zpm", "64x gtceu:fine_uranium_rhodium_dinaquadide_wire", "64x gtceu:fine_uranium_rhodium_dinaquadide_wire", "4x gtceu:vanadium_gallium_single_cable")
         .inputFluids("gtceu:soldering_alloy 1152", "gtceu:cryococcus 1152")
         .itemOutputs("gtceu:zpm_field_generator")
@@ -864,7 +864,7 @@ ServerEvents.recipes(event => {
     event.shapeless("4x minecraft:clay_ball", ["minecraft:clay"]);
 
     // Parallel Implosion Compressor
-    event.recipes.gtceu.assembly_line("gtceu:assembly_line/implosion_collider")
+    event.recipes.gtceu.assembly_line("gtceu:implosion_collider")
         .itemInputs("4x enderio:reinforced_obsidian_block", "2x #gtceu:circuits/zpm", "gtceu:solid_machine_casing", "3x gtceu:niobium_nitride_double_cable", "2x gtceu:zpm_electric_piston")
         .inputFluids("gtceu:soldering_alloy 1152", "gtceu:osmium 1152")
         .itemOutputs("gtceu:implosion_collider")


### PR DESCRIPTION
Due to Complex SMDs unlocking in UEV but the SoC recipes for LuV circuits and below all being available in UV, these recipes are all useless bloat and should be removed.