### PR TITLE
Make TES not consume infinity ingots like Joey Chestnut

### DIFF
--- a/kubejs/server_scripts/gregtech/creative_multis.js
+++ b/kubejs/server_scripts/gregtech/creative_multis.js
@@ -28,7 +28,7 @@ ServerEvents.recipes(event => {
 
     // Recipes used to run the creative multiblocks
     event.recipes.gtceu.creative_energy_multi("kubejs:superfuel_infinite_power")
-        .inputFluids("gtceu:naquadah_superfuel 500")
+        .inputFluids("gtceu:naquadah_superfuel 325")
         .duration(20)
 
     if (doQuantumCoolant) {

--- a/kubejs/server_scripts/processing_lines/naquadah_fuels.js
+++ b/kubejs/server_scripts/processing_lines/naquadah_fuels.js
@@ -114,7 +114,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.UV])
 
     event.recipes.gtceu.naquadah_refinery("naquadah_superfuel")
-        .itemInputs("1x gtceu:infinity_dust", "20x kubejs:naquadah_fuel_mixture_dust")
+        .itemInputs("3x gtceu:tiny_infinity_dust", "20x kubejs:naquadah_fuel_mixture_dust")
         .inputFluids("gtceu:hyperdegenerate_matter 200", "gtceu:naquadah_fuel 11000", "monilabs:eltz 192", "gtceu:quadium 400")
         .outputFluids("gtceu:naquadah_superfuel 20000")
         .duration(3000)


### PR DESCRIPTION
It does this by
A) Reducing the amount of infinity dust the recipe consumes by 1/3, 3 tiny dust
B) Decrease the amount of Naq. SuperFuel the TES consumes per second to 325 MB from 500 MB

This approx. consumes 1 infinity ingot every 5 minutes(if my math isn't bad lol), 5x more efficient than before