### PR TITLE
monium recipe nerf + collapser time decrease

### DIFF
--- a/kubejs/server_scripts/microverse/components.js
+++ b/kubejs/server_scripts/microverse/components.js
@@ -343,7 +343,7 @@ ServerEvents.recipes(event => {
             "12x gtceu:styrene_butadiene_rubber_foil"
         )
         .inputFluids("gtceu:advanced_soldering_alloy 2304", "monilabs:crystal_matrix 576", "gtceu:microversium 1152")
-        .duration(4000)
+        .duration(1000)
         .EUt(GTValues.VA[GTValues.UHV])
         .stationResearch(builder => builder
             .researchStack("kubejs:gravitational_amplifier")

--- a/kubejs/server_scripts/microverse/hyperbolic_missions.js
+++ b/kubejs/server_scripts/microverse/hyperbolic_missions.js
@@ -69,11 +69,11 @@ ServerEvents.recipes(event => {
             .requiredMicroverse(3) // Shattered
     })
 
-    microverse_mission(event, 12, 4).forEach(builder => {
+    microverse_mission(event, 12, 4, 90).forEach(builder => {
         builder
-            .itemInputs("kubejs:field_stabilised_omnic_pulsar_compound", "64x gtceu:infinity_ingot", "64x gtceu:meta_null_ingot")
+            .itemInputs("kubejs:field_stabilised_omnic_pulsar_compound", "32x gtceu:infinity_ingot", "32x gtceu:meta_null_ingot")
             .damageRate(150)
-            .itemOutputs("64x gtceu:monium_ingot")
+            .itemOutputs("16x gtceu:monium_ingot")
             .requiredMicroverse(4) // Corrupted
             .updateMicroverse(0)
             .blacklistMicroverseParallels()


### PR DESCRIPTION
Per stack of monium compared to before: 
- 4x FSOPC
- 2x infinity & null
- 4x corrupted microverses
- same time
Done to make monium and therefore chest more expensive
Also reduces Universal Collapse Device recipe time by 4x due to feedback from Jollahs