### PR TITLE
Bucket -> Checkmark quest requirement

### DIFF
--- a/config/ftbquests/quests/chapters/feeding_the_machine.snbt
+++ b/config/ftbquests/quests/chapters/feeding_the_machine.snbt
@@ -243,11 +243,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "1DDC0F9C01889F1E"
-				item: "gtceu:bacterial_sludge_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "1DDC0F9C01889F1E"
+					item: "gtceu:bacterial_sludge_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "2B3866629D62E0F1"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.1AC91A3E05215569.title}"
 			x: 1.25d
 			y: 1.25d
@@ -267,11 +275,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "43383D2F3008596B"
-				item: "gtceu:mutagen_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "43383D2F3008596B"
+					item: "gtceu:mutagen_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "7926B6762D5A1A26"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.35D128D56DAFDFAA.title}"
 			x: 0.25d
 			y: 1.25d
@@ -295,11 +311,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "25516F711598DF6D"
-				item: "gtceu:sterilized_growth_medium_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "25516F711598DF6D"
+					item: "gtceu:sterilized_growth_medium_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "5B9EC715FC008008"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.2F6EC962007FA9FB.title}"
 			x: -0.75d
 			y: 1.25d
@@ -763,14 +787,24 @@
 		{
 			dependencies: ["0F6B344C265D1FBB"]
 			description: ["{moni.quest.0B51A633811472A2.description1}"]
+			icon: "gtceu:living_soldering_alloy_bucket"
 			id: "0B51A633811472A2"
 			shape: "hexagon"
 			subtitle: "{moni.quest.0B51A633811472A2.subtitle}"
-			tasks: [{
-				id: "11D735664F6DB251"
-				item: "gtceu:living_soldering_alloy_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "11D735664F6DB251"
+					item: "gtceu:living_soldering_alloy_dust"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "0CC9E1168FF66AB9"
+					item: "gtceu:living_soldering_alloy_bucket"
+					optional_task: true
+					type: "item"
+				}
+			]
 			title: "{moni.quest.0B51A633811472A2.title}"
 			x: -3.0d
 			y: 2.5d
@@ -850,6 +884,7 @@
 		{
 			dependencies: ["1CA3A00393EDD648"]
 			description: ["{moni.quest.7D4B29BA4D8CB153.description1}"]
+			icon: "gtceu:sculk_bucket"
 			id: "7D4B29BA4D8CB153"
 			rewards: [{
 				id: "58B2869B54067EE8"
@@ -858,11 +893,19 @@
 			}]
 			shape: "hexagon"
 			subtitle: "{moni.quest.7D4B29BA4D8CB153.subtitle}"
-			tasks: [{
-				id: "7795E782E2941DB5"
-				item: "gtceu:sculk_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "7795E782E2941DB5"
+					item: "gtceu:sculk_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "6B249466F14B15B4"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.7D4B29BA4D8CB153.title}"
 			x: 3.75d
 			y: 2.5d
@@ -1117,6 +1160,7 @@
 				""
 				"{moni.quest.12E06D4D898F3E58.description3}"
 			]
+			icon: "gtceu:bacteria_bucket"
 			id: "12E06D4D898F3E58"
 			rewards: [{
 				id: "002122E2C7652B0D"
@@ -1124,11 +1168,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "3717795A52860482"
-				item: "gtceu:bacteria_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "3717795A52860482"
+					item: "gtceu:bacteria_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "25A2B1EE926E3F90"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.12E06D4D898F3E58.title}"
 			x: 2.25d
 			y: 1.25d
@@ -1236,13 +1288,22 @@
 				""
 				"{moni.quest.7FA6B36DCE648C66.description2}"
 			]
+			icon: "gtceu:hadal_sculk_bucket"
 			id: "7FA6B36DCE648C66"
 			shape: "hexagon"
-			tasks: [{
-				id: "275D59A2870C1EBB"
-				item: "gtceu:hadal_sculk_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "275D59A2870C1EBB"
+					item: "gtceu:hadal_sculk_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "0B752559E1E62440"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.7FA6B36DCE648C66.title}"
 			x: -2.25d
 			y: 10.25d
@@ -1289,7 +1350,10 @@
 			y: 0.25d
 		}
 		{
-			dependencies: ["4261BDA34D716EC8"]
+			dependencies: [
+				"4261BDA34D716EC8"
+				"2E87146C82EF941C"
+			]
 			description: [
 				"{moni.quest.61301FBD825F8280.description1}"
 				""

--- a/config/ftbquests/quests/chapters/groundwork.snbt
+++ b/config/ftbquests/quests/chapters/groundwork.snbt
@@ -1038,6 +1038,7 @@
 				""
 				"{moni.quest.4F4D0F44B615AF4C.description3}"
 			]
+			icon: "gtceu:sodium_persulfate_bucket"
 			id: "4F4D0F44B615AF4C"
 			rewards: [{
 				id: "1665820920C762E6"
@@ -1046,26 +1047,25 @@
 			}]
 			shape: "hexagon"
 			subtitle: "{moni.quest.4F4D0F44B615AF4C.subtitle}"
-			tasks: [{
-				id: "51BA79F86129325D"
-				item: {
-					Count: 1
-					id: "itemfilters:or"
-					tag: {
-						items: [
-							{
-								Count: 1b
-								id: "gtceu:sodium_persulfate_bucket"
-							}
-							{
-								Count: 1b
-								id: "gtceu:iron_iii_chloride_bucket"
-							}
-						]
-					}
+			tasks: [
+				{
+					id: "7D0DC42B9CBAA736"
+					item: "gtceu:sodium_persulfate_bucket"
+					optional_task: true
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					id: "41E11975C676C1A1"
+					item: "gtceu:iron_iii_chloride_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "407673EAB357D752"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.4F4D0F44B615AF4C.title}"
 			x: 6.0d
 			y: -2.5d
@@ -1411,10 +1411,43 @@
 			icon: "gtceu:phenol_bucket"
 			id: "451FD5817C0415D7"
 			shape: "hexagon"
-			tasks: [{
-				id: "3368C48BDB260FA8"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "3899A3D5954DC65D"
+					item: "gtceu:phenol_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "50D2923A31B5F1B4"
+					item: "gtceu:charcoal_byproducts_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "1FE15147FC41A587"
+					item: "gtceu:wood_tar_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "5F786AAFEF3E1E3C"
+					item: "gtceu:wood_gas_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "15F040D3335ABC5F"
+					item: "gtceu:wood_vinegar_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "0984AE73716D4A9B"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.451FD5817C0415D7.title}"
 			x: -0.75d
 			y: 2.0d
@@ -1559,6 +1592,7 @@
 				""
 				"{moni.quest.616555E46F314F04.description2}"
 			]
+			icon: "gtceu:sodium_potassium_bucket"
 			id: "616555E46F314F04"
 			rewards: [{
 				id: "3815CE147C3B07C5"
@@ -1566,11 +1600,18 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "778C1437764DF9E9"
-				item: "gtceu:sodium_potassium_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "778C1437764DF9E9"
+					item: "gtceu:sodium_potassium_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "6C13CB1FDE79CC66"
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.616555E46F314F04.title}"
 			x: 4.5d
 			y: 10.0d
@@ -1682,6 +1723,7 @@
 				""
 				"{moni.quest.153BDCAE4D1CC407.description4}"
 			]
+			icon: "gtceu:ethylene_bucket"
 			id: "153BDCAE4D1CC407"
 			rewards: [{
 				id: "2013156BC98A6B3E"
@@ -1690,11 +1732,19 @@
 			}]
 			shape: "hexagon"
 			size: 1.5d
-			tasks: [{
-				id: "476704217FDC81A0"
-				item: "gtceu:ethylene_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "476704217FDC81A0"
+					item: "gtceu:ethylene_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "1B17DC921919912F"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.153BDCAE4D1CC407.title}"
 			x: 2.5d
 			y: 7.0d
@@ -1899,6 +1949,7 @@
 				""
 				"{moni.quest.10722CBC4DAD28F4.description3}"
 			]
+			icon: "gtceu:chlorine_bucket"
 			id: "10722CBC4DAD28F4"
 			rewards: [{
 				id: "00856065A8DB0F17"
@@ -1906,11 +1957,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "4787CC8A2A2100FB"
-				item: "gtceu:chlorine_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "4787CC8A2A2100FB"
+					item: "gtceu:chlorine_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "0B50F7FD599AE240"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.10722CBC4DAD28F4.title}"
 			x: 3.75d
 			y: 8.5d
@@ -2310,17 +2369,26 @@
 				""
 				"{moni.quest.7ABC7057BC2E8CE4.description2}"
 			]
+			icon: "gtceu:oxalic_acid_solution_bucket"
 			id: "7ABC7057BC2E8CE4"
 			rewards: [{
 				id: "63338D828354FAAE"
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
-			tasks: [{
-				id: "7D564A2C88DE58B3"
-				item: "gtceu:oxalic_acid_solution_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "7D564A2C88DE58B3"
+					item: "gtceu:oxalic_acid_solution_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "6E5CE9387C5205B1"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.7ABC7057BC2E8CE4.title}"
 			x: 6.0d
 			y: 5.5d

--- a/config/ftbquests/quests/chapters/home_stretch.snbt
+++ b/config/ftbquests/quests/chapters/home_stretch.snbt
@@ -1028,14 +1028,23 @@
 		{
 			dependencies: ["5A31EEF439212D6E"]
 			description: ["{moni.quest.0E9B96B17D140B99.description1}"]
+			icon: "gtceu:polyether_ether_ketone_bucket"
 			id: "0E9B96B17D140B99"
 			shape: "hexagon"
 			subtitle: "{moni.quest.0E9B96B17D140B99.subtitle}"
-			tasks: [{
-				id: "6B5B6CBB315FBB39"
-				item: "gtceu:polyether_ether_ketone_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "6B5B6CBB315FBB39"
+					item: "gtceu:polyether_ether_ketone_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "256B03204F1D295D"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.0E9B96B17D140B99.title}"
 			x: 5.25d
 			y: -8.25d

--- a/config/ftbquests/quests/chapters/into_the_microverse.snbt
+++ b/config/ftbquests/quests/chapters/into_the_microverse.snbt
@@ -147,6 +147,7 @@
 				""
 				"{moni.quest.3BB7400C8BB392D9.description5}"
 			]
+			icon: "gtceu:phosphoric_acid_bucket"
 			id: "3BB7400C8BB392D9"
 			rewards: [{
 				id: "35DF5CEAEF8B9184"
@@ -154,11 +155,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "67E12CCD296D12FD"
-				item: "gtceu:phosphoric_acid_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "67E12CCD296D12FD"
+					item: "gtceu:phosphoric_acid_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "71BDB3CC528075E6"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.3BB7400C8BB392D9.title}"
 			x: -5.0d
 			y: -7.5d
@@ -179,6 +188,7 @@
 				""
 				"{moni.quest.648B1E09AA648798.description8}"
 			]
+			icon: "gtceu:sulfuric_acid_bucket"
 			id: "648B1E09AA648798"
 			rewards: [{
 				id: "1FB9EE0FCA383E6C"
@@ -186,11 +196,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "67FBB38B63BC93BB"
-				item: "gtceu:sulfuric_acid_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "67FBB38B63BC93BB"
+					item: "gtceu:sulfuric_acid_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "2D5EDB5484D8E82C"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.648B1E09AA648798.title}"
 			x: -5.0d
 			y: -9.0d
@@ -387,17 +405,26 @@
 				""
 				"{moni.quest.399AE4E449872B8A.description3}"
 			]
+			icon: "gtceu:liquid_ender_air_bucket"
 			id: "399AE4E449872B8A"
 			rewards: [{
 				id: "68E1D95E0AC47C7B"
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
-			tasks: [{
-				id: "7DD19A7DC7557C5D"
-				item: "gtceu:liquid_ender_air_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "7DD19A7DC7557C5D"
+					item: "gtceu:liquid_ender_air_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "30601DA91D002984"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.399AE4E449872B8A.title}"
 			x: -11.0d
 			y: 1.5d
@@ -696,6 +723,7 @@
 		{
 			dependencies: ["5E2489DE2E840738"]
 			description: ["{moni.quest.24415A26E5A0FD72.description1}"]
+			icon: "gtceu:rocket_fuel_bucket"
 			id: "24415A26E5A0FD72"
 			rewards: [{
 				count: 2
@@ -704,11 +732,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "645B1719FA830B75"
-				item: "gtceu:rocket_fuel_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "645B1719FA830B75"
+					item: "gtceu:rocket_fuel_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "544FF8F9BB179C30"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			x: 7.5d
 			y: -7.5d
 		}
@@ -719,6 +755,7 @@
 				"5878D53EB85F3881"
 			]
 			description: ["{moni.quest.5E2489DE2E840738.description1}"]
+			icon: "gtceu:dimethylhydrazine_bucket"
 			id: "5E2489DE2E840738"
 			rewards: [{
 				count: 3
@@ -727,11 +764,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "3D4A44BB8FD800F9"
-				item: "gtceu:dimethylhydrazine_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "3D4A44BB8FD800F9"
+					item: "gtceu:dimethylhydrazine_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "5B5C8165A62A16AE"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.5E2489DE2E840738.title}"
 			x: 7.5d
 			y: -8.75d
@@ -743,6 +788,7 @@
 				""
 				"{moni.quest.374EB1BB1E2F6B9C.description2}"
 			]
+			icon: "gtceu:ammonia_bucket"
 			id: "374EB1BB1E2F6B9C"
 			rewards: [{
 				id: "64CE305C66916861"
@@ -750,11 +796,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "770D687340CEC979"
-				item: "gtceu:ammonia_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "770D687340CEC979"
+					item: "gtceu:ammonia_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "47BC51C82CC64BCA"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.374EB1BB1E2F6B9C.title}"
 			x: 7.5d
 			y: -10.5d
@@ -768,6 +822,7 @@
 				""
 				"{moni.quest.5DA5231489336B1B.description3}"
 			]
+			icon: "gtceu:hypochlorous_acid_bucket"
 			id: "5DA5231489336B1B"
 			rewards: [{
 				id: "74161C0370473D5A"
@@ -775,17 +830,26 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "5E85DD8FC98BBCC9"
-				item: "gtceu:hypochlorous_acid_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "5E85DD8FC98BBCC9"
+					item: "gtceu:hypochlorous_acid_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "73BB5AEA7D105B60"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			x: 6.25d
 			y: -10.5d
 		}
 		{
 			dependencies: ["7A09229ACC000B09"]
 			description: ["{moni.quest.5878D53EB85F3881.description1}"]
+			icon: "gtceu:methanol_bucket"
 			id: "5878D53EB85F3881"
 			rewards: [{
 				id: "5AD6DCD80667ABA1"
@@ -793,11 +857,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "346BA20113588F1F"
-				item: "gtceu:methanol_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "346BA20113588F1F"
+					item: "gtceu:methanol_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "1B40EF1174810FF5"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.5878D53EB85F3881.title}"
 			x: 8.75d
 			y: -10.5d
@@ -842,6 +914,7 @@
 				""
 				"{moni.quest.7DE2C9292A09FC76.description7}"
 			]
+			icon: "gtceu:deuterium_bucket"
 			id: "7DE2C9292A09FC76"
 			rewards: [{
 				id: "7D1DF49C64A72FE6"
@@ -849,11 +922,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "585B4986E1D33DF9"
-				item: "gtceu:deuterium_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "585B4986E1D33DF9"
+					item: "gtceu:deuterium_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "0FCD265BAF7F9526"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.7DE2C9292A09FC76.title}"
 			x: 3.5d
 			y: -4.0d

--- a/config/ftbquests/quests/chapters/progression.snbt
+++ b/config/ftbquests/quests/chapters/progression.snbt
@@ -185,6 +185,13 @@
 			x: 18.5d
 			y: 0.5d
 		}
+		{
+			id: "72AB40B2D5F508E6"
+			linked_quest: "61301FBD825F8280"
+			shape: "hexagon"
+			x: 20.0d
+			y: 2.0d
+		}
 	]
 	quests: [
 		{
@@ -2336,23 +2343,6 @@
 			y: 6.5d
 		}
 		{
-			dependencies: ["2E87146C82EF941C"]
-			description: [
-				"{moni.quest.6DF2C1E88BE7CE5F.description1}"
-				""
-				"{moni.quest.6DF2C1E88BE7CE5F.description2}"
-			]
-			id: "6DF2C1E88BE7CE5F"
-			shape: "hexagon"
-			tasks: [{
-				id: "6E9EDE045B0C0B3E"
-				item: "gtceu:omnium_ingot"
-				type: "item"
-			}]
-			x: 20.0d
-			y: 2.0d
-		}
-		{
 			dependencies: [
 				"4542BF5E00FCBEA1"
 				"6A914B240E1A7BCB"
@@ -2490,7 +2480,6 @@
 		}
 		{
 			dependencies: [
-				"6DF2C1E88BE7CE5F"
 				"61301FBD825F8280"
 				"6A6983C64374366C"
 			]

--- a/config/ftbquests/quests/chapters/renewable_production.snbt
+++ b/config/ftbquests/quests/chapters/renewable_production.snbt
@@ -73,10 +73,19 @@
 			id: "500B77982B9CDF9B"
 			optional: true
 			subtitle: "[\"\",{\"italic\":\"true\",\"translate\":\"moni.processing.step1\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"gtceu.extractor\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step3\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"LV\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step4\"}]"
-			tasks: [{
-				id: "6B06F7499D051242"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "231370C8AD261AE8"
+					item: "thermal:ender_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "25D0100456A15524"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.500B77982B9CDF9B.title}"
 			x: -8.5d
 			y: 6.5d
@@ -153,10 +162,19 @@
 			icon: "gtceu:concrete_bucket"
 			id: "7F165C2BCCCBA565"
 			subtitle: "[\"\",{\"italic\":\"true\",\"translate\":\"moni.processing.step1\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"gtceu.mixer\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step3\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"LV\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step4\"}]"
-			tasks: [{
-				id: "0D045E8E928B8757"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "142F150D5A05D7FE"
+					item: "gtceu:concrete_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "7A609D29572FE137"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.7F165C2BCCCBA565.title}"
 			x: 9.0d
 			y: -9.5d
@@ -248,10 +266,19 @@
 			icon: "minecraft:water_bucket"
 			id: "4BC0A5F24E5837ED"
 			subtitle: "{moni.quest.water.subtitle}"
-			tasks: [{
-				id: "7070DC4C26103D4B"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "455987E6396919A1"
+					item: "minecraft:water_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "05C8F0728F992606"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{block.minecraft.water}"
 			x: 9.0d
 			y: -8.0d
@@ -318,10 +345,19 @@
 			]
 			icon: "minecraft:lava_bucket"
 			id: "36100ACD3655DAFF"
-			tasks: [{
-				id: "485DD9829B640F9B"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "3BEF917609AB7B4B"
+					item: "minecraft:lava_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "49671B99CAF250CF"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{block.minecraft.lava}"
 			x: 7.5d
 			y: -3.5d
@@ -667,10 +703,19 @@
 			id: "447E9501E57DA010"
 			optional: true
 			subtitle: "{moni.quest.water.subtitle}"
-			tasks: [{
-				id: "3E5B4CD1CB1ED343"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "3D88A8072F2B5285"
+					item: "minecraft:water_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "62EA98351219BCF2"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{block.minecraft.water}"
 			x: -2.5d
 			y: 2.0d
@@ -1060,13 +1105,22 @@
 		{
 			dependencies: ["2BF1E9CC0D7F7C91"]
 			description: ["{moni.quest.519389755420A7A8.description1}"]
+			icon: "gtceu:glue_bucket"
 			id: "519389755420A7A8"
 			subtitle: "[\"\",{\"italic\":\"true\",\"translate\":\"moni.processing.step1\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"gtceu.centrifuge\"},\".\"]"
-			tasks: [{
-				id: "48CAAA4DA3F8281C"
-				item: "gtceu:glue_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "48CAAA4DA3F8281C"
+					item: "gtceu:glue_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "5F873954A02F0209"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			x: 3.5d
 			y: 7.5d
 		}
@@ -1076,25 +1130,43 @@
 				"1FEC7E9025F6277A"
 			]
 			description: ["{moni.quest.3B1873913255E7C0.description1}"]
+			icon: "gtceu:biomass_bucket"
 			id: "3B1873913255E7C0"
 			subtitle: "[\"\",{\"italic\":\"true\",\"translate\":\"moni.processing.step1\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"gtceu.brewery\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step2\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"gtceu.pyrolyse_oven\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step3\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"LV\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step4\"}]"
-			tasks: [{
-				id: "64C7D02CF6242D24"
-				item: "gtceu:biomass_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "64C7D02CF6242D24"
+					item: "gtceu:biomass_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "044264CD41C23764"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			x: 8.0d
 			y: 4.5d
 		}
 		{
 			description: ["{moni.quest.water.description}"]
+			icon: "minecraft:water_bucket"
 			id: "2AC7A8036CA65AF3"
 			subtitle: "{moni.quest.water.subtitle}"
-			tasks: [{
-				id: "66EE299E0F4A6BF8"
-				item: "minecraft:water_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "66EE299E0F4A6BF8"
+					item: "minecraft:water_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "44E8278736719DAE"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{block.minecraft.water}"
 			x: 8.0d
 			y: 3.0d
@@ -1159,13 +1231,22 @@
 		{
 			dependencies: ["3B1873913255E7C0"]
 			description: ["{moni.quest.60A7102F5BA0DE19.description1}"]
+			icon: "gtceu:ethanol_bucket"
 			id: "60A7102F5BA0DE19"
 			subtitle: "[\"\",{\"italic\":\"true\",\"translate\":\"moni.processing.step1\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"gtceu.distillery\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step3\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"MV\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step4\"}]"
-			tasks: [{
-				id: "794EFF38BC2B0474"
-				item: "gtceu:ethanol_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "794EFF38BC2B0474"
+					item: "gtceu:ethanol_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "69AB85ED2AAB7D29"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			x: 9.5d
 			y: 4.5d
 		}
@@ -1201,14 +1282,23 @@
 		{
 			dependencies: ["0E8C258BD7E36154"]
 			description: ["{moni.quest.57C389A59CA5E00F.description1}"]
+			icon: "gtceu:charcoal_byproducts_bucket"
 			id: "57C389A59CA5E00F"
 			size: 1.25d
 			subtitle: "[\"\",{\"italic\":\"true\",\"translate\":\"moni.processing.step1\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"gtceu.pyrolyse_oven\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step3\"},{\"italic\":\"true\",\"bold\":\"true\",\"translate\":\"MV\"},{\"italic\":\"true\",\"translate\":\"moni.processing.step4\"}]"
-			tasks: [{
-				id: "06604A48AED2B19B"
-				item: "gtceu:charcoal_byproducts_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "06604A48AED2B19B"
+					item: "gtceu:charcoal_byproducts_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "68C4CAB6B5F7F417"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			x: 2.5d
 			y: 1.5d
 		}

--- a/config/ftbquests/quests/chapters/scaling_up.snbt
+++ b/config/ftbquests/quests/chapters/scaling_up.snbt
@@ -388,10 +388,19 @@
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
-			tasks: [{
-				id: "74FE595844AC8C3C"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "756E0F6D89C5EAF0"
+					item: "gtceu:elemental_reduction_fluid_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "2CD24A37A4A4E6DE"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.58FCAC329B09FEB0.title}"
 			x: -19.75d
 			y: -8.5d
@@ -403,18 +412,27 @@
 				""
 				"{moni.quest.476F71CC0B0AC2A4.description2}"
 			]
+			icon: "gtceu:hydrofluoric_acid_bucket"
 			id: "476F71CC0B0AC2A4"
 			rewards: [{
 				id: "7CAFCC053CC1526A"
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
-			tasks: [{
-				icon: "gtceu:hydrofluoric_acid_bucket"
-				id: "410F772752989787"
-				item: "gtceu:hydrofluoric_acid_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					icon: "gtceu:hydrofluoric_acid_bucket"
+					id: "410F772752989787"
+					item: "gtceu:hydrofluoric_acid_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "38AAD2B4B4F01DCD"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.476F71CC0B0AC2A4.title}"
 			x: -19.75d
 			y: -11.75d
@@ -430,11 +448,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "09F975A61B3C84FA"
-				item: "gtceu:mana_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "09F975A61B3C84FA"
+					item: "gtceu:mana_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "540129886DE67FC8"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.63F438F7033521C3.title}"
 			x: -19.75d
 			y: -1.75d
@@ -511,6 +537,7 @@
 				""
 				"{moni.quest.5BE9EDB88D656840.description2}"
 			]
+			icon: "gtceu:titanium_tetrachloride_bucket"
 			id: "5BE9EDB88D656840"
 			rewards: [{
 				id: "71343BFD7B180C0A"
@@ -518,11 +545,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "55E406D669A95D6A"
-				item: "gtceu:titanium_tetrachloride_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "55E406D669A95D6A"
+					item: "gtceu:titanium_tetrachloride_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "6EF18668229EDB33"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.5BE9EDB88D656840.title}"
 			x: -13.25d
 			y: -4.5d
@@ -632,6 +667,7 @@
 				""
 				"{moni.quest.0143E903317263D4.description2}"
 			]
+			icon: "gtceu:polytetrafluoroethylene_bucket"
 			id: "0143E903317263D4"
 			rewards: [{
 				id: "7B765F0CA1B23968"
@@ -639,11 +675,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "3243A3CE807A3DC1"
-				item: "gtceu:polytetrafluoroethylene_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "3243A3CE807A3DC1"
+					item: "gtceu:polytetrafluoroethylene_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "7F0D2A9B85C1905F"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.0143E903317263D4.title}"
 			x: -10.25d
 			y: -11.75d
@@ -718,11 +762,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "229C13A334082C92"
-				item: "gtceu:radon_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "229C13A334082C92"
+					item: "gtceu:radon_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "56DF519F24A3F11B"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.49D33146A1F417E8.title}"
 			x: -11.75d
 			y: 3.75d
@@ -875,39 +927,47 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "32ABC9C584E278E7"
-				item: {
-					Count: 1
-					id: "itemfilters:or"
-					tag: {
-						items: [
-							{
-								Count: 1b
-								id: "gtceu:helium_bucket"
-							}
-							{
-								Count: 1b
-								id: "gtceu:argon_bucket"
-							}
-							{
-								Count: 1b
-								id: "gtceu:krypton_bucket"
-							}
-							{
-								Count: 1b
-								id: "gtceu:xenon_bucket"
-							}
-							{
-								Count: 1b
-								id: "gtceu:radon_bucket"
-							}
-						]
+			tasks: [
+				{
+					id: "32ABC9C584E278E7"
+					item: {
+						Count: 1
+						id: "itemfilters:or"
+						tag: {
+							items: [
+								{
+									Count: 1b
+									id: "gtceu:helium_bucket"
+								}
+								{
+									Count: 1b
+									id: "gtceu:argon_bucket"
+								}
+								{
+									Count: 1b
+									id: "gtceu:krypton_bucket"
+								}
+								{
+									Count: 1b
+									id: "gtceu:xenon_bucket"
+								}
+								{
+									Count: 1b
+									id: "gtceu:radon_bucket"
+								}
+							]
+						}
 					}
+					optional_task: true
+					title: "{moni.task.32ABC9C584E278E7}"
+					type: "item"
 				}
-				title: "{moni.task.32ABC9C584E278E7}"
-				type: "item"
-			}]
+				{
+					id: "52C9E6D39D3A0B8E"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.4C475D22CC95EB93.title}"
 			x: 7.25d
 			y: -5.25d
@@ -933,11 +993,19 @@
 			}]
 			shape: "hexagon"
 			size: 2.0d
-			tasks: [{
-				id: "42AC56FDBA8442EE"
-				item: "gtceu:liquid_air_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "42AC56FDBA8442EE"
+					item: "gtceu:liquid_air_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "0C34F182662A1AB7"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.77CEA89E47BB3B7A.title}"
 			x: 7.25d
 			y: -7.25d
@@ -1013,11 +1081,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "2F60FFACB0B47C9F"
-				item: "gtceu:nitrogen_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "2F60FFACB0B47C9F"
+					item: "gtceu:nitrogen_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "1C09298892C632ED"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.6203088E30E34B45.title}"
 			x: 9.25d
 			y: -7.25d
@@ -1083,11 +1159,19 @@
 			}]
 			shape: "hexagon"
 			subtitle: "{moni.quest.595F205B551A53C9.subtitle}"
-			tasks: [{
-				id: "73779F75B9CA3B06"
-				item: "gtceu:nitric_acid_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "73779F75B9CA3B06"
+					item: "gtceu:nitric_acid_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "6CFC10641179186D"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.595F205B551A53C9.title}"
 			x: 14.25d
 			y: -7.25d
@@ -1107,11 +1191,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "32FEE3B58C918C4A"
-				item: "gtceu:acetic_acid_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "32FEE3B58C918C4A"
+					item: "gtceu:acetic_acid_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "512BE947AFB06A80"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.5FF33EF493DB7E01.title}"
 			x: 16.75d
 			y: -9.25d
@@ -1131,11 +1223,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "07AB0C8153AB8153"
-				item: "gtceu:ethenone_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "07AB0C8153AB8153"
+					item: "gtceu:ethenone_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "370700662A7102A8"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.51F895647CB242F1.title}"
 			x: 16.75d
 			y: -7.25d
@@ -1160,11 +1260,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "673BEB0E2F9992E8"
-				item: "gtceu:tetranitromethane_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "673BEB0E2F9992E8"
+					item: "gtceu:tetranitromethane_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "21E63B60CA97F1F9"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.16EACCF9B4FA89B3.title}"
 			x: 16.75d
 			y: -5.25d
@@ -1191,10 +1299,37 @@
 			icon: "gtceu:oil_bucket"
 			id: "6D434F3B0E720A5A"
 			shape: "hexagon"
-			tasks: [{
-				id: "4717EFD2B67D9EDB"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "1815999D66C3206E"
+					item: "gtceu:oil_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "11965D5CFFF1F0EE"
+					item: "gtceu:oil_heavy_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "1B2995D1E1AC363E"
+					item: "gtceu:oil_medium_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "6E6CE2A79EB83580"
+					item: "gtceu:oil_light_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "365BCE97D7BB1075"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.6D434F3B0E720A5A.title}"
 			x: 22.25d
 			y: -7.25d
@@ -1253,11 +1388,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "4FE2BF6F06A4D9BF"
-				item: "gtceu:diesel_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "4FE2BF6F06A4D9BF"
+					item: "gtceu:diesel_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "44C9958B26BAB9CC"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.74EDAE84246C7228.title}"
 			x: 18.25d
 			y: -5.25d
@@ -1276,11 +1419,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "76BE3671F88639AD"
-				item: "gtceu:light_fuel_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "76BE3671F88639AD"
+					item: "gtceu:light_fuel_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "63AF565D3B78C9F7"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.0E20199737DFE4AC.title}"
 			x: 20.25d
 			y: -5.25d
@@ -1296,11 +1447,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "7D024FBCBF0F1DDB"
-				item: "gtceu:heavy_fuel_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "7D024FBCBF0F1DDB"
+					item: "gtceu:heavy_fuel_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "29D112F427E97FCA"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.1F2E76FA4B2C2E84.title}"
 			x: 20.25d
 			y: -7.25d
@@ -1320,11 +1479,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "4E6B5549E5808764"
-				item: "gtceu:hydrogen_sulfide_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "4E6B5549E5808764"
+					item: "gtceu:hydrogen_sulfide_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "4B775DCD6941A4CF"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.6FE459376BF7ABBA.title}"
 			x: 18.5d
 			y: -9.25d
@@ -1336,6 +1503,7 @@
 				""
 				"{moni.quest.2396EF225839C65D.description2}"
 			]
+			icon: "gtceu:refinery_gas_bucket"
 			id: "2396EF225839C65D"
 			rewards: [{
 				id: "70073E9059FEF2F4"
@@ -1343,11 +1511,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "7F5D3D54B145AE62"
-				item: "gtceu:refinery_gas_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "7F5D3D54B145AE62"
+					item: "gtceu:refinery_gas_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "36340115B3BCC255"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.2396EF225839C65D.title}"
 			x: 20.25d
 			y: -9.25d
@@ -1367,11 +1543,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "65EB9C1F38F1D80B"
-				item: "gtceu:naphtha_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "65EB9C1F38F1D80B"
+					item: "gtceu:naphtha_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "5BDEB9CBC2C49CAF"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.04BDE09518C184E4.title}"
 			x: 22.25d
 			y: -5.25d
@@ -1453,11 +1637,19 @@
 			}]
 			shape: "hexagon"
 			size: 1.5d
-			tasks: [{
-				id: "6E1239406B0E8A94"
-				item: "gtceu:gasoline_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "6E1239406B0E8A94"
+					item: "gtceu:gasoline_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "649102C9E206A098"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.4C76017864258EA9.title}"
 			x: 24.25d
 			y: -7.25d
@@ -1483,11 +1675,19 @@
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
-			tasks: [{
-				id: "5C57B3D8A0E38AB2"
-				item: "gtceu:high_octane_gasoline_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "5C57B3D8A0E38AB2"
+					item: "gtceu:high_octane_gasoline_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "3AA4DB0A68D5C588"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.2CC50101A39EA2C0.title}"
 			x: 24.25d
 			y: -5.25d
@@ -1509,10 +1709,25 @@
 			icon: "gtceu:glycerol_bucket"
 			id: "502AB887CB316377"
 			shape: "hexagon"
-			tasks: [{
-				id: "525BCFACC82E3A60"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "367E9D27A7C7F256"
+					item: "gtceu:bio_diesel_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "63D3DA5D05F712B5"
+					item: "gtceu:glycerol_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "55C220937726D83D"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.502AB887CB316377.title}"
 			x: 12.25d
 			y: -3.25d
@@ -1555,10 +1770,25 @@
 			icon: "gtceu:fish_oil_bucket"
 			id: "78EB8574A67B10D4"
 			shape: "hexagon"
-			tasks: [{
-				id: "0948D3609E8F3E64"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "7643AD091F86BD96"
+					item: "gtceu:fish_oil_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "66A2F2EA875FFF16"
+					item: "gtceu:seed_oil_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "0FBE66675FF8113F"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.78EB8574A67B10D4.title}"
 			x: 12.25d
 			y: -5.25d
@@ -1583,11 +1813,19 @@
 				type: "item"
 			}]
 			shape: "hexagon"
-			tasks: [{
-				id: "79AA407B90ECD8DC"
-				item: "gtceu:epichlorohydrin_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "79AA407B90ECD8DC"
+					item: "gtceu:epichlorohydrin_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "19D16D07AD508439"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.7174484A926682F3.title}"
 			x: 12.25d
 			y: -0.25d
@@ -1602,10 +1840,19 @@
 			icon: "gtceu:epoxy_bucket"
 			id: "58A9F4F2BEDB1B96"
 			shape: "hexagon"
-			tasks: [{
-				id: "0548DF6E816D0050"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "30618007E2FC134F"
+					item: "gtceu:epoxy_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "333472FD94C53B6B"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.58A9F4F2BEDB1B96.title}"
 			x: 9.25d
 			y: -0.25d
@@ -1623,13 +1870,22 @@
 			id: "2EFC9DDA09527638"
 			shape: "hexagon"
 			size: 1.0d
-			tasks: [{
-				id: "5AF49C149838D83D"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "2C81A045D91C55AA"
+					item: "gtceu:allyl_chloride_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "145A12C5AFB81CD4"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.2EFC9DDA09527638.title}"
-			x: 22.275d
-			y: -0.22499999999999964d
+			x: 22.25d
+			y: -0.25d
 		}
 		{
 			dependencies: ["58A9F4F2BEDB1B96"]
@@ -2142,10 +2398,19 @@
 			icon: "gtceu:silicone_rubber_bucket"
 			id: "08B36E2C37C417E5"
 			shape: "hexagon"
-			tasks: [{
-				id: "2D0945AF2DEA44E4"
-				type: "checkmark"
-			}]
+			tasks: [
+				{
+					id: "01AE7FC86F316B66"
+					item: "gtceu:silicone_rubber_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "5067C1B721747C34"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.08B36E2C37C417E5.title}"
 			x: 6.25d
 			y: 7.0d
@@ -2166,11 +2431,19 @@
 			}]
 			shape: "hexagon"
 			size: 1.5d
-			tasks: [{
-				id: "043025061B52906B"
-				item: "gtceu:polybenzimidazole_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "043025061B52906B"
+					item: "gtceu:polybenzimidazole_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "4A6C18AF7D83EF69"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.51A463024F35DC2E.title}"
 			x: 9.25d
 			y: 5.75d
@@ -2905,11 +3178,25 @@
 			}]
 			shape: "hexagon"
 			subtitle: "{moni.quest.0D0A0C18ED958511.subtitle}"
-			tasks: [{
-				id: "75538AD487A995CD"
-				item: "gtceu:cetane_boosted_diesel_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "75538AD487A995CD"
+					item: "gtceu:cetane_boosted_diesel_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "7588D2E5FEF931A1"
+					item: "gtceu:bio_diesel_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "26B1E9877AD7C900"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.0D0A0C18ED958511.title}"
 			x: 16.75d
 			y: -3.25d
@@ -3000,12 +3287,21 @@
 				""
 				"{moni.quest.053DDDCD2505E20B.description8}"
 			]
+			icon: "gtceu:jean_gasoline_bucket"
 			id: "053DDDCD2505E20B"
-			tasks: [{
-				id: "6E961DB62F3D14AF"
-				item: "gtceu:jean_gasoline_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "6E961DB62F3D14AF"
+					item: "gtceu:jean_gasoline_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "1AEC3C60527A97D7"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.053DDDCD2505E20B.title}"
 			x: 24.25d
 			y: -3.25d
@@ -3182,17 +3478,27 @@
 				""
 				"{moni.quest.70FD95AEA44548B0.description2}"
 			]
+			icon: "gtceu:advanced_soldering_alloy_bucket"
 			id: "70FD95AEA44548B0"
 			rewards: [{
 				id: "39A3488F3C1EEF77"
 				item: "kubejs:moni_quarter"
 				type: "item"
 			}]
-			tasks: [{
-				id: "4554FBB55F422385"
-				item: "gtceu:advanced_soldering_alloy_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "4554FBB55F422385"
+					item: "gtceu:advanced_soldering_alloy_dust"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "67937E0AF20C61E6"
+					item: "gtceu:advanced_soldering_alloy_bucket"
+					optional_task: true
+					type: "item"
+				}
+			]
 			title: "{moni.quest.70FD95AEA44548B0.title}"
 			x: -16.5d
 			y: 7.75d

--- a/config/ftbquests/quests/chapters/simulating_resources.snbt
+++ b/config/ftbquests/quests/chapters/simulating_resources.snbt
@@ -465,11 +465,19 @@
 				item: "kubejs:moni_dollar"
 				type: "item"
 			}]
-			tasks: [{
-				id: "485B18F9D8C07C54"
-				item: "gtceu:liquid_nether_air_bucket"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "485B18F9D8C07C54"
+					item: "gtceu:liquid_nether_air_bucket"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "64B2FB57C29031C6"
+					optional_task: true
+					type: "checkmark"
+				}
+			]
 			title: "{moni.quest.45DD07F2BB9C6A59.title}"
 			x: -2.5d
 			y: 4.5d

--- a/config/ftbquests/quests/chapters/the_factory.snbt
+++ b/config/ftbquests/quests/chapters/the_factory.snbt
@@ -1515,12 +1515,19 @@
 				{
 					id: "47392B270D61CD4C"
 					item: "gtceu:hydrogen_bucket"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "7F2D244D03684EB3"
 					item: "gtceu:oxygen_bucket"
+					optional_task: true
 					type: "item"
+				}
+				{
+					id: "0BD8CFAB2DB4AF72"
+					optional_task: true
+					type: "checkmark"
 				}
 			]
 			title: "{moni.quest.6FE99EDDC6223F2E.title}"
@@ -1876,11 +1883,20 @@
 				item: "kubejs:moni_nickel"
 				type: "item"
 			}]
-			tasks: [{
-				id: "00DCE69057EC3D8F"
-				item: "gtceu:soldering_alloy_dust"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "00DCE69057EC3D8F"
+					item: "gtceu:soldering_alloy_dust"
+					optional_task: true
+					type: "item"
+				}
+				{
+					id: "424B2600A9124D11"
+					item: "gtceu:soldering_alloy_bucket"
+					optional_task: true
+					type: "item"
+				}
+			]
 			title: "{moni.quest.56924FC6B029BA0F.title}"
 			x: -2.0d
 			y: 11.0d
@@ -2712,7 +2728,13 @@
 		}
 		{
 			dependencies: ["1BC6DDC2D50F9C46"]
-			description: ["{moni.quest.114B300F56E48351.description1}"]
+			description: [
+				"{moni.quest.114B300F56E48351.description1}"
+				""
+				"{moni.quest.114B300F56E48351.description2}"
+				""
+				"{moni.quest.114B300F56E48351.description3}"
+			]
 			id: "114B300F56E48351"
 			shape: "hexagon"
 			tasks: [{


### PR DESCRIPTION
Changes bucket quests to accept a bucket or a check except solder quests, which accept a bucket or the dust form.
Should allow players to avoid having to bucket fluids just to complete quests, while still accommodating players who do that anyways.