### PR TITLE
Change HDD, Sculk Supercon recipes to match QB

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -237,7 +237,7 @@ ServerEvents.recipes(event => {
 
 
     event.recipes.gtceu.vacuum_freezer("sculk_superconductor")
-        .itemInputs("gtceu:cryococcus_rod")
+        .itemInputs("gtceu:cryococcus_single_wire")
         .itemOutputs("gtceu:sculk_superconductor_single_wire")
         .inputFluids(Fluid.of("gtceu:nether_star", 72))
         .duration(40)

--- a/kubejs/startup_scripts/gregtech_crafting_components.js
+++ b/kubejs/startup_scripts/gregtech_crafting_components.js
@@ -13,7 +13,7 @@ GTCEuStartupEvents.craftingComponents(event => {
     event.setMaterialEntries("wire_single", {
         LuV: "wireGtSingle:vanadium_gallium",
         ZPM: "wireGtSingle:naquadah_alloy",
-        UV: "wireGtSingle:europium",
+        UV: "wireGtSingle:cryococcus",
         UHV: "wireGtSingle:omnium",
         UEV: "wireGtSingle:necrosiderite",
     })

--- a/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
@@ -31,13 +31,14 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0x035155).secondaryColor(0x04203d).iconSet("dull")
         .blastTemp(6800, "higher")
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FRAME)
-        .cableProperties(524288, 4, 0, true);
+        .cableProperties(GTValues.V[GTValues.UV], 4, 0, true);
 
     event.create("cryococcus")
         .ingot().fluid()
         .element(GTElements.get("cryococcus"))
         .color(0x009295).secondaryColor(0x07303b).iconSet("dull")
         .flags(GTMaterialFlags.NO_SMELTING, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FRAME)
+        .cableProperties(GTValues.V[GTValues.UHV], 6, 16, true);
 
     event.create("sculk_superconductor")
         .element(GTElements.get("sculk_superconductor"))


### PR DESCRIPTION
Gets rid of all forms of HDD and Sculk Superconductor except wires (and fine wire + foil for HDD) and adds recipes so that the forms that *do* exist can be crafted in the EBF/Vac Freezer.