### PR TITLE
Fix Dimensional Superassembler's casing texture

### DIFF
--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -660,7 +660,7 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
             .where(" ", Predicates.air())
             .where("#", Predicates.any())
             .build())
-        .workableCasingModel("kubejs:block/casing/netherite/casing",
+        .workableCasingModel("monilabs:block/casing/netherite",
             "gtceu:block/multiblock/assembly_line")
 
     // MABS


### PR DESCRIPTION
This fixes something that was missed when Netherite was ported over to Monilabs due to being part of TES.