### PR TITLE
Last minute changes to MM missions to make missions make sense

### DIFF
--- a/kubejs/server_scripts/gregtech/antimatter.js
+++ b/kubejs/server_scripts/gregtech/antimatter.js
@@ -27,7 +27,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.ZPM])
 
     event.recipes.gtceu.microverse("protomatter_universal")
-        .itemInputs("kubejs:microminer_t10", "kubejs:microversal_alchemy_kit", "5x kubejs:universe_creation_data")
+        .itemInputs("kubejs:microminer_t10", "kubejs:microversal_alchemy_kit", "4x kubejs:ultra_dense_hydrogen", "1x kubejs:ultra_dense_helium")
         .itemOutputs("kubejs:microminer_t10", "64x kubejs:protomatter")
         .addData("projector_tier", 3)
         .requiredMicroverse(3) // Shattered

--- a/kubejs/server_scripts/gregtech/antimatter.js
+++ b/kubejs/server_scripts/gregtech/antimatter.js
@@ -26,23 +26,12 @@ ServerEvents.recipes(event => {
         .duration(200)
         .EUt(GTValues.VA[GTValues.ZPM])
 
-    event.recipes.gtceu.microverse("protomatter_stellar")
-        .itemInputs("kubejs:microminer_t9", "kubejs:microversal_alchemy_kit")
-        .inputFluids("gtceu:hydrogen 16000")
-        .itemOutputs("kubejs:microminer_t9", "16x kubejs:protomatter")
-        .addData("projector_tier", 3)
-        .requiredMicroverse(1) // Normal
-        .damageRate(50)
-        .duration(400)
-        .EUt(GTValues.VA[GTValues.UV])
-
     event.recipes.gtceu.microverse("protomatter_universal")
-        .itemInputs("kubejs:microminer_t10", "kubejs:microversal_alchemy_kit")
-        .inputFluids("gtceu:hydrogen 32000")
+        .itemInputs("kubejs:microminer_t10", "kubejs:microversal_alchemy_kit", "5x kubejs:universe_creation_data")
         .itemOutputs("kubejs:microminer_t10", "64x kubejs:protomatter")
         .addData("projector_tier", 3)
-        .requiredMicroverse(4) // Corrupted
-        .damageRate(40)
+        .requiredMicroverse(3) // Shattered
+        .damageRate(25)
         .duration(400)
         .EUt(GTValues.VA[GTValues.UV])
 

--- a/kubejs/server_scripts/microverse/advanced_missions.js
+++ b/kubejs/server_scripts/microverse/advanced_missions.js
@@ -68,7 +68,7 @@ ServerEvents.recipes(event => {
             .itemInputs("4x kubejs:quantum_flux")
             .itemInputs("16x kubejs:petrotheum_dust")
             .itemInputs("kubejs:advanced_drilling_kit")
-            .itemInputs("gtceu:stainless_steel_drill_head")
+            .itemInputs("gtceu:vanadium_steel_drill_head")
             .itemOutputs(
                 "64x gtceu:raw_pyrochlore",
                 "64x gtceu:raw_pyrochlore",

--- a/kubejs/server_scripts/microverse/basic_missions.js
+++ b/kubejs/server_scripts/microverse/basic_missions.js
@@ -11,11 +11,10 @@
 ServerEvents.recipes(event => {
     event.recipes.gtceu.microverse("normal_microverse_projection")
         .itemInputs("kubejs:universe_creation_data", "64x kubejs:quantum_flux", "64x kubejs:quantum_flux")
-        .inputFluids("gtceu:hydrogen 8000")
         .updateMicroverse(1) // Normal
         .addData("projector_tier", 1)
         .EUt(GTValues.VHA[GTValues.HV])
-        .duration(2000) // 100s, like a T1 mission
+        .duration(1000) // 50s, half the duration of a T1 mission
 
     // T1MM missions
     microverse_mission(event, 1, 1).forEach(builder => {

--- a/kubejs/server_scripts/microverse/components.js
+++ b/kubejs/server_scripts/microverse/components.js
@@ -3,6 +3,19 @@
  * Each of these are a custom KubeJS item or block used in the creation of Micro Miners.
  */
 ServerEvents.recipes(event => {
+    // Universe Creation Data
+    event.recipes.gtceu.extractor("universe_creation_data_hydrogen")
+        .itemInputs("kubejs:ultra_dense_hydrogen")
+        .itemOutputs("kubejs:universe_creation_data")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.MV])
+
+    event.recipes.gtceu.extractor("universe_creation_data_helium")
+        .itemInputs("kubejs:ultra_dense_helium")
+        .itemOutputs("2x kubejs:universe_creation_data")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.EV])
+
     // Basic Guidance
     event.shaped("kubejs:basic_micro_miner_guidance_system", [
         "GPG",
@@ -137,7 +150,7 @@ ServerEvents.recipes(event => {
             "64x gtceu:fine_tritanium_wire")
         .inputFluids("gtceu:soldering_alloy 1152", "gtceu:naquadria 576")
         .itemOutputs("kubejs:universal_navigator")
-        .stationResearch(b => b.researchStack("kubejs:stellar_creation_data").CWUt(96, 384000).EUt(491520))
+        .stationResearch(b => b.researchStack("gtceu:gravi_star").CWUt(96, 384000).EUt(491520))
         .duration(6000)
         .EUt(491520)
 

--- a/kubejs/server_scripts/microverse/components.js
+++ b/kubejs/server_scripts/microverse/components.js
@@ -4,17 +4,12 @@
  */
 ServerEvents.recipes(event => {
     // Universe Creation Data
-    event.recipes.gtceu.extractor("universe_creation_data_hydrogen")
-        .itemInputs("kubejs:ultra_dense_hydrogen")
+    event.recipes.gtceu.scanner("universe_creation_data_hydrogen")
+        .itemInputs("gtceu:data_stick")
+        .inputFluids("gtceu:hydrogen 16000")
         .itemOutputs("kubejs:universe_creation_data")
         .duration(100)
-        .EUt(GTValues.VA[GTValues.MV])
-
-    event.recipes.gtceu.extractor("universe_creation_data_helium")
-        .itemInputs("kubejs:ultra_dense_helium")
-        .itemOutputs("2x kubejs:universe_creation_data")
-        .duration(100)
-        .EUt(GTValues.VA[GTValues.EV])
+        .EUt(GTValues.VA[GTValues.HV])
 
     // Basic Guidance
     event.shaped("kubejs:basic_micro_miner_guidance_system", [

--- a/kubejs/server_scripts/microverse/elite_missions.js
+++ b/kubejs/server_scripts/microverse/elite_missions.js
@@ -140,8 +140,8 @@ ServerEvents.recipes(event => {
     microverse_mission(event, 9, 3).forEach(builder => {
         builder
             .inputFluids("gtceu:oxygen_plasma 10000")
-            .itemInputs("kubejs:gravitational_amplifier", "16x kubejs:shattered_star_data", "64x gtceu:gravi_star")
-            .damageRate(1)
+            .itemInputs("kubejs:gravitational_amplifier", "64x gtceu:gravi_star")
+            .damageRate(4)
             .itemOutputs("16x kubejs:quasi_stable_neutron_star")
             .requiredMicroverse(3) // Shattered
     })
@@ -151,7 +151,7 @@ ServerEvents.recipes(event => {
         builder
             .inputFluids("gtceu:helium_plasma 16000")
             .itemInputs("kubejs:universal_collapse_device")
-            .damageRate(25)
+            .damageRate(40)
             .itemOutputs("kubejs:heart_of_a_universe")
             .requiredMicroverse(1) // Normal
             .updateMicroverse(3, true)

--- a/kubejs/server_scripts/microverse/hardmode_missions.js
+++ b/kubejs/server_scripts/microverse/hardmode_missions.js
@@ -8,7 +8,7 @@ ServerEvents.recipes(event => {
                 .itemInputs("8x minecraft:tnt")
                 .inputFluids("minecraft:lava 4000")
                 .requiredMicroverse(1) // Normal
-                .damageRate(100)
+                .damageRate(50)
                 .updateMicroverse(2) // Hostile
 
         })
@@ -28,7 +28,7 @@ ServerEvents.recipes(event => {
                 "32x minecraft:gunpowder",
                 "16x minecraft:string",
             )
-            .requiredMicroverse( (doHostileMicroverse ? 2 : 1)) // Hostile : Normal
+            .requiredMicroverse((doHostileMicroverse ? 2 : 1)) // Hostile : Normal
     })
 
     microverse_mission(event, "2half", 1, undefined, undefined, 100).forEach(builder => {
@@ -42,7 +42,7 @@ ServerEvents.recipes(event => {
                 "48x minecraft:slime_ball",
                 "24x kubejs:guardian_scale",
             )
-            .requiredMicroverse( (doHostileMicroverse ? 2 : 1)) // Hostile : Normal
+            .requiredMicroverse((doHostileMicroverse ? 2 : 1)) // Hostile : Normal
     })
 
     microverse_mission(event, "2half", 1, undefined, undefined, 100).forEach(builder => {
@@ -58,7 +58,7 @@ ServerEvents.recipes(event => {
                 "16x thermal:blitz_rod",
                 "16x thermal:basalz_rod",
             )
-            .requiredMicroverse( (doHostileMicroverse ? 2 : 1)) // Hostile : Normal
+            .requiredMicroverse((doHostileMicroverse ? 2 : 1)) // Hostile : Normal
     })
 
     microverse_mission(event, "2half", 1, undefined, undefined, 100).forEach(builder => {
@@ -73,7 +73,7 @@ ServerEvents.recipes(event => {
                 "48x kubejs:wither_bone", // drops of evil aren"t in the pack
                 "32x minecraft:magma_cream",
             )
-            .requiredMicroverse( (doHostileMicroverse ? 2 : 1)) // Hostile : Normal
+            .requiredMicroverse((doHostileMicroverse ? 2 : 1)) // Hostile : Normal
     })
 
     microverse_mission(event, "2half", 1, undefined, undefined, 100).forEach(builder => {
@@ -89,7 +89,7 @@ ServerEvents.recipes(event => {
                 "16x minecraft:ender_pearl",
                 "16x minecraft:shulker_shell", // shulker pearls aren"t in the pack
             )
-            .requiredMicroverse( (doHostileMicroverse ? 2 : 1)) // Hostile : Normal
+            .requiredMicroverse((doHostileMicroverse ? 2 : 1)) // Hostile : Normal
     })
 
     // T4.5
@@ -106,7 +106,7 @@ ServerEvents.recipes(event => {
                 "32x minecraft:dragon_breath",
                 "32x kubejs:ender_dragon_scale",
             )
-            .requiredMicroverse( (doHostileMicroverse ? 2 : 1)) // Hostile : Normal
+            .requiredMicroverse((doHostileMicroverse ? 2 : 1)) // Hostile : Normal
     })
 
     microverse_mission(event, "4half", 2, undefined, undefined, 100).forEach(builder => {
@@ -121,7 +121,7 @@ ServerEvents.recipes(event => {
                 "32x kubejs:ender_dragon_scale",
                 "64x minecraft:dragon_breath",
             )
-            .requiredMicroverse( (doHostileMicroverse ? 2 : 1)) // Hostile : Normal
+            .requiredMicroverse((doHostileMicroverse ? 2 : 1)) // Hostile : Normal
     })
 
     microverse_mission(event, "4half", 2, undefined, undefined, 100).forEach(builder => {
@@ -137,7 +137,7 @@ ServerEvents.recipes(event => {
                 "16x minecraft:nether_star",
                 "16x minecraft:nether_star",
             )
-            .requiredMicroverse( (doHostileMicroverse ? 2 : 1)) // Hostile : Normal
+            .requiredMicroverse((doHostileMicroverse ? 2 : 1)) // Hostile : Normal
     })
 
     microverse_mission(event, "4half", 2, undefined, undefined, 100).forEach(builder => {
@@ -187,7 +187,7 @@ ServerEvents.recipes(event => {
                 "6x gtceu:naquadah_block",
                 "4x kubejs:warden_horn",
             )
-            .damageRate(3)
+            .damageRate(10)
             .itemOutputs(
                 "64x gtceu:raw_dulysite",
                 "64x gtceu:raw_dulysite",
@@ -207,7 +207,7 @@ ServerEvents.recipes(event => {
                 "6x gtceu:uranium_block",
                 "4x kubejs:warden_horn",
             )
-            .damageRate(3)
+            .damageRate(10)
             .itemOutputs(
                 "64x gtceu:raw_plutonium",
                 "64x gtceu:raw_plutonium",
@@ -221,7 +221,7 @@ ServerEvents.recipes(event => {
             .itemInputs("kubejs:elite_drilling_kit")
             .itemInputs("gtceu:duranium_drill_head")
             .itemInputs("gtceu:osmium_dust")
-            .damageRate(3)
+            .damageRate(10)
             .itemOutputs(
                 "32x gtceu:raw_iridosmine",
             )
@@ -234,7 +234,7 @@ ServerEvents.recipes(event => {
             .itemInputs("kubejs:elite_drilling_kit")
             .itemInputs("gtceu:duranium_drill_head")
             .itemInputs("gtceu:iridium_dust")
-            .damageRate(3)
+            .damageRate(10)
             .itemOutputs(
                 "32x gtceu:raw_osmiridium",
             )

--- a/kubejs/server_scripts/microverse/hyperbolic_missions.js
+++ b/kubejs/server_scripts/microverse/hyperbolic_missions.js
@@ -12,7 +12,7 @@ ServerEvents.recipes(event => {
                 Item.of("kubejs:hadal_energy_core", "{Damage:8000000}").weakNBT(),
                 "kubejs:lair_of_the_warden_data"
             )
-            .damageRate(10)
+            .damageRate(20)
             .itemOutputs(
                 "48x kubejs:hadal_shard",
                 "64x kubejs:warden_heart",
@@ -28,9 +28,10 @@ ServerEvents.recipes(event => {
     microverse_mission(event, 10, 4).forEach(builder => {
         builder
             .itemInputs("kubejs:universal_collapse_device", "4x kubejs:active_prismatic_core")
-            .damageRate(10)
+            .damageRate(120)
             .itemOutputs("16x kubejs:heart_of_a_universe")
             .requiredMicroverse(4) // Corrupted
+            .updateMicroverse(0)
     })
 
     // T11MM missions
@@ -53,7 +54,6 @@ ServerEvents.recipes(event => {
         builder
             .itemInputs(
                 "kubejs:universal_collapse_device",
-                "kubejs:corrupted_universe_data",
                 "64x gtceu:gravi_star",
                 "64x gtceu:gravi_star"
             )
@@ -71,7 +71,7 @@ ServerEvents.recipes(event => {
     microverse_mission(event, 12, 4).forEach(builder => {
         builder
             .itemInputs("kubejs:field_stabilised_omnic_pulsar_compound", "64x gtceu:infinity_ingot", "64x gtceu:meta_null_ingot")
-            .damageRate(200)
+            .damageRate(150)
             .itemOutputs("64x gtceu:monium_ingot")
             .requiredMicroverse(4) // Corrupted
             .updateMicroverse(0)
@@ -80,7 +80,7 @@ ServerEvents.recipes(event => {
     microverse_mission(event, 12, 4, undefined, GTValues.VA[GTValues.UIV]).forEach(builder => {
         builder
             .itemInputs("8x kubejs:timeless_monic_heavy_plating")
-            .damageRate(150)
+            .damageRate(80)
             .itemOutputs("4x kubejs:causality_exempt_monic_heavy_plating")
             .requiredMicroverse(4) // Corrupted
             .updateMicroverse(0)

--- a/kubejs/startup_scripts/registry/item_registry.js
+++ b/kubejs/startup_scripts/registry/item_registry.js
@@ -137,11 +137,7 @@ StartupEvents.registry("item", event => {
     event.create("wither_realm_data").displayName("§dWither Realm Data")
     event.create("deep_dark_data").displayName("§dDeep Dark Data")
     event.create("lair_of_the_warden_data").displayName("§dLair Of The Warden Data")
-    event.create("stellar_creation_data").displayName("§bStellar Creation Data")
     event.create("universe_creation_data").displayName("§dUniverse Creation Data")
-    event.create("shattered_star_data").displayName("§dShattered Star Data")
-    event.create("shattered_universe_data").displayName("§dShattered Universe Data")
-    event.create("corrupted_universe_data").displayName("§dCorrupted Universe Data")
 
 
     // Endgame Items


### PR DESCRIPTION
A bunch of small tweaks to get rid of hard locks (e.g. uncraftable Datas used in some recipes) and tweak recipes' damage-pe-tick values to make more sense (For example, ripping the heart out of a universe should not be survivable for that universe without any input of Quantum flux)