### PR TITLE
Make Beryllium Oxide available in all modes

### DIFF
--- a/kubejs/startup_scripts/gregtech_material_registry/chemline_eltz.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/chemline_eltz.js
@@ -65,10 +65,18 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0x231e1e)
         .components(GTMaterials.Iron.multiply(1), GTMaterials.Oxygen.multiply(1))
 
+    // Also used in Snowchestiteline (HM only)
     event.create("caesium_hydroxide")
         .dust()
         .color(0xbd8340).iconSet("dull")
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
         .components("caesium", "oxygen", "hydrogen")
         .ignoredTagPrefixes([TagPrefix.dustTiny, TagPrefix.dustSmall])
+
+    // Also used in the Magnetron
+    event.create("beryllium_oxide")
+        .ingot()
+        .color(0x54C757).iconSet("dull")
+        .flags(GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_RING)
+        .components("beryllium", "oxygen")
 })

--- a/kubejs/startup_scripts/gregtech_material_registry/chemline_harder_misc.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/chemline_harder_misc.js
@@ -14,18 +14,6 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     }
 })
 
-// Magnetron Components
-GTCEuStartupEvents.registry("gtceu:material", event => {
-
-    if (doHarderProcessing) {
-        event.create("beryllium_oxide")
-            .ingot()
-            .color(0x54C757).iconSet("dull")
-            .flags(GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_RING)
-            .components("beryllium", "oxygen")
-    }
-})
-
 // Harder Tantalite/Pyrochlore Processing
 GTCEuStartupEvents.registry("gtceu:material", event => {
 


### PR DESCRIPTION
Beryllium Oxide is a byproduct of processing Emeralds in Eltzline.
This adds the dust form to all modes. Beryllium Oxide rings, the Magnetron, and the synthesis recipe in a Chem reactor remain HM+.