### PR TITLE
Update UHV trophy to Manyullyn

### DIFF
--- a/config/ftbquests/quests/chapters/progression.snbt
+++ b/config/ftbquests/quests/chapters/progression.snbt
@@ -3178,7 +3178,7 @@
 					id: "trofers:large_pillar"
 					tag: {
 						BlockEntityTag: {
-							Trophy: "monifactory:neutronium"
+							Trophy: "monifactory:manyullyn"
 						}
 					}
 				}

--- a/kubejs/data/monifactory/trofers/manyullyn.json
+++ b/kubejs/data/monifactory/trofers/manyullyn.json
@@ -1,0 +1,31 @@
+{
+    "name": "UHV Age",
+    "tooltip": [
+        "Welcome to the UHV age!"
+    ],
+    "item": {
+        "item": "gtceu:manyullyn_ingot",
+        "count": 1
+    },
+    "display": {
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "scale": 1.5
+    },
+    "animation": {
+        "type": "spinning",
+        "speed": 0.6
+    },
+    "colors": {
+        "base": "#6B8F85",
+        "accent": "#c05cff"
+    }
+}


### PR DESCRIPTION
Does not remove old Neutronium trophy, so players who update their saves will keep the old trophy.