### PR TITLE
Update Deprecation Pipeline to allow for deprecating blocks

### DIFF
--- a/kubejs/client_scripts/deprecation_pipeline.js
+++ b/kubejs/client_scripts/deprecation_pipeline.js
@@ -13,11 +13,17 @@ JEIEvents.hideItems(event => {
     Object.entries(global.deprecatedFluids).forEach(([oldFluidID, replacementFluidID]) => {
         event.hide(oldFluidID.concat("_bucket"))
     })
+    Object.entries(global.deprecatedBlocks).forEach(([oldBlockID, replacementBlockID]) => {
+        event.hide(oldBlockID)
+    })
 })
 
 ItemEvents.tooltip(event => {
     Object.entries(global.deprecatedItems).forEach(([oldItemID, replacementItemID]) => {
         event.add(oldItemID, Text.red(`Deprecated. Use in a crafting table to convert into ${Item.of(replacementItemID).getDisplayName().getString()}`).bold(true))
+    })
+    Object.entries(global.deprecatedBlocks).forEach(([oldBlockID, replacementBlockID]) => {
+        event.add(oldBlockID, Text.red(`Deprecated. Use in a crafting table to convert into ${Item.of(replacementBlockID).getDisplayName().getString()}`).bold(true))
     })
 })
 

--- a/kubejs/server_scripts/deprecation_pipeline.js
+++ b/kubejs/server_scripts/deprecation_pipeline.js
@@ -32,3 +32,15 @@ Object.entries(global.deprecatedFluids).forEach(([oldFluidID, replacementFluidID
             .EUt(GTValues.VA[GTValues.ULV])
     });
 });
+
+Object.entries(global.deprecatedBlocks).forEach(([oldBlockID, replacementBlockID]) => {
+    ServerEvents.recipes(event => {
+        event.shapeless(replacementBlockID, [oldBlockID]).id(`${oldBlockID}_legacy_updater`);
+
+        event.recipes.gtceu.atomic_reconstruction(`${oldBlockID}_legacy_updater`)
+            .itemInputs(oldBlockID)
+            .itemOutputs(replacementBlockID)
+            .duration(20)
+            .EUt(GTValues.VA[GTValues.ULV])
+    });
+});

--- a/kubejs/startup_scripts/deprecation_pipeline.js
+++ b/kubejs/startup_scripts/deprecation_pipeline.js
@@ -4,13 +4,13 @@
  * in such a way that they can be replaced without players' items or fluids getting voided.
  *
  * To use this:
- * 1. Remove references to the item or fluid in every way possible, including
+ * 1. Delete references to the item or fluid in every way possible, including
  *    tags, recipes, tooltip, definition, lang, or other extra functionality.
- * 2. Use either of the utility functions below to specify the old and new IDs.
- *    If the item or fluid is created through KJS, delete the regular definition.
+ * 2. Use any of the utility functions below to specify the old and new IDs.
+ *    If the item, fluid, or block is created through KJS, delete the regular definition.
  *    The functions below create a replacement that is automatically substituted for the old one
  *    if you provide the correct ID.
- * 3. When fully removing the deprecated item or fluid, delete the call to the utility function to fully remove the old item.
+ * 3. When finally removing the deprecated item or fluid, delete the call to the utility function to fully remove the old item.
  *
  * TODO: add functionality for blocks
  */
@@ -28,6 +28,13 @@ global.deprecatedItems = {};
  * Used for tooltip & recipe generation for the deprecation pipeline.
  */
 global.deprecatedFluids = {};
+
+/**
+ * @type {Dictionary<ResourceLocation, ResourceLocation>}
+ * Dictionary of deprecated blocks and their replacements.
+ * Used for tooltip & recipe generation for the deprecation pipeline.
+ */
+global.deprecatedBlocks = {};
 
 /**
  * For a given item ID:
@@ -51,7 +58,7 @@ function deprecateItem(oldItemID, replacementItemID, oldItemName) {
 
 /**
  * For a given fluid ID:
- *   Creates an fluid with that ID if none exists
+ *   Creates a fluid with that ID if none exists
  *   Creates a recipe to convert the old fluid to the new fluid
  *   Applies a tooltip to the old fluid indicating that it's deprecated
  *
@@ -67,4 +74,24 @@ function deprecateFluid(oldFluidID, replacementFluidID, oldFluidName) {
             event.create(oldFluidID).displayName(`${oldFluidName} §c[DEPRECATED]`);
     })
     global.deprecatedFluids[oldFluidID] = replacementFluidID
+}
+
+/**
+ * For a given block ID:
+ *   Creates a block with that ID if none exists
+ *   Creates a recipe to convert an item with the old block ID to an item with the new block ID
+ *   Applies a tooltip to an item with the old block ID indicating that it's deprecated
+ *
+ * This allows the player to load their world and the generated block will replace the deprecated block,
+ * which can then be converted to the new, replacement block assuming the new item and block IDs are the same.
+ * @param {ResourceLocation} oldBlockID
+ * @param {ResourceLocation} replacementBlockID
+ * @param {String} oldBlockName
+ */
+function deprecateBlock(oldBlockID, replacementBlockID, oldBlockName) {
+    StartupEvents.registry("block", event => {
+        if(!Fluid.exists(oldBlockID))
+            event.create(oldBlockID).displayName(`${oldBlockName} §c[DEPRECATED]`);
+    })
+    global.deprecatedBlocks[oldBlockID] = replacementBlockID
 }


### PR DESCRIPTION
Updates Deprecation pipeline to allow for deprecating blocks in addition to the current options of items and fluids.
As a reminder, the block must be removed *before* the deprecation for it is added.