### PR TITLE
Slightly increase Moni superconductor amperages

### DIFF
--- a/kubejs/startup_scripts/gregtech_material_registry/enderio.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/enderio.js
@@ -34,7 +34,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.DECOMPOSITION_BY_CENTRIFUGING)
         .blastTemp(1350, "low", 120, 400)
         .components("energetic_alloy", "ender_pearl")
-        .cableProperties(512, 1, 0, true)
+        .cableProperties(512, 2, 0, true)
         .formula("Au2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2)(BeK4N5)");
 
     // Pulsating Iron
@@ -63,7 +63,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR)
         .blastTemp(2700, "mid", 480, 900)
         .toolStats(new ToolProperty(4.0, 3.5, 1024, 3, []))
-        .cableProperties(2048, 1, 0, true)
+        .cableProperties(2048, 2, 0, true)
         .components("dark_steel", "endstone", "vibrant_alloy")
         .formula("Fe(SiO2)(Au2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2)(BeK4N5))");
 

--- a/kubejs/startup_scripts/gregtech_material_registry/thermal.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/thermal.js
@@ -25,7 +25,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0xf6ff99).secondaryColor(0xff7400)
         .iconSet("magic")
         .blastTemp(4500, "mid", GTValues.VA[GTValues.EV], 1000)
-        .cableProperties(8192, 1, 0, true)
+        .cableProperties(8192, 3, 0, true)
         .fluidPipeProperties(4500, 256, true, true, true, false)
         .components("4x tin_alloy", "2x sterling_silver", "mana")
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE)
@@ -35,7 +35,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0xff6b0f).secondaryColor(0xc32e00)
         .iconSet("magic")
         .blastTemp(4000, "high", GTValues.VA[GTValues.IV], 1400)
-        .cableProperties(32768, 1, 0, true)
+        .cableProperties(32768, 3, 0, true)
         .components("4x annealed_copper", "2x red_steel", "2x red_alloy", "mana")
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR)
 
@@ -44,7 +44,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0x1f6b62).secondaryColor(0x16455f)
         .iconSet("magic")
         .blastTemp(6400, "highest", GTValues.VA[GTValues.LuV], 1600)
-        .cableProperties(131072, 1, 0, true)
+        .cableProperties(131072, 4, 0, true)
         .components("4x lead", "2x platinum", "blue_steel", "osmium", "tantalum", "mana")
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE)
 


### PR DESCRIPTION
In the midgame around IV, the Moni superconductors get somewhat more expensive to create while the GT superconductors continue to get cheaper. At the point that Lumium becomes available, it's already cheaper per-amp to just use the GT superconductor (Samarium Iron Arsenic Oxide or similar) leading to Moni's superconductors being labelled as a "noob trap". Thus, this PR changes superconductor's amperages to smoothly ramp up from 1 to Cryolobus' 4 instead of staying at 1 amp per cable thickness.