### PR TITLE
Change NM RMM processing to be faster

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/delay_rmm.js
+++ b/kubejs/server_scripts/fixes_tweaks/delay_rmm.js
@@ -27,7 +27,7 @@ ServerEvents.recipes(event => {
             .itemOutputs("5x gtceu:iridium_metal_residue_dust")
             .outputFluids("gtceu:acidic_osmium_solution 2000")
             .outputFluids("gtceu:hydrogen 3000")
-            .duration(400)
+            .duration(100)
             .EUt(GTValues.VHA[GTValues.LuV])
     }
 })


### PR DESCRIPTION
This changes the LuV Rarest Metal Mixture processing step to have the same speed as the default, IV Rarest Metal Mixture processing step when overclocked.