### PR TITLE
Blacklist projection parallels

### DIFF
--- a/kubejs/server_scripts/microverse/basic_missions.js
+++ b/kubejs/server_scripts/microverse/basic_missions.js
@@ -15,6 +15,7 @@ ServerEvents.recipes(event => {
         .addData("projector_tier", 1)
         .EUt(GTValues.VHA[GTValues.HV])
         .duration(1000) // 50s, half the duration of a T1 mission
+        .blacklistMicroverseParallels()
 
     // T1MM missions
     microverse_mission(event, 1, 1).forEach(builder => {

--- a/kubejs/server_scripts/microverse/elite_missions.js
+++ b/kubejs/server_scripts/microverse/elite_missions.js
@@ -155,5 +155,6 @@ ServerEvents.recipes(event => {
             .itemOutputs("kubejs:heart_of_a_universe")
             .requiredMicroverse(1) // Normal
             .updateMicroverse(3, true)
+            .blacklistMicroverseParallels()
     })
 })

--- a/kubejs/server_scripts/microverse/hardmode_missions.js
+++ b/kubejs/server_scripts/microverse/hardmode_missions.js
@@ -10,7 +10,7 @@ ServerEvents.recipes(event => {
                 .requiredMicroverse(1) // Normal
                 .damageRate(50)
                 .updateMicroverse(2) // Hostile
-
+                .blacklistMicroverseParallels()
         })
     }
 

--- a/kubejs/server_scripts/microverse/hyperbolic_missions.js
+++ b/kubejs/server_scripts/microverse/hyperbolic_missions.js
@@ -32,6 +32,7 @@ ServerEvents.recipes(event => {
             .itemOutputs("16x kubejs:heart_of_a_universe")
             .requiredMicroverse(4) // Corrupted
             .updateMicroverse(0)
+            .blacklistMicroverseParallels()
     })
 
     // T11MM missions
@@ -75,6 +76,7 @@ ServerEvents.recipes(event => {
             .itemOutputs("64x gtceu:monium_ingot")
             .requiredMicroverse(4) // Corrupted
             .updateMicroverse(0)
+            .blacklistMicroverseParallels()
     })
 
     microverse_mission(event, 12, 4, undefined, GTValues.VA[GTValues.UIV]).forEach(builder => {
@@ -84,5 +86,6 @@ ServerEvents.recipes(event => {
             .itemOutputs("4x kubejs:causality_exempt_monic_heavy_plating")
             .requiredMicroverse(4) // Corrupted
             .updateMicroverse(0)
+            .blacklistMicroverseParallels()
     })
 })

--- a/manifest.json
+++ b/manifest.json
@@ -1086,7 +1086,7 @@
       "required": true
     },
     {
-      "fileID": 6875368,
+      "fileID": 6875982,
       "projectID": 1266569,
       "required": true
     },


### PR DESCRIPTION
do this for all missions that change microverse type
also update monilabs to 0.11.1 for emi to show when you can't parallel