### PR TITLE
Superfuel tweaks

### DIFF
--- a/kubejs/server_scripts/gregtech/naquadah_reactor.js
+++ b/kubejs/server_scripts/gregtech/naquadah_reactor.js
@@ -66,8 +66,8 @@ ServerEvents.recipes(event => {
         .EUt(-GTValues.V[GTValues.UHV], 32)
 
     event.recipes.gtceu.large_naquadah_reactor("kubejs:process_superfuel")
-        .inputFluids("gtceu:naquadah_superfuel 50")
-        // .outputFluids("gtceu:naquadah_superfuel_depleted 50")
+        .inputFluids("gtceu:naquadah_superfuel 30")
+        // .outputFluids("gtceu:naquadah_superfuel_depleted 30")
         .duration(40)
-        .EUt(-GTValues.V[GTValues.UHV], 128)
+        .EUt(-GTValues.V[GTValues.UHV], 64)
 })

--- a/kubejs/server_scripts/processing_lines/naquadah_fuels.js
+++ b/kubejs/server_scripts/processing_lines/naquadah_fuels.js
@@ -116,7 +116,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.naquadah_refinery("naquadah_superfuel")
         .itemInputs("2x gtceu:tiny_infinity_dust", "20x kubejs:naquadah_fuel_mixture_dust")
-        .inputFluids("gtceu:hyperdegenerate_matter 200", "gtceu:naquadah_fuel 11000", "monilabs:eltz 192", "gtceu:quadium 400")
+        .inputFluids("gtceu:hyperdegenerate_matter 200", "gtceu:naquadah_fuel 11000", "monilabs:actinium 192", "gtceu:quadium 400")
         .outputFluids("gtceu:naquadah_superfuel 20000")
         .duration(3000)
         .EUt(GTValues.VA[GTValues.UHV])

--- a/kubejs/server_scripts/processing_lines/naquadah_fuels.js
+++ b/kubejs/server_scripts/processing_lines/naquadah_fuels.js
@@ -116,7 +116,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.naquadah_refinery("naquadah_superfuel")
         .itemInputs("2x gtceu:tiny_infinity_dust", "20x kubejs:naquadah_fuel_mixture_dust")
-        .inputFluids("gtceu:hyperdegenerate_matter 200", "gtceu:naquadah_fuel 11000", "monilabs:actinium 192", "gtceu:quadium 400")
+        .inputFluids("gtceu:hyperdegenerate_matter 200", "gtceu:naquadah_fuel 11000", "gtceu:actinium 192", "gtceu:quadium 400")
         .outputFluids("gtceu:naquadah_superfuel 20000")
         .duration(3000)
         .EUt(GTValues.VA[GTValues.UHV])


### PR DESCRIPTION
Change Eltz -> Actinium in superfuel recipe, and slight nerf to Superfuel's power generation.

This doubles the LNRs needed for beating the pack (According to Jollahs) from 2 to 4, but only decreases fuel energy density by 16.6%.