### PR TITLE
Bioalloy Base Changes

### DIFF
--- a/kubejs/server_scripts/processing_lines/sculk_bioalloy.js
+++ b/kubejs/server_scripts/processing_lines/sculk_bioalloy.js
@@ -32,14 +32,6 @@ ServerEvents.recipes(event => {
         .duration(10)
         .cleanroom(CleanroomType.STERILE_CLEANROOM)
 
-    event.recipes.gtceu.mixer("bioalloy_base")
-        .itemInputs("4x gtceu:blue_alloy_dust", "2x gtceu:lead_dust", "1x gtceu:lutetium_dust")
-        .itemOutputs("7x gtceu:bioalloy_base_dust")
-        .duration(40 * 20)
-        .EUt(GTValues.VA[GTValues.LuV])
-        .circuit(3)
-        .cleanroom(CleanroomType.STERILE_CLEANROOM)
-
     event.recipes.gtceu.alloy_blast_smelter("bioalloy_base")
         .itemInputs("4x gtceu:blue_alloy_dust", "2x gtceu:lead_dust", "1x gtceu:lutetium_dust")
         .outputFluids("gtceu:bioalloy_base 1008")
@@ -47,6 +39,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.LuV])
         .blastFurnaceTemp(11900)
         .cleanroom(CleanroomType.STERILE_CLEANROOM)
+        .circuit(3)
 
     event.recipes.gtceu.alloy_blast_smelter("bioalloy_base_gas")
         .itemInputs("4x gtceu:blue_alloy_dust", "2x gtceu:lead_dust", "1x gtceu:lutetium_dust")
@@ -56,6 +49,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.LuV])
         .blastFurnaceTemp(11900)
         .cleanroom(CleanroomType.STERILE_CLEANROOM)
+        .circuit(13)
 
     event.recipes.gtceu.sculk_vat("sculk_bioalloy")
         .itemInputs("kubejs:amalgamated_sculk")

--- a/kubejs/startup_scripts/gregtech_material_registry/chemline_misc.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/chemline_misc.js
@@ -223,10 +223,9 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
 
     event.create("bioalloy_base")
-        .dust()
         .liquid(1936)
         .color(0x52a5c6).secondaryColor(0x48539b)
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_CENTRIFUGING)
+        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
         .components(GTMaterials.BlueAlloy.multiply(4), GTMaterials.Lead.multiply(2), GTMaterials.Lutetium.multiply(1))
 })
 


### PR DESCRIPTION
- Removed the dust form of Bioalloy Base because it existing only gave the alloy a mixer recipe, bypassing the Omnic Matrix Coil gate of Bioalloy
- Gave the ABS recipes of Bioalloy Base program circuits to properly distinguish between the two recipes
- Removed decomposition by centrifuging because that recipe consumed 1B of bioalloy base and gave back the materials to craft 1,008mB of bioalloy base, meaning that performing 125 recipes would magically grant you 126 recipes worth of materials back (lol)