### PR TITLE
Tone down Helical Fusion Reactor's recipe

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -103,15 +103,15 @@ ServerEvents.recipes(event => {
 
     // Helical Fusion Reactor
     event.recipes.gtceu.assembly_line("gtceu:helical_fusion_reactor")
-        .itemInputs("gtceu:uv_fusion_reactor", "4x #gtceu:circuits/uev", "16x gtceu:gravi_star", "2x gtceu:double_activated_netherite_plate", "4x gtceu:uhv_field_generator", "64x kubejs:multidimensional_cpu_chip", "64x kubejs:multidimensional_cpu_chip", "64x gtceu:ruthenium_trinium_americium_neutronate_double_wire")
-        .inputFluids("gtceu:advanced_soldering_alloy 11520", "gtceu:omnium 5760", "gtceu:polyethyl_cyanoacrylate 3456")
+        .itemInputs("gtceu:uv_fusion_reactor", "4x #gtceu:circuits/uev", "8x gtceu:gravi_star", "2x gtceu:double_activated_netherite_plate", "4x gtceu:uhv_field_generator", "64x kubejs:uxpic_chip", "64x kubejs:uxpic_chip", "64x gtceu:ruthenium_trinium_americium_neutronate_single_wire")
+        .inputFluids("gtceu:advanced_soldering_alloy 1152", "gtceu:darconite 1152", "gtceu:polyethyl_cyanoacrylate 576")
         .itemOutputs("gtceu:helical_fusion_reactor")
-        .duration(6000)
+        .duration(1500)
         .EUt(GTValues.VA[GTValues.UEV])
         .stationResearch(b => b
             .researchStack("gtceu:uv_fusion_reactor")
             .CWUt(160, 1024000)
-            .EUt(1200000)
+            .EUt(GTValues.VA[GTValues.UHV])
         )
 
 


### PR DESCRIPTION
Primarily makes the Helical fusion reactor controller's recipe cheaper to get so it's not such a violent jump up in expense.
Also makes it more consistent with previous reactor tiers (e.g. using power chips instead of compute)