### PR TITLE
Change solution to Sapphire Boule recipe conflict

### DIFF
--- a/kubejs/server_scripts/gregtech/opticals.js
+++ b/kubejs/server_scripts/gregtech/opticals.js
@@ -63,13 +63,12 @@ ServerEvents.recipes(event => {
         .itemInputs("2x gtceu:flawless_sapphire_gem", "1x kubejs:heart_of_a_universe")
         .itemOutputs("1x kubejs:sapphire_seed_crystal")
 
-    event.remove({ id: "gtceu:electric_blast_furnace/aluminium_from_sapphire_dust"})
     event.recipes.gtceu.electric_blast_furnace("sapphire_boule")
         .blastFurnaceTemp(10900)
         .duration(22000)
         .EUt(GTValues.VA[GTValues.LuV])
         .inputFluids("gtceu:krypton 8000")
-        .itemInputs("64x gtceu:sapphire_dust", "16x gtceu:omnium_nugget", "1x kubejs:sapphire_seed_crystal")
+        .itemInputs("12x gtceu:sapphire_block", "16x gtceu:omnium_nugget", "1x kubejs:sapphire_seed_crystal")
         .itemOutputs("1x kubejs:sapphire_boule")
 
     event.recipes.gtceu.cutter("cut_sapphire_boule_water")


### PR DESCRIPTION
Previous solution was to get rid of the base GT conflicting recipe (Sapphire Dust in EBF -> aluminium ingot)
This changes the Sapphire Boule recipe to use Sapphire Blocks (much like how other advanced boules use Silicon blocks) to accomplish the same goal without removing a recipe.