### PR TITLE
Buff the Germanium SMD Diode recipe.

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -831,7 +831,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.assembler("germanium_smd_diode")
         .itemInputs("1x gtceu:germanium_dust", "8x gtceu:fine_platinum_wire")
         .inputFluids("gtceu:polyethylene 288")
-        .itemOutputs("32x gtceu:smd_diode")
+        .itemOutputs("64x gtceu:smd_diode")
         .duration(200)
         .EUt(GTValues.VA[GTValues.HV])
 
@@ -839,7 +839,7 @@ ServerEvents.recipes(event => {
         .notConsumable("gtceu:cylinder_casting_mold")
         .inputFluids("gtceu:borosilicate_glass 18")
         .itemOutputs("2x gtceu:petri_dish")
-        .duration(4 * 20)
+        .duration(80)
         .EUt(GTValues.VA[GTValues.HV])
 
     // Alternate Recipe for Octane


### PR DESCRIPTION
### As title says, buffs the Germanium recipe for SMD Diodes.
*Germanium? What's next, Tin???*

All the *other* base SMDs have better recipes that actually give more output, so why not diodes?