### PR TITLE
Remove ZPM field gen recipe w/o cryococcus

### DIFF
--- a/kubejs/server_scripts/Remove_Recipes.js
+++ b/kubejs/server_scripts/Remove_Recipes.js
@@ -13,6 +13,8 @@ ServerEvents.recipes(event => {
     // GT
     event.remove({ id: "gtceu:mixer/rhodium_plated_palladium" })
     event.remove({ id: "gtceu:electrolyzer/decomposition_electrolyzing_gunpowder"})
+    event.remove({ id: "gtceu:assembly_line/field_generator_zpm"})
+    event.remove({ id: "gtceu:assembly_line/field_generator_zpm/advanced_soldering_alloy"})
 
     // Redstone arsenal
     event.remove({ id: "redstone_arsenal:materials/flux_dust" })


### PR DESCRIPTION
self explanatory

tell me if theres a better way to remove gtceu recipes