### PR TITLE
Add ChatCalculator mod

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1094,6 +1094,11 @@
       "fileID": 6562791,
       "projectID": 1205571,
       "required": true
+    },
+    {
+      "fileID": 5152464,
+      "projectID": 384920,
+      "required": true
     }
   ]
 }


### PR DESCRIPTION
Adds a calculator players can use by typing in the chat.
Resolves #1126.