### PR TITLE
Pterb Retier Fix

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/pterb_retier.js
+++ b/kubejs/server_scripts/fixes_tweaks/pterb_retier.js
@@ -3,8 +3,8 @@
  * - Replaces UV components with LuV components.
  */
 ServerEvents.recipes(event => {
-    event.remove({ id: "gtceu:pterb" })
-    event.remove({ id: "gtceu:research_station/1_x_gtceu_active_transformer" })
+    event.remove({ id: "gtceu:assembly_line/pterb" })
+    event.remove({ id: "gtceu:research_station/1x_gtceu_active_transformer" })
 
     event.recipes.gtceu.assembly_line("pterb")
         .itemInputs("gtceu:active_transformer")


### PR DESCRIPTION
Pterb had its research recipe still, and because the gt recipe wasn't properly removed, the soldering alloy script was creating new recipes based off the more expensive recipe. 