### PR TITLE
update monilabs to 0.9.0

### DIFF
--- a/config-overrides/expert/gtceu.yaml
+++ b/config-overrides/expert/gtceu.yaml
@@ -543,7 +543,7 @@ compat:
     oreIconSize: 32
 
     # The string prepending ore names in the ore vein tooltip
-    oreNamePrefix: - 
+    oreNamePrefix: -
 
     # The color to draw a box around the ore icon with.
     # Accepts either an ARGB hex color prefixed with # or the string 'material' to use the ore's material color
@@ -604,7 +604,7 @@ compat:
 dev:
   # Debug general events? (will print recipe conficts etc. to server's debug.log)
   # Default: false
-  debug: false
+  debug: true
 
   # Debug ore vein placement? (will print placed veins to server's debug.log)
   # Default: false (no placement printout in debug.log)

--- a/config-overrides/hardmode/gtceu.yaml
+++ b/config-overrides/hardmode/gtceu.yaml
@@ -543,7 +543,7 @@ compat:
     oreIconSize: 32
 
     # The string prepending ore names in the ore vein tooltip
-    oreNamePrefix: - 
+    oreNamePrefix: -
 
     # The color to draw a box around the ore icon with.
     # Accepts either an ARGB hex color prefixed with # or the string 'material' to use the ore's material color
@@ -608,7 +608,7 @@ dev:
 
   # Debug ore vein placement? (will print placed veins to server's debug.log)
   # Default: false (no placement printout in debug.log)
-  debugWorldgen: false
+  debugWorldgen: true
 
   # Generate ores in superflat worlds?
   # Default: false

--- a/config-overrides/normal/gtceu.yaml
+++ b/config-overrides/normal/gtceu.yaml
@@ -608,7 +608,7 @@ dev:
 
   # Debug ore vein placement? (will print placed veins to server's debug.log)
   # Default: false (no placement printout in debug.log)
-  debugWorldgen: false
+  debugWorldgen: true
 
   # Generate ores in superflat worlds?
   # Default: false

--- a/config/jade/plugins.json
+++ b/config/jade/plugins.json
@@ -7,6 +7,7 @@
   },
   "monilabs": {
     "color_info": true,
+    "sculk_vat_xp_info": true,
     "microverse_info": true
   },
   "minecraft": {

--- a/kubejs/server_scripts/gregtech/Prismatic_Crucible.js
+++ b/kubejs/server_scripts/gregtech/Prismatic_Crucible.js
@@ -721,7 +721,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.chromatic_transcendence("prismatic_core_b_v")
         .itemInputs("kubejs:indigo_prismatic_core")
         .outputFluids("gtceu:meta_null 1184")
-        .inputColor(PrismaticColor.NOT_INDIGO)
+        .inputColor(PrismaticColor.NOT_PINK)
         .outputStatesRelative(0)
         .duration(40)
         .EUt(GTValues.VHA[GTValues.UHV])

--- a/manifest.json
+++ b/manifest.json
@@ -1081,7 +1081,7 @@
       "required": true
     },
     {
-      "fileID": 6792842,
+      "fileID": 6825355,
       "projectID": 1266569,
       "required": true
     }


### PR DESCRIPTION
Updates monilabs.
Fixes a prismac recipe.
Enables recipe debugging for packdev.