### PR TITLE
Bioalloy use omnium coils

### DIFF
--- a/kubejs/server_scripts/processing_lines/sculk_bioalloy.js
+++ b/kubejs/server_scripts/processing_lines/sculk_bioalloy.js
@@ -37,7 +37,7 @@ ServerEvents.recipes(event => {
         .outputFluids("monilabs:sculk_bioalloy 1440")
         .duration(100)
         .EUt(GTValues.VA[GTValues.ZPM])
-        .blastFurnaceTemp(2836)
+        .blastFurnaceTemp(12000)
         .cleanroom(CleanroomType.STERILE_CLEANROOM)
 
     event.recipes.gtceu.alloy_blast_smelter("sculk_bioalloy_gas")
@@ -46,6 +46,6 @@ ServerEvents.recipes(event => {
         .outputFluids("monilabs:sculk_bioalloy 1440")
         .duration(75)
         .EUt(GTValues.VA[GTValues.ZPM])
-        .blastFurnaceTemp(2836)
+        .blastFurnaceTemp(12000)
         .cleanroom(CleanroomType.STERILE_CLEANROOM)
 })


### PR DESCRIPTION
Increases required coils for bioalloy recipe to Omnic Matric Coils
bioalloy now properly gated to UHV instead of just mk3 fusion