### PR TITLE
Fix Hyperdegenerate Matter Recipe Emi Text

### DIFF
--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -229,6 +229,7 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
     }
 
     // Helical Fusion Reactor
+    FusionReactorMachine.registerFusionTier(GTValues.UHV, " (Helical)")
     event.create("helical_fusion_reactor", "multiblock")
         .machine((holder) => new FusionReactorMachine(holder, GTValues.UEV))
         .rotationState(RotationState.ALL)


### PR DESCRIPTION
Because there was no mk4 fusion registered, the HDM recipe would say `EU To Start: 640MEUnull`
This registers mk4 as "Helical" such that it now correctly labels the recipe as needing Helical
<img width="352" height="151" alt="image" src="https://github.com/user-attachments/assets/d552e92e-d58e-4cc0-a816-690659fb1d1f" />
