### PR TITLE
Assline control casing recipe + MM proj retier + stab miner emi

### DIFF
--- a/kubejs/server_scripts/microverse/mission_utils.js
+++ b/kubejs/server_scripts/microverse/mission_utils.js
@@ -127,6 +127,7 @@ function microverse_mission(event, minerTier, projectorTier, duration, EUt, mine
             .itemInputs(`kubejs:stabilized_microminer_t${minerTier}`)
             .itemOutputs(`kubejs:stabilized_microminer_t${minerTier}`)
             .duration(Math.round(duration * 20))
+            .addData("duration", Math.round(duration * 20))
             .EUt(EUt)
     }
 

--- a/kubejs/server_scripts/microverse/projectors.js
+++ b/kubejs/server_scripts/microverse/projectors.js
@@ -29,20 +29,21 @@ ServerEvents.recipes(event => {
 
     // Single-recipe microverse projectors
     let projector = [
-        ["basic_microverse_projector", "#gtceu:circuits/hv"],
-        ["advanced_microverse_projector", "#gtceu:circuits/ev"],
-        ["elite_microverse_projector", "#gtceu:circuits/iv"]
+        ["basic_microverse_projector", "#gtceu:circuits/mv", "gtceu:mv_field_generator"],
+        ["advanced_microverse_projector", "#gtceu:circuits/ev", "gtceu:ev_field_generator"],
+        ["elite_microverse_projector", "#gtceu:circuits/luv", "gtceu:luv_field_generator"]
     ]
 
     projector.forEach(projector => {
         event.shaped(`monilabs:${projector[0]}`, [
-            "CMC",
-            "MAM",
-            "CMC"
+            "MCM",
+            "FAF",
+            "MCM"
         ], {
             C: projector[1],
             M: "monilabs:microverse_casing",
-            A: "gtceu:computer_monitor_cover"
+            A: "gtceu:computer_monitor_cover",
+            F: projector[2]
         }).id(`kubejs:${projector[0]}`)
     })
 

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -226,20 +226,6 @@ ServerEvents.recipes(event => {
         .duration(300)
         .EUt(7680)
 
-    // Ass control casing
-    event.shaped("4x gtceu:assembly_line_unit", [
-        "CHC",
-        "SFE",
-        "CMC"
-    ], {
-        C: "#gtceu:circuits/luv",
-        H: "gtceu:hpic_chip",
-        S: "gtceu:iv_sensor",
-        F: "gtceu:tungsten_steel_frame",
-        E: "gtceu:iv_emitter",
-        M: "gtceu:iv_electric_motor"
-    }).id("gtceu:shaped/casing_assembly_line")
-
     // Netherstar Crafting
     event.shaped("kubejs:nether_star_south", [
         "ADA",


### PR DESCRIPTION
Assembly control casing had a recipe added by moni that was ludicrously expensive for some reason
Microverse projectors now have field generators in their recipes of tiers mv/hv/luv to properly gate them to around when they are used rather than all being available in late HV
Fixed stab miner's integrity damage text in emi