### PR TITLE
update gtmutils to 2.3.3

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/omnibreaker_retier.js
+++ b/kubejs/server_scripts/fixes_tweaks/omnibreaker_retier.js
@@ -14,6 +14,7 @@ ServerEvents.recipes(event => {
             "4x gtceu:naquadah_screw"
         )
         .itemOutputs("gtmutils:omnibreaker")
+        .addMaterialInfo(true)
         .duration(60 * 20)
         .EUt(GTValues.VA[GTValues.IV], 2)
 })

--- a/kubejs/server_scripts/fixes_tweaks/pterb_retier.js
+++ b/kubejs/server_scripts/fixes_tweaks/pterb_retier.js
@@ -19,6 +19,7 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:soldering_alloy 4608")
         .EUt(GTValues.VA[GTValues.ZPM])
         .duration(1200)
+        .addMaterialInfo(true)
         .itemOutputs("gtmutils:pterb_machine")
         ["scannerResearch(java.util.function.UnaryOperator)"](b => b
             .researchStack("gtceu:active_transformer")

--- a/manifest.json
+++ b/manifest.json
@@ -1056,7 +1056,7 @@
       "required": true
     },
     {
-      "fileID": 7204528,
+      "fileID": 7212819,
       "projectID": 1235020,
       "required": true
     },


### PR DESCRIPTION
update some material info
fixed lang for quantum coolant usage on the PTERB to be clearer that it uses millibuckets
(maybe) fixed parallel hatch mixin not working on servers, not sure if it will be the case in production