### PR TITLE
Oxalic Acid recipe tweak

### DIFF
--- a/kubejs/server_scripts/gregtech/terbium.js
+++ b/kubejs/server_scripts/gregtech/terbium.js
@@ -48,23 +48,12 @@ ServerEvents.recipes(event => {
         .itemOutputs("gtceu:ammonium_oxalate_dust")
         .duration(120).EUt(7)
 
-    event.recipes.gtceu.extractor("sugar_cane_solution")
-        .itemInputs("2x minecraft:sugar_cane")
-        .outputFluids(Fluid.of("gtceu:sucrose_solution", 1000))
-        .duration(300).EUt(120)
-
-    event.recipes.gtceu.distillery("sucrose_distillation")
-        .inputFluids(Fluid.of("gtceu:sucrose_solution", 1000))
-        .itemOutputs("gtceu:sucrose_dust")
-        .outputFluids(Fluid.of("water", 1000))
-        .duration(160).EUt(30)
-
     event.recipes.gtceu.large_chemical_reactor("oxalic_acid_dihydrate")
-        .notConsumable("gtceu:vanadium_dust")
-        .itemInputs("gtceu:sucrose_dust")
-        .inputFluids(Fluid.of("gtceu:nitric_acid", 36000))
+        .notConsumable(doHarderProcessing ? "gtceu:vanadium_pentoxide_dust" : "gtceu:vanadium_dust")
+        .itemInputs("minecraft:sugar")
+        .inputFluids(Fluid.of("gtceu:nitric_acid", 12000), "minecraft:water")
         .itemOutputs("6x gtceu:oxalic_acid_dihydrate_dust")
-        .outputFluids("gtceu:nitrogen_dioxide 36000", "minecraft:water 11000")
+        .outputFluids("gtceu:nitric_oxide 12000")
         .duration(600).EUt(30)
 
     event.recipes.gtceu.electric_blast_furnace("oxalic_acid")

--- a/kubejs/server_scripts/gregtech/terbium.js
+++ b/kubejs/server_scripts/gregtech/terbium.js
@@ -64,6 +64,13 @@ ServerEvents.recipes(event => {
         .blastFurnaceTemp(1700)
         .EUt(120)
 
+    event.recipes.gtceu.electrolyzer("sugar_electrolysis")
+        .itemInputs("23x minecraft:sugar")
+        .itemOutputs("12x gtceu:carbon_dust")
+        .outputFluids(Fluid.of("minecraft:water", 11000))
+        .duration(3.2 * 20)
+        .EUt(GTValues.VA[GTValues.LV])
+
     event.recipes.gtceu.chemical_reactor("ammonium_nitrate")
         .inputFluids("gtceu:ammonia 1000", "gtceu:nitric_acid 1000")
         .circuit(5)

--- a/kubejs/startup_scripts/gregtech_material_registry/misc.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/misc.js
@@ -173,19 +173,6 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .formula("(NH4)2C2O4")
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
 
-    event.create("sucrose_solution")
-        .fluid()
-        .color(0x818582)
-        .components("12x carbon", "24x hydrogen", "12x oxygen")
-        .formula("(C12H22O11)H2O")
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
-
-    event.create("sucrose")
-        .dust()
-        .color(0xe0ddda)
-        .components("12x carbon", "22x hydrogen", "11x oxygen")
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
-
     event.create("oxalic_acid_dihydrate")
         .dust()
         .color(0xfafaf7)
@@ -389,6 +376,9 @@ GTCEuStartupEvents.materialModification(event => {
 
     GTMaterials.RhodiumPlatedPalladium.setComponents(GTMaterials.Palladium.multiply(3), GTMaterials.Rhodium.multiply(1), "2x lumium")
     GTMaterials.RhodiumPlatedPalladium.setFormula("Pd3Rh(SnFe)4(CuAg4)2", true)
+
+    GTMaterials.Sugar.setComponents(GTMaterials.Carbon.multiply(12), GTMaterials.Water.multiply(11))
+    GTMaterials.Sugar.setFormula("C12H22O11", true)
 
     // We keep Ingots in the material definition so we can replace it in the Ore Processing Diagram with vanilla Netherite Scrap, then remove it here.
     TagPrefix.ingot.setIgnored(GTMaterials.get("netherite_scrap"), Ingredient.of("minecraft:netherite_scrap"))


### PR DESCRIPTION
Changes Oxalic Acid Dihydrate to use Minecraft's Sugar directly and far less Nitric Acid.

To ensure that the stoichiometry remains consistent, Sugar's chemical formula was changed from that of Glucose to that of Sucrose since the only other recipe involving Sugar that needs consistent stoichiometry is the Electrolysis recipe (which has also been altered accordingly)