### PR TITLE
feat: remove certus quartz from almostunified to fix charging automation

### DIFF
--- a/config/almostunified/unify.json
+++ b/config/almostunified/unify.json
@@ -81,7 +81,6 @@
     "zinc",
     "dark_steel",
     "neutronium",
-    "certus_quartz",
     "energetic_alloy",
     "vibrant_alloy",
     "pulsating_alloy",


### PR DESCRIPTION
# Changes
- Removes certus quartz from almost unified config

# Effects
- Fixes Charged Certus Quartz Automation
  - Right now, certus quartz in either the regular AE2 charger or advanced charger will get charged, but the charged certus quartz is unable to be automatically pulled out (with hoppers, conveyor belts, etc.)
- Fixes in-world Fluix creation recipe
  - Right now, regular certus quartz can be used instead of charged certus quartz when creating fluix crystals.
  - This fixes it to require charged certus quartz


I'm not sure why exactly this config is causing either of these behaviors, would love some enlightenment.
Would also love any feedback regarding unintended side effects.