### PR TITLE
Allow the dim superass to take either exactly 1 data hatch or exactly one optical hatch.

### DIFF
--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -627,7 +627,7 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
             .where("L", Predicates.blocks(GCYMBlocks.CASING_LARGE_SCALE_ASSEMBLING.get()))
             .where("O", Predicates.blocks(GTBlocks.CASING_ASSEMBLY_LINE.get()))
             .where("F", Predicates.blocks("monilabs:bioalloy_fusion_casing"))
-            .where('R', dataHatchPredicate(blocks(CASING_GRATE.get())))
+            .where("R", dataHatchPredicate(blocks(CASING_GRATE.get())))
             .where("M", Predicates.blocks("monilabs:eltz_casing"))
             .where("I", Predicates.blocks("monilabs:transcendental_matrix_frame"))
             .where(" ", Predicates.air())


### PR DESCRIPTION
Does what it says on the tin I suppose. Switched out the current r predicate with the dataHatchPredicate.