### PR TITLE
Switch Gallite veins to Veined Veins

### DIFF
--- a/kubejs/server_scripts/worldgen/oreVeins.js
+++ b/kubejs/server_scripts/worldgen/oreVeins.js
@@ -543,8 +543,8 @@ GTCEuServerEvents.oreVeins(event => {
             .oreBlock(GTMaterials.Chalcopyrite, 2)
             .oreBlock(GTMaterials.get("briartite"), 1)
             .veininessThreshold(0.2)
-            .maxRichnessThreshold(0.6)
-            .minRichness(0.7)
+            .maxRichnessThreshold(0.4)
+            .minRichness(0.6)
             .maxRichness(0.7)
         )
         vein.surfaceIndicatorGenerator(indicator => indicator


### PR DESCRIPTION
Switches Gallite veins to the veiny kind, which makes them less viable as a primary source of Germanium to encourage doing the Coal Fly Ash line instead.