### PR TITLE
Fix tantalum pentoxide synthesis stoich

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -892,9 +892,9 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.HV])
 
     event.recipes.gtceu.chemical_reactor("tantalum_pentoxide")
-        .itemInputs("gtceu:tantalum_dust")
+        .itemInputs("2x gtceu:tantalum_dust")
         .inputFluids("gtceu:oxygen 5000")
-        .itemOutputs("gtceu:tantalum_pentoxide_dust")
+        .itemOutputs("7x gtceu:tantalum_pentoxide_dust")
         .duration(200)
         .EUt(GTValues.VA[GTValues.HV])
 })


### PR DESCRIPTION
Tantalum Pentoxide, unlike Rutile, follows alloy stoich.
It also has 2 Tantalum per 5 Oxygen.