### PR TITLE
Remove spark due to freezing linux systems

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -841,11 +841,6 @@
       "required": true
     },
     {
-      "fileID": 4738952,
-      "projectID": 361579,
-      "required": true
-    },
-    {
       "fileID": 6925239,
       "projectID": 1008510,
       "required": true


### PR DESCRIPTION
This is due to spark freezing systems on the latest Linux kernel release.