### PR TITLE
Separate Naqfuelline Fusion recipes out to a dedicated recipe type

### DIFF
--- a/kubejs/assets/gtceu/lang/en_us.json
+++ b/kubejs/assets/gtceu/lang/en_us.json
@@ -165,6 +165,7 @@
     "gtceu.anti_collider": "Annihilation",
     "gtceu.recipe.cleanroom_sterile.display_name": "Sterile Hatch",
     "gtceu.antimatter_manipulation": "Antimatter Manipulation",
+    "gtceu.particle_acceleration": "Particle Acceleration",
     "__CREATIVE_MACHINES__.header": "=====================",
     "__CREATIVE_MACHINES__.flufff": "> Creative Machines <",
     "__CREATIVE_MACHINES__.footer": "=====================",

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -142,7 +142,7 @@ ItemEvents.tooltip(tooltip => {
     tooltip.addAdvanced("gtceu:helical_fusion_reactor", (item, adv, text) => {
         text.add(1, Text.translatable("gtceu.machine.fusion_reactor.capacity", Math.trunc(FusionReactorMachine.calculateEnergyStorageFactor(GTValues.UHV, 16) / 1000000)))
         text.add(2, Text.translatable("gtceu.multiblock.parallelizable.tooltip"))
-        text.add(3, Text.translatable("gtceu.machine.available_recipe_map_1.tooltip", Text.translatable("gtceu.fusion_reactor")))
+        text.add(3, Text.translatable("gtceu.machine.available_recipe_map_2.tooltip", Text.translatable("gtceu.fusion_reactor"), Text.translatable("gtceu.particle_acceleration")))
         text.add(4, Text.translatable("gtceu.multiblock.helical_fusion_reactor.description"))
     })
 

--- a/kubejs/server_scripts/processing_lines/naquadah_fuels.js
+++ b/kubejs/server_scripts/processing_lines/naquadah_fuels.js
@@ -58,7 +58,7 @@ ServerEvents.recipes(event => {
     })
 
     // Naquadah Activation
-    event.recipes.gtceu.fusion_reactor("naquadah_activation")
+    event.recipes.gtceu.particle_acceleration("naquadah_activation")
         .inputFluids("gtceu:raw_naquadah_solution 625", "gtceu:tritium_radon_difluoride 125")
         .outputFluids("gtceu:active_naquadah_blend 625")
         .duration(32)
@@ -135,7 +135,7 @@ ServerEvents.recipes(event => {
 
     isotopes.forEach(isotope => {
         cracking_mats.forEach((cracking_mat, mat_tier) => {
-            event.recipes.gtceu.fusion_reactor(`${isotope[0]}_isotope_cracking_fusion_${cracking_mat[0]}`)
+            event.recipes.gtceu.particle_acceleration(`${isotope[0]}_isotope_cracking_fusion_${cracking_mat[0]}`)
                 .inputFluids(`gtceu:${isotope[1]} 125`, `gtceu:${cracking_mat[0]} ${cracking_mat[1]}`)
                 .outputFluids(`gtceu:cracked_${isotope[1]} 125`)
                 .duration(60 / (1 + Math.floor(mat_tier / 2)))
@@ -228,14 +228,14 @@ ServerEvents.recipes(event => {
             .EUt(GTValues.VA[GTValues.ZPM])
     }
 
-    event.recipes.gtceu.fusion_reactor("exotic_particle_activation")
+    event.recipes.gtceu.particle_acceleration("exotic_particle_activation")
         .inputFluids("gtceu:purified_heavy_residue 50", "gtceu:americium 72")
         .outputFluids("gtceu:exotic_particle_solution 50")
         .duration(128)
         .EUt(GTValues.VA[GTValues.UV])
         .fusionStartEU(200000000)
 
-    event.recipes.gtceu.fusion_reactor("hyperdegenerate_activation")
+    event.recipes.gtceu.particle_acceleration("hyperdegenerate_activation")
         .inputFluids("gtceu:purified_superheavy_residue 50", "gtceu:actinium 36")
         .outputFluids("gtceu:hyperdegenerate_matter 25")
         .duration(128)

--- a/kubejs/startup_scripts/gregtech_material_registry/chemline_naqfuel.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/chemline_naqfuel.js
@@ -6,6 +6,31 @@ GTCEuStartupEvents.registry("gtceu:material_icon_set", event => {
     event.create("naquadah_superfuel").parent(GTMaterialIconSet.RADIOACTIVE)
 })
 
+// Tweaks to Fusion reactors to allow for separate "particle acceleration" recipe type
+GTCEuStartupEvents.registry("gtceu:recipe_type", event => {
+    // Block scope so as to not conflict with the similar declaration in multiblock_registry.js
+    const FusionReactorMachine = Java.loadClass("com.gregtechceu.gtceu.common.machine.multiblock.electric.FusionReactorMachine")
+
+    event.create("particle_acceleration")
+        .category("multiblock")
+        .setMaxIOSize(0, 0, 2, 1)
+        .setEUIO("in")
+        .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, FillDirection.LEFT_TO_RIGHT)
+        .setSound(GTSoundEntries.ARC)
+        .setMaxTooltips(4)
+        .setUiBuilder((a, b) => FusionReactorMachine.addEUToStartLabel(a, b))
+})
+
+StartupEvents.postInit(event => {
+    // Do this with java methods since we can't in the KJS builder
+    GTRecipeTypes.get("particle_acceleration").setOffsetVoltageText(true)
+
+    // Apply the particle acceleration recipe type to Fusion Reactors
+    GTMultiMachines.FUSION_REACTOR.forEach(fusionReactorTier => {
+        if(fusionReactorTier != null) fusionReactorTier.setRecipeTypes([GTRecipeTypes.FUSION_RECIPES, GTRecipeTypes.get("particle_acceleration")])
+    })
+})
+
 GTCEuStartupEvents.registry("gtceu:material", event => {
     event.create("crude_naquadah_fuel")
         .liquid()

--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -243,7 +243,7 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
     event.create("helical_fusion_reactor", "multiblock")
         .machine((holder) => new FusionReactorMachine(holder, GTValues.UEV))
         .rotationState(RotationState.ALL)
-        .recipeTypes(GTRecipeTypes.FUSION_RECIPES)
+        .recipeTypes([GTRecipeTypes.FUSION_RECIPES, GTRecipeTypes.get("particle_acceleration")])
         .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, MachineModifiers.FUSION_REACTOR, GTRecipeModifiers.BATCH_MODE])
         .appearanceBlock(GCYMBlocks.CASING_ATOMIC)
         .pattern(definition => FactoryBlockPattern.start()


### PR DESCRIPTION
This PR separates out all non-Fusion recipes in the Fusion Reactor into their own recipe map called Particle Acceleration.

Currently, Naqfueline recipes in the Fusion Reactors take up about half of the recipe map. You can't page through the recipes for fusing elements without having to sift through useless neutron-cracking recipes, and vice-versa. Since the two categories of recipes are unrelated beyond the fact that they share a machine, I took the liberty of making this PR to solve that problem.