### PR TITLE
Fix bugged Air Collector recipe in Lost Cities

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -42,7 +42,7 @@ ServerEvents.recipes(event => {
 
     // Lost Cities Air (normal air)
     event.recipes.gtceu.gas_collector("lc_air")
-        .dimension("lostcities:lostcities")
+        .dimension("lostcities:lostcity")
         .outputFluids(Fluid.of("gtceu:air", 10000))
         .circuit(5)
         .EUt(16)

--- a/kubejs/startup_scripts/worldgen/dimension_marker.js
+++ b/kubejs/startup_scripts/worldgen/dimension_marker.js
@@ -10,7 +10,7 @@ GTCEuStartupEvents.registry("gtceu:dimension_marker", event => {
         .overrideName("Void Dimension")
 
     // Lost Cities
-    event.create("lostcities:lostcities")
+    event.create("lostcities:lostcity")
         .iconSupplier(() => Item.of("telepastries:lost_city_cake").getItem())
         .tier(0)
         .overrideName("Lost Cities")


### PR DESCRIPTION
Fix a bugged dimension restriction for the Air Collector recipe. Resolves #1931.