### PR TITLE
Add faulty memory card recipe

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -1099,8 +1099,8 @@ ServerEvents.recipes(event => {
         .duration(200)
         .EUt(GTValues.VA[GTValues.MV])
 
-    // BetterP2P
-    event.shapeless("betterp2p:advanced_memory_card", ["ae2:memory_card", "ae2:network_tool"])
+    // Faulty Memory Card
+    event.shapeless("mae2:faulty_card", ["ae2:memory_card", "#ae2:knife"])
 
     // Network Analyser
     event.remove({ id:"ae2netanalyser:analyser"})


### PR DESCRIPTION
The faulty memory card from MAE2 currently doesn't have a recipe, so I added a new recipe taking a regular memory card and crafting with an ae2 knife. Please feel free to edit the recipe as needed.

Maybe we could mention the existance of it (and how to use decrement mode) in the QB for assembly line?

<img width="568" height="877" alt="image" src="https://github.com/user-attachments/assets/635b3940-d3c0-426d-823b-addda35aea16" />

---

Also, the advanced memory card from BetterP2P seems to have a duplicated recipe and the extra recipe isn't actually needed:

Current build:
<img width="590" height="900" alt="image" src="https://github.com/user-attachments/assets/91c41eae-97ba-4370-a479-d321bc0b62c9" />

Changed build:
<img width="616" height="919" alt="image" src="https://github.com/user-attachments/assets/9cdfe018-c1ea-4022-8188-8b61ab6685fa" />

