### PR TITLE
Fix cleaning maintenance hatch recycling recipe.

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -617,8 +617,8 @@ ServerEvents.recipes(event => {
         H: "gtceu:iv_machine_hull",
         C: "#gtceu:circuits/iv"
     })
-    .addMaterialInfo()
-    .id('moni:shaped/cleaning_maintenance_hatch');
+        .addMaterialInfo()
+        .id("moni:shaped/cleaning_maintenance_hatch");
 
     // ZPM Field Gen
     event.remove({ id: "gtceu:field_generator_zpm" })


### PR DESCRIPTION
Fixes the cleaning maintenance hatch recycle recipe still using the material info from the base gt recipe.
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/a5abef2e-29ad-453e-986b-940f4b741b48" />
