### PR TITLE
saltpeter + trinaq + sculk in svat

### DIFF
--- a/kubejs/server_scripts/gregtech/sculk.js
+++ b/kubejs/server_scripts/gregtech/sculk.js
@@ -58,11 +58,3 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.ULV])
         .category("gtceu:macerator_recycling")
 })
-
-/*
-Add a custom tag to all the items whose blocks can be used to grow Sculk
-for use in the Svat recipe that grows sculk
-*/
-ServerEvents.tags("item", event => {
-    event.add("moni:sculk_growable", Block.getTaggedIds("minecraft:sculk_replaceable"))
-})

--- a/kubejs/server_scripts/gregtech/sculk_vat.js
+++ b/kubejs/server_scripts/gregtech/sculk_vat.js
@@ -71,7 +71,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.sculk_vat("sculk_growth")
         .notConsumable("minecraft:sculk_catalyst")
-        .itemInputs("1x #moni:sculk_growable")
+        .itemInputs("1x minecraft:stone")
         .outputFluids("gtceu:sculk 288")
         .xpRange(64000, 88000)
         .duration(20 * 3)

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -291,7 +291,7 @@ ServerEvents.recipes(event => {
         .EUt(2)
 
     event.remove({ id: "gtceu:macerator/macerate_sandstone" });
-    event.recipes.gtceu.macerator("saltpeter_dust")
+    event.recipes.gtceu.electrolyzer("saltpeter_dust")
         .itemInputs("4x #forge:sandstone")
         .itemOutputs("gtceu:saltpeter_dust")
         .duration(300)

--- a/kubejs/startup_scripts/gregtech_material_registry/other_mods.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/other_mods.js
@@ -270,7 +270,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .iconSet("bright")
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_DENSE)
         .components("6x trinium", "2x naquadah", "1x carbon")
-        .blastTemp(8747, "higher", 131072, 1200)
+        .blastTemp(8747, "higher", GTValues.VA[GTValues.ZPM], 1200)
 
     // Microversium is *technically* original to OmNoMoniTM, but it's a fairly direct riff on Modularium.
 


### PR DESCRIPTION
Saltpeter from sandstone recipe moved from macerator to electrolyzer to avoid conflict with sandstone -> sand recipe
Trinaquadalloy's abs recipe used an exact zpm amp instead of adjusted voltage
Tag system for liquid sculk in svat worked inconsistently so switched to just normal stone only