### PR TITLE
Cheaper LaserIO card Assembler recipe

### DIFF
--- a/kubejs/server_scripts/mods/laserio.js
+++ b/kubejs/server_scripts/mods/laserio.js
@@ -36,6 +36,12 @@ ServerEvents.recipes(event => {
                 G: "minecraft:gold_nugget",
                 T: "gtceu:tin_plate"
             }).id(`laserio:card_${card[0]}`)
+
+            event.recipes.gtceu.assembler(`laserio:card_${card[0]}`)
+                .itemInputs(card[1], cardChip, "3x gtceu:tin_plate", "6x minecraft:gold_nugget")
+                .itemOutputs(`2x laserio:card_${card[0]}`)
+                .duration(80)
+                .EUt(16)
         })
 
         // Overclockers


### PR DESCRIPTION
Gives LaserIO cards (Item/Fluid/Energy/Redstone, not the overclockers) an Assembler recipe that's cheaper on everything but Gold.