### PR TITLE
Dynamo fixes

### DIFF
--- a/kubejs/server_scripts/_hardmode/hardmode.js
+++ b/kubejs/server_scripts/_hardmode/hardmode.js
@@ -37,18 +37,6 @@ ServerEvents.recipes(event => {
     }
 
     if (doHarderRecipes) {
-        event.shaped("thermal:dynamo_numismatic", [
-            " A ",
-            "BCB",
-            "DED"
-        ], {
-            A: "kubejs:excitationcoil",
-            B: "gtceu:zeron_100_plate",
-            C: "ironfurnaces:diamond_furnace",
-            D: "enderio:vibrant_gear",
-            E: "kubejs:redstone_transmission_coil"
-        })
-
         event.remove({ id: "gtceu:large_chemical_reactor/radon_from_uranium_238" })
         event.remove({ id: "gtceu:electric_blast_furnace/blast_cryolobus_gas" })
         event.remove({ id: "gtceu:circuit_assembler/wetware_board" })

--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -2,13 +2,14 @@
  * Custom recipes for the Thermal Series
  */
 ServerEvents.recipes(event => {
-    event.remove({ output: ["systeams:steam_dynamo", "steamdynamo:steam_dynamo", "thermal:dynamo_compression", "thermal:dynamo_magmatic", "thermal:dynamo_numismatic", "thermal:dynamo_gourmand", "systeams:boiler_pipe", "thermal:rf_coil"] })
+    event.remove({ output: ["systeams:steam_dynamo", "steamdynamo:steam_dynamo", "systeams:boiler_pipe", "thermal:rf_coil"] })
     event.remove({ output: ["thermal:dynamo_throttle_augment", "thermal:upgrade_augment_1", "thermal:upgrade_augment_2", "thermal:upgrade_augment_3"] })
     event.remove({ output: ["thermal:machine_frame", "thermal:energy_cell_frame"] })
     event.remove({ output: ["thermal:machine_furnace", "thermal:machine_sawmill", "thermal:machine_pulverizer", "thermal:machine_smelter", "thermal:machine_centrifuge", "thermal:machine_crucible", "thermal:machine_chiller", "thermal:machine_refinery", "thermal:machine_pyrolyzer", "thermal:machine_bottler", "thermal:machine_brewer", "thermal:machine_crystallizer"] })
 
     event.remove({ id: /thermal:[A-Za-z]+_dust_/ }) // I don't even know what recipes this line of code is supposed to target
     event.remove({ id: /thermal:.*_cast/ })
+    event.remove({ id: /^thermal:dynamo_/}) // Remove non-downgrade recipes for Thermal dynamos
     event.remove({ id: "thermal:fire_charge/obsidian_glass_2" })
     event.remove({ id: "thermal:fire_charge/signalum_glass_2" })
     event.remove({ id: "thermal:fire_charge/lumium_glass_2" })
@@ -360,7 +361,6 @@ ServerEvents.recipes(event => {
             E: "systeams:boiler_pipe"
         })
 
-        event.shapeless("systeams:stirling_boiler", ["steamdynamo:steam_dynamo", "systeams:boiler_pipe"])
         event.shaped("systeams:boiler_pipe", [
             " C ",
             "ABA",
@@ -371,6 +371,35 @@ ServerEvents.recipes(event => {
             C: "gtceu:iron_gear",
             D: "#enderio:fused_quartz"
         })
+
+        // Steam Dynamo upgrade (Does not work with the systeams:upgrade_shapeless recipe type sadly,
+        // so we recreate the special recipe stuff using KJS here)
+        event.shapeless("systeams:stirling_boiler", ["steamdynamo:steam_dynamo", "systeams:boiler_pipe"])
+            .modifyResult((grid, result) => {
+                let input = grid.find("steamdynamo:steam_dynamo")
+                return result.withNBT(input.nbt)
+            })
+            .replaceIngredient("steamdynamo:steam_dynamo", "thermal:rf_coil")
+            .id("systeams:boiler/upgrades/stirling_upgrade")
+
+
+        // Steam Dynamo downgrade
+        event.custom(
+            {
+                "type": "systeams:upgrade_shapeless",
+                "ingredients": [
+                    {"item":"systeams:stirling_boiler"},
+                    {"item":"thermal:rf_coil"}
+                ],
+                "result": {
+                    "item": "steamdynamo:steam_dynamo"
+                },
+                "replacement": "systeams:boiler_pipe"
+            }
+        )
+
+        // Remove recipes for boilers that aren't the upgrade from dynamo recipe
+        event.remove({ id: /^systeams:boilers\/(?!upgrade)/ })
     }
 
     event.shaped("thermal:dynamo_magmatic", [

--- a/kubejs/startup_scripts/dynamo_conversion_fix.js
+++ b/kubejs/startup_scripts/dynamo_conversion_fix.js
@@ -1,0 +1,17 @@
+/**
+ * Fixes the Thermal Systeams' dynamo conversion mechanic to use Steam Dynamo instead of Stirling Dynamo
+ */
+
+const ConversionKitItem = Java.loadClass("chiefarug.mods.systeams.ConversionKitItem")
+const ThermalCore = Java.loadClass("cofh.thermal.core.ThermalCore")
+const ThermalIDs = Java.loadClass("cofh.thermal.lib.util.ThermalIDs")
+const SysteamsRegistry = Java.loadClass("chiefarug.mods.systeams.SysteamsRegistry")
+const SteamDynamoRegistry = Java.loadClass("dev.joshument.steamdynamo.Registry")
+
+StartupEvents.postInit(() => {
+    // Remove entry for base Thermal dynamo
+    ConversionKitItem.dynamoBoilerMap.remove(ThermalCore.BLOCKS["get(java.lang.String)"](ThermalIDs.ID_DYNAMO_STIRLING))
+
+    // Add entry for new Steam dynamo
+    ConversionKitItem.dynamoBoilerMap.put(SteamDynamoRegistry.Blocks.DYNAMO_STEAM.get(), SysteamsRegistry.Boilers.STIRLING.block())
+})

--- a/kubejs/startup_scripts/nukeLists/fluid.js
+++ b/kubejs/startup_scripts/nukeLists/fluid.js
@@ -1,4 +1,4 @@
-// priority: 900
+// priority: 800
 /*
 The fluidNukeList is used to list all IDs of fluids that should be removed from the game, or "nuked".
 While this makes it far more difficult to access the fluids and effectively obliterates them in most cases,

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -1,4 +1,4 @@
-// priority: 900
+// priority: 800
 /*
 The itemNukeList is used to list all IDs and regexes matching IDs of items that should be removed from the game, or "nuked".
 While this makes it far more difficult to access the items and effectively obliterates them in most cases,

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -211,12 +211,8 @@ global.itemNukeList = [
     // SophStorage offers a way to remove items from the registry with config.
 
     // Systeams
-    "systeams:compression_boiler",
     "systeams:disenchantment_boiler",
-    "systeams:gourmand_boiler",
     "systeams:lapidary_boiler",
-    "systeams:magmatic_boiler",
-    "systeams:numismatic_boiler",
     "systeams:steamiestest_ball",
 
     // Telepastries
@@ -436,5 +432,16 @@ if (Platform.isLoaded("create")) {
         "create:mechanical_press",
         "create:mechanical_roller",
         "create:encased_fan"
+    );
+}
+
+// If not doing boilers, nuke them.
+if (!global.doBoilers) {
+    global.itemNukeList.push(
+        "systeams:stirling_boiler",
+        "systeams:compression_boiler",
+        "systeams:gourmand_boiler",
+        "systeams:magmatic_boiler",
+        "systeams:numismatic_boiler",
     );
 }

--- a/kubejs/startup_scripts/nukeLists/unificationPatterns.js
+++ b/kubejs/startup_scripts/nukeLists/unificationPatterns.js
@@ -1,4 +1,4 @@
-// priority: 900
+// priority: 800
 /**
  * This file defines RegEx patterns that match with large quantities of certain items.
  *


### PR DESCRIPTION
Advocated to go back to using Stirling Dynamos instead of replacing them with Steam Dynamo earlier because it was causing some issues, but then decided to take my own advice and see what I could do without %t withersnuking it.

Turns out the issues are fixable with a little KJS.

Resolves #2056 
Resolves #1122 
Fixes an as-of-yet-unreported bug where Numismatic Dynamos had a duplicate recipe in HM
Fixes a priority conflict between some startup scripts that could potentially cause an issue in the future