### PR TITLE
Platine and Indium related ore tags. 

### DIFF
--- a/kubejs/server_scripts/platine_and_indium_ore_tags.js
+++ b/kubejs/server_scripts/platine_and_indium_ore_tags.js
@@ -4,5 +4,5 @@ Platline and Indium related ore tags for easier tag bus filtering.
 
 ServerEvents.tags("item", (event) => {
     event.add("gtceu:purified_platline_ores", ["gtceu:purified_chalcopyrite_ore", "gtceu:purified_cooperite_ore", "gtceu:purified_pentlandite_ore", "gtceu:purified_bornite_ore", "gtceu:purified_chalcocite_ore", "gtceu:purified_tetrahedrite_ore"]);
-    event.add("gtceu:purified_indium_ores", ["gtceu:purified_sphalerite_ore", "gtceu:purified_galena_ore"]);
+    event.add("gtceu:purified_indium_ores", ["gtceu:purified_sphalerite_ore", "gtceu:purified_galena_ore", "gtceu:purified_argentite_ore"]);
 });


### PR DESCRIPTION
This PR seeks to add tags called gtceu:purified_platline_ores and gtceu:purified_indium_ores to help make ore processing systems easier with tag export/storage busses.