### PR TITLE
docs: Update build tools README.md

### DIFF
--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -3,12 +3,20 @@
 Uses juke from <https://github.com/tgstation/tgstation>
 
 
-Juke is a Node.js library, [install Node and NPM](https://nodejs.org/en/download) first.
+Juke is a Node.js library, [install Node and NPM](https://nodejs.org/en/download) first. Requires Node 20 or later.
 
 Build steps:
 - Go to tools/build.
 - Run `npm install`.
 - Run `node .`; dot required.
+- Using Node 19 or below will result in an error like this, go update your Node version to Node 20 or later.
+```
+import { hash } from "crypto";
+         ^^^^
+SyntaxError: The requested module 'crypto' does not provide an export named 'hash'
+    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
+    at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)
+```
 
 The script will skip build steps whose inputs have not changed since the last run.
 


### PR DESCRIPTION
Node 19 and below can cause the build script fail on a moved internal crypto library function.