### PR TITLE
Fix actinium recipe

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -409,6 +409,7 @@ ServerEvents.recipes(event => {
         .itemInputs("kubejs:radium_salt")
         .itemOutputs("gtceu:rock_salt_dust")
         .outputFluids(Fluid.of("gtceu:radon", 1000))
+        .circuit(1)
         .duration(200)
         .EUt(2000)
 


### PR DESCRIPTION
radon salt recipe for actinium conflicts with regular radon salt electrolysis recipe. Now circuited.