### PR TITLE
Nerf JEAN & transform up to shorten burntime

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -665,8 +665,8 @@ ServerEvents.recipes(event => {
     // JEAN Gasoline consumption
     event.recipes.gtceu.combustion_generator("jean_gasoline_generator")
         .inputFluids("gtceu:jean_gasoline 1")
-        .duration(2560)
-        .EUt(-32)
+        .duration(160)
+        .EUt(-GTValues.V[GTValues.MV])
 
     // JEAN Gasoline
     event.recipes.gtceu.large_chemical_reactor("kubejs:jean_gasoline")


### PR DESCRIPTION
Unfortunately prevents JEAN from working in LV generators, but will help prevent generators from operating at reduced parallels for long past the period of limited demand.