### PR TITLE
Netherite smithing and endgame GT Pipe rebalance

### DIFF
--- a/kubejs/assets/ftbquests/lang/de_de.json
+++ b/kubejs/assets/ftbquests/lang/de_de.json
@@ -1624,7 +1624,7 @@
     "moni.quest.4A696D4BA5442928.title": "&9Drawers",
     "moni.quest.4A6F916494B787AE.title": "Element 001: Hydrogen",
     "moni.quest.4A8FB1EF600F0882.description1": "&6Americium Ingots&r are obtained by placing &9NuclearCraft&r Americium isotopes into an &3Extractor&r and solidifying the fluid. As with other GT materials, use the ingot or fluid to forge the other forms.",
-    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. These are also the best &aItem Pipe&r material, in terms of throughput.",
+    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. It is also a very good &aItem Pipe&r material.",
     "moni.quest.4A8FB1EF600F0882.title": "&2Americium Ingot",
     "moni.quest.4A96659253CCFACF.description1": "Well, you need patterns too I guess.",
     "moni.quest.4A96659253CCFACF.description2": "The details of autocrafting will be explained in a later quest.",

--- a/kubejs/assets/ftbquests/lang/en_us.json
+++ b/kubejs/assets/ftbquests/lang/en_us.json
@@ -1776,7 +1776,7 @@
   "moni.quest.4A696D4BA5442928.title": "&9Drawers",
   "moni.quest.4A6F916494B787AE.title": "Element 001: Hydrogen",
   "moni.quest.4A8FB1EF600F0882.description1": "&6Americium Ingots&r are obtained by placing &9NuclearCraft&r Americium isotopes into an &3Extractor&r and solidifying the fluid. As with other GT materials, use the ingot or fluid to forge the other forms.",
-  "moni.quest.4A8FB1EF600F0882.description2": "&2You\u0027re gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. These are also the best &aItem Pipe&r material, in terms of throughput.",
+  "moni.quest.4A8FB1EF600F0882.description2": "&2You\u0027re gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. It is also a very good &aItem Pipe&r material.",
   "moni.quest.4A8FB1EF600F0882.title": "&2Americium Ingot",
   "moni.quest.4A96659253CCFACF.description1": "Well, you need patterns too I guess.",
   "moni.quest.4A96659253CCFACF.description2": "The details of autocrafting will be explained in a later quest.",

--- a/kubejs/assets/ftbquests/lang/es_es.json
+++ b/kubejs/assets/ftbquests/lang/es_es.json
@@ -1622,7 +1622,7 @@
     "moni.quest.4A696D4BA5442928.title": "&9Cajones",
     "moni.quest.4A6F916494B787AE.title": "Elemento 001: Hidrógeno",
     "moni.quest.4A8FB1EF600F0882.description1": "&6Americium Ingots&r are obtained by placing &9NuclearCraft&r Americium isotopes into an &3Extractor&r and solidifying the fluid. As with other GT materials, use the ingot or fluid to forge the other forms.",
-    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. These are also the best &aItem Pipe&r material, in terms of throughput.",
+    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. It is also a very good &aItem Pipe&r material.",
     "moni.quest.4A8FB1EF600F0882.title": "&2Americium Ingot",
     "moni.quest.4A96659253CCFACF.description1": "Well, you need patterns too I guess.",
     "moni.quest.4A96659253CCFACF.description2": "The details of autocrafting will be explained in a later quest.",

--- a/kubejs/assets/ftbquests/lang/fr_fr.json
+++ b/kubejs/assets/ftbquests/lang/fr_fr.json
@@ -1624,7 +1624,7 @@
     "moni.quest.4A696D4BA5442928.title": "&9Drawers",
     "moni.quest.4A6F916494B787AE.title": "Element 001: Hydrogen",
     "moni.quest.4A8FB1EF600F0882.description1": "&6Americium Ingots&r are obtained by placing &9NuclearCraft&r Americium isotopes into an &3Extractor&r and solidifying the fluid. As with other GT materials, use the ingot or fluid to forge the other forms.",
-    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. These are also the best &aItem Pipe&r material, in terms of throughput.",
+    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. It is also a very good &aItem Pipe&r material.",
     "moni.quest.4A8FB1EF600F0882.title": "&2Americium Ingot",
     "moni.quest.4A96659253CCFACF.description1": "Well, you need patterns too I guess.",
     "moni.quest.4A96659253CCFACF.description2": "The details of autocrafting will be explained in a later quest.",

--- a/kubejs/assets/ftbquests/lang/ja_jp.json
+++ b/kubejs/assets/ftbquests/lang/ja_jp.json
@@ -1622,7 +1622,7 @@
     "moni.quest.4A696D4BA5442928.title": "&9Drawers",
     "moni.quest.4A6F916494B787AE.title": "元素番号001番:水素",
     "moni.quest.4A8FB1EF600F0882.description1": "&6Americium Ingots&r are obtained by placing &9NuclearCraft&r Americium isotopes into an &3Extractor&r and solidifying the fluid. As with other GT materials, use the ingot or fluid to forge the other forms.",
-    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. These are also the best &aItem Pipe&r material, in terms of throughput.",
+    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. It is also a very good &aItem Pipe&r material.",
     "moni.quest.4A8FB1EF600F0882.title": "&2Americium Ingot",
     "moni.quest.4A96659253CCFACF.description1": "Well, you need patterns too I guess.",
     "moni.quest.4A96659253CCFACF.description2": "The details of autocrafting will be explained in a later quest.",

--- a/kubejs/assets/ftbquests/lang/pt_br.json
+++ b/kubejs/assets/ftbquests/lang/pt_br.json
@@ -1622,7 +1622,7 @@
     "moni.quest.4A696D4BA5442928.title": "&9Gavetas",
     "moni.quest.4A6F916494B787AE.title": "Element 001: Hydrogen",
     "moni.quest.4A8FB1EF600F0882.description1": "&6Americium Ingots&r are obtained by placing &9NuclearCraft&r Americium isotopes into an &3Extractor&r and solidifying the fluid. As with other GT materials, use the ingot or fluid to forge the other forms.",
-    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. These are also the best &aItem Pipe&r material, in terms of throughput.",
+    "moni.quest.4A8FB1EF600F0882.description2": "&2You're gonna need quite a bit of Americium.&r You cannot convert this form of Americium back to NuclearCraft Americium isotopes. It is also a very good &aItem Pipe&r material.",
     "moni.quest.4A8FB1EF600F0882.title": "&2Americium Ingot",
     "moni.quest.4A96659253CCFACF.description1": "Well, you need patterns too I guess.",
     "moni.quest.4A96659253CCFACF.description2": "The details of autocrafting will be explained in a later quest.",

--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -457,7 +457,7 @@ ServerEvents.recipes(event => {
         .EUt(65520)
 
     event.recipes.gtceu.assembler("kubejs:netherite_casing")
-        .itemInputs("8x gtceu:neutronium_plate", "8x gtceu:large_scale_assembler_casing", "2x gtceu:dense_activated_netherite_plate", "6x gtceu:tungsten_steel_rod")
+        .itemInputs("8x gtceu:neutronium_plate", "8x gtceu:large_scale_assembler_casing", "2x gtceu:double_activated_netherite_plate", "6x gtceu:tungsten_steel_rod")
         .itemOutputs("4x monilabs:dimensional_stabilization_netherite_casing")
         .duration(100)
         .EUt(65520)

--- a/kubejs/server_scripts/gregtech/circuits.js
+++ b/kubejs/server_scripts/gregtech/circuits.js
@@ -257,7 +257,7 @@ ServerEvents.recipes(event => {
             "kubejs:optical_processing_unit",
             "kubejs:quantum_soc_chip",
             "8x gtceu:fine_ruthenium_trinium_americium_neutronate_wire",
-            "8x gtceu:activated_netherite_bolt"
+            "8x gtceu:necrosiderite_bolt"
         )
         .itemOutputs("4x kubejs:optical_processor")
         .cleanroom(CleanroomType.CLEANROOM)

--- a/kubejs/server_scripts/gregtech/netherite.js
+++ b/kubejs/server_scripts/gregtech/netherite.js
@@ -110,16 +110,10 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.HV])
 
     event.recipes.gtceu.forming_press("inert_nether_compound_ingot")
-        .itemInputs("gtceu:hot_ardite_ingot", "3x gtceu:nether_conduit_dust", "4x kubejs:primal_mana")
+        .itemInputs("gtceu:hot_ardite_ingot", "3x gtceu:nether_conduit_dust", "4x kubejs:primal_mana", "4x kubejs:activated_netherite_scrap", "4x minecraft:gold_ingot")
         .itemOutputs("kubejs:inert_nether_compound_ingot")
         .duration(300)
         .EUt(GTValues.VA[GTValues.UV])
-
-    event.recipes.gtceu.forming_press("netherite_ingot_final")
-        .itemInputs("kubejs:inert_nether_compound_ingot", "gtceu:crystal_matrix_frame", "4x kubejs:activated_netherite_scrap", "4x minecraft:gold_ingot")
-        .itemOutputs("gtceu:activated_netherite_ingot")
-        .duration(200)
-        .EUt(GTValues.VA[GTValues.UHV])
 })
 
 ServerEvents.tags("item", event => {
@@ -129,4 +123,39 @@ ServerEvents.tags("item", event => {
     event.removeAllTagsFrom(oresToRemove.filter((value) => {
         return ResourceLocation.of("minecraft:ancient_debris", ":").compareTo(value) != 0
     }))
+})
+
+ServerEvents.recipes(event => {
+    /**
+     * Helper method for programmatically generating Smithing recipes for Activated Netherite.
+     * @param {String} material Material to generate a list of IDs and material quantities for
+     * @returns an array of entries which consist of [Ingredient ID, count, material count]
+     */
+    let tagPrefixes = (material) => {return [
+        `gtceu:${material}_plate`,
+        `gtceu:double_${material}_plate`,
+        `gtceu:${material}_rotor`,
+        `gtceu:${material}_ingot`,
+        `gtceu:${material}_rod`,
+        `gtceu:${material}_block`,
+        `gtceu:${material}_frame`,
+        `gtceu:${material}_tiny_fluid_pipe`,
+        `gtceu:${material}_small_fluid_pipe`,
+        `gtceu:${material}_normal_fluid_pipe`,
+        `gtceu:${material}_large_fluid_pipe`,
+        `gtceu:${material}_huge_fluid_pipe`,
+        `gtceu:${material}_quadruple_fluid_pipe`,
+        `gtceu:${material}_nonuple_fluid_pipe`,
+    ]}
+
+    let crystal_matrix_forms = tagPrefixes("crystal_matrix")
+    let activated_netherite_forms = tagPrefixes("activated_netherite");
+    activated_netherite_forms.forEach((entry, index) => {
+        event.smithing(
+            entry,
+            "minecraft:netherite_upgrade_smithing_template",
+            crystal_matrix_forms[index],
+            "kubejs:inert_nether_compound_ingot"
+        )
+    })
 })

--- a/kubejs/server_scripts/microverse/basic_missions.js
+++ b/kubejs/server_scripts/microverse/basic_missions.js
@@ -384,6 +384,7 @@ ServerEvents.recipes(event => {
                 "24x minecraft:gilded_blackstone",
                 "4x minecraft:gold_block",
             )
+            .chancedOutput("1x minecraft:netherite_upgrade_smithing_template", 500, 0)
     })
 
     microverse_mission(event, 3, 1).forEach(builder => {

--- a/kubejs/server_scripts/microverse/components.js
+++ b/kubejs/server_scripts/microverse/components.js
@@ -151,7 +151,7 @@ ServerEvents.recipes(event => {
             "2x gtceu:uev_sensor",
             "2x gtceu:uev_emitter",
             "4x gtceu:dense_naquadah_alloy_plate",
-            "64x gtceu:fine_activated_netherite_wire",
+            "64x gtceu:fine_necrosiderite_wire",
             "32x gtceu:fine_ruthenium_trinium_americium_neutronate_wire")
         .inputFluids("gtceu:soldering_alloy 11520", "gtceu:crystal_matrix 5760", "gtceu:naquadria 2304")
         .itemOutputs("kubejs:extradimensional_navigator")

--- a/kubejs/startup_scripts/gregtech_material_registry/chemicals.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/chemicals.js
@@ -174,7 +174,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .polymer().liquid()
         .color(0x708787)
         .components("1x nitrogen", "6x carbon", "7x hydrogen", "2x oxygen")
-        .fluidPipeProperties(3000, 12000, true, true, true, false)
+        .fluidPipeProperties(1300, 1000, true, true, true, false)
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.STICKY)
         .formula("C6H7NO2");
 
@@ -332,8 +332,9 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .liquid().dust().polymer()
         .color(0x272a2e)
         .components("19x carbon", "12x hydrogen", "3x oxygen")
-        .formula("(C6H4O2)(C13H8O)")
+        .itemPipeProperties(64, 24)
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.STICKY)
+        .formula("(C6H4O2)(C13H8O)")
 
     event.create("radiant_blend")
         .liquid()

--- a/kubejs/startup_scripts/gregtech_material_registry/endgame.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/endgame.js
@@ -59,7 +59,8 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .secondaryColor(0x004590)
         .blastTemp(3823, "highest", GTValues.VA[GTValues.ZPM])
         .iconSet("shiny")
-        .flags(GTMaterialFlags.NO_WORKING, GTMaterialFlags.EXCLUDE_BLOCK_CRAFTING_RECIPES, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE);
+        .fluidPipeProperties(4773, 1200, true, false, true, true)
+        .flags(GTMaterialFlags.NO_WORKING, GTMaterialFlags.EXCLUDE_BLOCK_CRAFTING_RECIPES, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_ROTOR);
 
     event.create("omnium")
         .ingot()
@@ -95,8 +96,9 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .element(GTElements.get("activated_netherite"))
         .color(0x4C484C)
         .iconSet("dull")
-        .fluidPipeProperties(11000, 8500, true, false, true, true)
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.GENERATE_SPRING)
+        .fluidPipeProperties(12500, 800, true, false, false, true)
+        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.NO_UNIFICATION)
+        .ignoredTagPrefixes([TagPrefix.dust, TagPrefix.dustSmall, TagPrefix.dustTiny, TagPrefix.nugget, TagPrefix.ring, TagPrefix.bolt, TagPrefix.screw])
 
     event.create("experience_attuned")
         .dust().gas()

--- a/kubejs/startup_scripts/gregtech_material_registry/material_rework.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_rework.js
@@ -54,7 +54,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .iconSet("meta_null")
         .element(GTElements.get("meta_null"))
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_ROTOR)
-        .fluidPipeProperties(200000, 20000, true, true, true, true)
+        .fluidPipeProperties(15000, 1500, true, true, true, true)
 
     // UEV emitter foil + infinity base
     event.create("transcendental_matrix")

--- a/kubejs/startup_scripts/gregtech_material_registry/misc.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/misc.js
@@ -3,6 +3,8 @@
  ? Place non-nomifactory materials here
  */
 
+const PropertyKey = Java.loadClass("com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey");
+
 // AE2 Materials
 
 GTCEuStartupEvents.registry("gtceu:element", event => {
@@ -390,4 +392,10 @@ GTCEuStartupEvents.materialModification(event => {
 
     // We keep Ingots in the material definition so we can replace it in the Ore Processing Diagram with vanilla Netherite Scrap, then remove it here.
     TagPrefix.ingot.setIgnored(GTMaterials.get("netherite_scrap"), Ingredient.of("minecraft:netherite_scrap"))
+
+    GTMaterials.Neutronium.getProperty(PropertyKey.FLUID_PIPE).setThroughput(400)
+    GTMaterials.Neutronium.getProperty(PropertyKey.FLUID_PIPE).setMaxFluidTemperature(10000)
+    GTMaterials.Ultimet.getProperty(PropertyKey.ITEM_PIPE).setTransferRate(4)
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ITEM_PIPE).setTransferRate(12)
+    GTMaterials.Americium.getProperty(PropertyKey.ITEM_PIPE).setTransferRate(20)
 })


### PR DESCRIPTION
One of the complaints I've seen levied against Moni is that most of the materials feel somewhat same-y.
This was partially helped with Sculk Superconductor and Hyperdegenerate Darconite being made directly in cable form with a special process.

This applies a similar concept to Activated Netherite, whereby in this PR all components are made from their Crystal Matrix counterpart in the Smithing Table, in a parallel to how Diamond tools and armor work.

The Smithing Table recipes can be done in Molecular Assemblers as a feature of base AE2, so the process can be fully automated.

![activated_netherite_smithing](https://github.com/user-attachments/assets/78ca6dae-945b-456c-80e9-621750731e77)

This PR also rebalances the endgame GT item & fluid pipes, since the best in each category goes a bit off the charts (Neutronium and Americium respectively) in a way that's unfriendly for any further item & fluid pipes like Netherite or Null.