### PR TITLE
Fix Stab Miner Recipes Not Working

### DIFF
--- a/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
@@ -50,6 +50,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     GTMaterials.VanadiumGallium.addFlags(GTMaterialFlags.GENERATE_BOLT_SCREW)
     GTMaterials.Trinium.addFlags(GTMaterialFlags.GENERATE_SPRING)
     GTMaterials.Tritanium.addFlags(GTMaterialFlags.GENERATE_SPRING)
+    GTMaterials.Iridium.addFlags(GTMaterialFlags.GENERATE_DENSE)
 
     // Small Springs for Power Transformer recipes
     GTMaterials.RedAlloy.addFlags(GTMaterialFlags.GENERATE_SPRING_SMALL)


### PR DESCRIPTION
People were unable to craft stab miners because Dense Iridium Plates didn't exist, so this pr fixes that. 