### PR TITLE
sterile/cleaning hatch texture change to match tier

### DIFF
--- a/kubejs/assets/gtceu/models/block/machine/cleaning_maintenance_hatch.json
+++ b/kubejs/assets/gtceu/models/block/machine/cleaning_maintenance_hatch.json
@@ -1,0 +1,22 @@
+{
+  "parent": "minecraft:block/block",
+  "loader": "gtceu:machine",
+  "machine": "gtceu:cleaning_maintenance_hatch",
+  "replaceable_textures": [
+    "bottom",
+    "top",
+    "side"
+  ],
+  "variants": {
+    "": {
+      "model": {
+        "parent": "gtceu:block/machine/part/cleaning_maintenance_hatch",
+        "textures": {
+          "bottom": "gtceu:block/casings/voltage/iv/bottom",
+          "side": "gtceu:block/casings/voltage/iv/side",
+          "top": "gtceu:block/casings/voltage/iv/top"
+        }
+      }
+    }
+  }
+}

--- a/kubejs/assets/gtmutils/models/block/machine/sterile_cleaning_maintenance_hatch.json
+++ b/kubejs/assets/gtmutils/models/block/machine/sterile_cleaning_maintenance_hatch.json
@@ -1,0 +1,22 @@
+{
+  "parent": "minecraft:block/block",
+  "loader": "gtceu:machine",
+  "machine": "gtmutils:sterile_cleaning_maintenance_hatch",
+  "replaceable_textures": [
+    "bottom",
+    "top",
+    "side"
+  ],
+  "variants": {
+    "": {
+      "model": {
+        "parent": "gtmutils:block/machine/part/sterile_cleaning_maintenance_hatch",
+        "textures": {
+          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
+          "side": "gtceu:block/casings/voltage/zpm/side",
+          "top": "gtceu:block/casings/voltage/zpm/top"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Changes the hull textures of sterile and cleaning maint hatches to match their appropriate tiers. Cleaning looks like IV and sterile looks like ZPM. 