### PR TITLE
Remove mods from being added to client build

### DIFF
--- a/tools/build/index.js
+++ b/tools/build/index.js
@@ -253,7 +253,6 @@ export const BuildClientTarget = new Juke.Target({
         for (const folders of includeList) {
             fs.cpSync(folders, `dist/client/${folders}`, { recursive: true })
         }
-        fs.cpSync("dist/modcache", "dist/client/mods", { recursive: true })
 
         await packMod("client");
     }


### PR DESCRIPTION
Reverts line 256 from #1996 to stop mods from being added to client builds of the pack.