### PR TITLE
Give Fusion Reactors an Efficiency Modifer.

### DIFF
--- a/kubejs/startup_scripts/fusion_reactor_modifier.js
+++ b/kubejs/startup_scripts/fusion_reactor_modifier.js
@@ -1,0 +1,11 @@
+/*
+Adds the Efficiency Modifier to Fusion Reactors.
+*/
+const $RecipeModifierList = Java.loadClass("com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifierList")
+const $EfficiencyModifier = Java.loadClass("com.gregtechceu.gtceu.api.recipe.modifier.EfficiencyModifier")
+
+StartupEvents.postInit(event => {
+    GTMultiMachines.FUSION_REACTOR.forEach((reactor) => {
+        if(reactor != null) reactor.setRecipeModifier(new $RecipeModifierList(reactor.getRecipeModifier(), $EfficiencyModifier.of(0.997)))
+    })
+})


### PR DESCRIPTION
This halves their speed when cold, but it slowly increases as more recipes are ran to a top speed of 2x that listed in EMI.
Pre-approved by Withers.