### PR TITLE
Give Curium an ingot form

### DIFF
--- a/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
@@ -77,6 +77,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     GTMaterials.Curium.setMaterialARGB(0x58307f);
     GTMaterials.Curium.setMaterialSecondaryARGB(0x221255);
     GTMaterials.Curium.setProperty(PropertyKey.DUST, new $DustProperty());
+    GTMaterials.Curium.setProperty($PropertyKey.INGOT, new $IngotProperty());
     addFluid(GTMaterials.NetherStar, $FluidStorageKeys.LIQUID, 1337);
     addFluid(GTMaterials.Actinium, $FluidStorageKeys.LIQUID, 1324);
     GTMaterials.Americium.setMaterialSecondaryARGB(0x083946);


### PR DESCRIPTION
Without this, there's no way to convert liquid Curium to the dust form for mixing into the UHV cable.