### PR TITLE
Fix moving coremod materials

### DIFF
--- a/kubejs/server_scripts/gregtech/Crystal_Matrix.js
+++ b/kubejs/server_scripts/gregtech/Crystal_Matrix.js
@@ -94,18 +94,20 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.electric_blast_furnace("matrix_blasting")
         .itemInputs("kubejs:adhered_matrix_mesh")
-        .itemOutputs("gtceu:hot_crystal_matrix_ingot")
+        .itemOutputs("monilabs:hot_crystal_matrix_ingot")
         .duration(750)
         .EUt(GTValues.VA[GTValues.ZPM])
         .blastFurnaceTemp(3823)
+        .circuit(1)
 
     event.recipes.gtceu.electric_blast_furnace("matrix_blasting_gas")
         .itemInputs("kubejs:adhered_matrix_mesh")
-        .itemOutputs("gtceu:hot_crystal_matrix_ingot")
+        .itemOutputs("monilabs:hot_crystal_matrix_ingot")
         .inputFluids("gtceu:krypton 10")
         .duration(500)
         .EUt(GTValues.VA[GTValues.ZPM])
         .blastFurnaceTemp(3823)
+        .circuit(2)
 
     event.recipes.gtceu.macerator("matrix_macerating")
         .itemInputs("kubejs:adhered_matrix_mesh")

--- a/kubejs/server_scripts/gregtech/Post_UV_Components.js
+++ b/kubejs/server_scripts/gregtech/Post_UV_Components.js
@@ -194,7 +194,7 @@ ServerEvents.recipes(event => {
         )
 
     event.recipes.gtceu.assembly_line("uev_motor")
-        .itemInputs("gtceu:long_magnetic_terbium_rod", "8x gtceu:long_sculk_bioalloy_rod", "8x monilabs:sculk_bioalloy_ring", "16x monilabs:sculk_bioalloy_round", "64x gtceu:fine_necrosiderite_wire", "64x gtceu:fine_necrosiderite_wire", "48x gtceu:fine_necrosiderite_wire", "2x gtceu:darconite_single_cable")
+        .itemInputs("gtceu:long_magnetic_terbium_rod", "8x monilabs:long_sculk_bioalloy_rod", "8x monilabs:sculk_bioalloy_ring", "16x monilabs:sculk_bioalloy_round", "64x gtceu:fine_necrosiderite_wire", "64x gtceu:fine_necrosiderite_wire", "48x gtceu:fine_necrosiderite_wire", "2x gtceu:darconite_single_cable")
         .inputFluids("gtceu:advanced_soldering_alloy 5760", "gtceu:lubricant 3000", "gtceu:neutronium 576")
         .itemOutputs("gtceu:uev_electric_motor")
         .duration(600)
@@ -221,7 +221,7 @@ ServerEvents.recipes(event => {
         )
 
     event.recipes.gtceu.assembly_line("uev_piston")
-        .itemInputs("gtceu:uev_electric_motor", "4x monilabs:sculk_bioalloy_plate", "4x monilabs:sculk_bioalloy_ring", "16x monilabs:sculk_bioalloy_round", "4x monilabs:sculk_bioalloy_rod", "monilabs:sculk_bioalloy_gear", "2x gtceu:small_sculk_bioalloy_gear", "2x gtceu:darconite_single_cable")
+        .itemInputs("gtceu:uev_electric_motor", "4x monilabs:sculk_bioalloy_plate", "4x monilabs:sculk_bioalloy_ring", "16x monilabs:sculk_bioalloy_round", "4x monilabs:sculk_bioalloy_rod", "monilabs:sculk_bioalloy_gear", "2x monilabs:small_sculk_bioalloy_gear", "2x gtceu:darconite_single_cable")
         .inputFluids("gtceu:advanced_soldering_alloy 5760", "gtceu:lubricant 3000", "gtceu:neutronium 576")
         .itemOutputs("gtceu:uev_electric_piston")
         .duration(600)
@@ -248,7 +248,7 @@ ServerEvents.recipes(event => {
         )
 
     event.recipes.gtceu.assembly_line("uev_robot_arm")
-        .itemInputs("4x gtceu:long_sculk_bioalloy_rod", "monilabs:sculk_bioalloy_gear", "3x gtceu:small_sculk_bioalloy_gear", "3x gtceu:uev_electric_motor", "gtceu:uev_electric_piston", "#gtceu:circuits/uev", "2x #gtceu:circuits/uhv", "4x #gtceu:circuits/uv", "4x gtceu:darconite_single_cable")
+        .itemInputs("4x monilabs:long_sculk_bioalloy_rod", "monilabs:sculk_bioalloy_gear", "3x monilabs:small_sculk_bioalloy_gear", "3x gtceu:uev_electric_motor", "gtceu:uev_electric_piston", "#gtceu:circuits/uev", "2x #gtceu:circuits/uhv", "4x #gtceu:circuits/uv", "4x gtceu:darconite_single_cable")
         .inputFluids("gtceu:advanced_soldering_alloy 5760", "gtceu:lubricant 3000", "gtceu:neutronium 576")
         .itemOutputs("gtceu:uev_robot_arm")
         .duration(600)
@@ -302,7 +302,7 @@ ServerEvents.recipes(event => {
         )
 
     event.recipes.gtceu.assembly_line("uev_emitter")
-        .itemInputs("monilabs:sculk_bioalloy_frame", "gtceu:uev_electric_motor", "4x gtceu:long_sculk_bioalloy_rod", "kubejs:quasi_stable_neutron_star", "#gtceu:circuits/uev", "64x gtceu:transcendental_matrix_foil", "32x gtceu:transcendental_matrix_foil", "4x gtceu:darconite_single_cable")
+        .itemInputs("monilabs:sculk_bioalloy_frame", "gtceu:uev_electric_motor", "4x monilabs:long_sculk_bioalloy_rod", "kubejs:quasi_stable_neutron_star", "#gtceu:circuits/uev", "64x gtceu:transcendental_matrix_foil", "32x gtceu:transcendental_matrix_foil", "4x gtceu:darconite_single_cable")
         .inputFluids("gtceu:advanced_soldering_alloy 5760", "gtceu:neutronium 576")
         .itemOutputs("gtceu:uev_emitter")
         .duration(600)

--- a/kubejs/server_scripts/gregtech/antimatter.js
+++ b/kubejs/server_scripts/gregtech/antimatter.js
@@ -43,7 +43,7 @@ ServerEvents.recipes(event => {
 
     // Controller Recipes
     event.recipes.gtceu.assembly_line("antimatter_manipulator")
-        .itemInputs("monilabs:bioalloy_fusion_casing", "#gtceu:circuits/uhv", "2x gtceu:uhv_field_generator", "2x gtceu:double_sculk_bioalloy_plate", "2x gtceu:uhv_emitter", "2x gtceu:uhv_electric_pump", "6x gtceu:neutronium_large_fluid_pipe", "32x gtceu:fine_ruthenium_trinium_americium_neutronate_wire")
+        .itemInputs("monilabs:bioalloy_fusion_casing", "#gtceu:circuits/uhv", "2x gtceu:uhv_field_generator", "2x monilabs:double_sculk_bioalloy_plate", "2x gtceu:uhv_emitter", "2x gtceu:uhv_electric_pump", "6x gtceu:neutronium_large_fluid_pipe", "32x gtceu:fine_ruthenium_trinium_americium_neutronate_wire")
         .inputFluids("gtceu:advanced_soldering_alloy 2304", "gtceu:omnium 576", "gtceu:polyethyl_cyanoacrylate 1152")
         .itemOutputs("gtceu:antimatter_manipulator")
         .duration(200)
@@ -55,7 +55,7 @@ ServerEvents.recipes(event => {
         )
 
     event.recipes.gtceu.assembly_line("antimatter_collider")
-        .itemInputs("6x monilabs:bioalloy_fusion_casing", "8x #gtceu:circuits/uhv", "16x gtceu:double_sculk_bioalloy_plate", "24x gtceu:hsse_frame", "12x solarflux:sp_custom_hadal", "4x gtceu:uhv_field_generator", "6x gtceu:uhv_emitter", "10x gtceu:uhv_electric_pump", "10x gtceu:superconducting_coil", "10x gtceu:neutronium_huge_fluid_pipe", "64x gtceu:fine_ruthenium_trinium_americium_neutronate_wire", "64x gtceu:fine_ruthenium_trinium_americium_neutronate_wire")
+        .itemInputs("6x monilabs:bioalloy_fusion_casing", "8x #gtceu:circuits/uhv", "16x monilabs:double_sculk_bioalloy_plate", "24x gtceu:hsse_frame", "12x solarflux:sp_custom_hadal", "4x gtceu:uhv_field_generator", "6x gtceu:uhv_emitter", "10x gtceu:uhv_electric_pump", "10x gtceu:superconducting_coil", "10x gtceu:neutronium_huge_fluid_pipe", "64x gtceu:fine_ruthenium_trinium_americium_neutronate_wire", "64x gtceu:fine_ruthenium_trinium_americium_neutronate_wire")
         .inputFluids("gtceu:advanced_soldering_alloy 4608", "gtceu:omnium 1152", "gtceu:polyethyl_cyanoacrylate 2304")
         .itemOutputs("gtceu:antimatter_collider")
         .duration(600)

--- a/kubejs/server_scripts/microverse/miners.js
+++ b/kubejs/server_scripts/microverse/miners.js
@@ -156,7 +156,7 @@ ServerEvents.recipes(event => {
     ], {
         G: "kubejs:advanced_micro_miner_guidance_system",
         C: "monilabs:double_crystal_matrix_plate",
-        W: "monilabs:double_rhodium_plated_palladium_plate",
+        W: "gtceu:double_rhodium_plated_palladium_plate",
         L: "kubejs:supercharged_laser_array",
         I: "gtceu:double_duranium_plate",
         A: "gtceu:hv_super_chest",

--- a/kubejs/server_scripts/microverse/miners.js
+++ b/kubejs/server_scripts/microverse/miners.js
@@ -155,8 +155,8 @@ ServerEvents.recipes(event => {
         " E     E "
     ], {
         G: "kubejs:advanced_micro_miner_guidance_system",
-        C: "gtceu:double_crystal_matrix_plate",
-        W: "gtceu:double_rhodium_plated_palladium_plate",
+        C: "monilabs:double_crystal_matrix_plate",
+        W: "monilabs:double_rhodium_plated_palladium_plate",
         L: "kubejs:supercharged_laser_array",
         I: "gtceu:double_duranium_plate",
         A: "gtceu:hv_super_chest",
@@ -227,7 +227,7 @@ ServerEvents.recipes(event => {
         " W       W "
     ], {
         O: "kubejs:elementally_infused_omnic_matrix_heavy_plating",
-        M: "gtceu:double_crystal_matrix_plate",
+        M: "monilabs:double_crystal_matrix_plate",
         P: "solarflux:sp_custom_neutronium",
         W: "kubejs:hadal_warp_engine",
         A: "gtceu:uhv_robot_arm",

--- a/kubejs/server_scripts/microverse/repair.js
+++ b/kubejs/server_scripts/microverse/repair.js
@@ -54,7 +54,7 @@ ServerEvents.recipes(event => {
 
     repairing(8)
         .EUt(GTValues.VA[GTValues.ZPM])
-        .chancedInput("2x gtceu:double_crystal_matrix_plate", 3000, 0)
+        .chancedInput("2x monilabs:double_crystal_matrix_plate", 3000, 0)
         .chancedInput("2x gtceu:double_rhodium_plated_palladium_plate", 2500, 0)
         .chancedInput("2x gtceu:double_duranium_plate", 2000, 0)
         .chancedInput("2x kubejs:supercharged_laser_array", 2500, 0)


### PR DESCRIPTION
When bioalloy and cmatrix were moved to coremod, the double plates and long rods and small gears were left behind
Also fixed c-matrix mesh smelting having conflicting ebf recipes