### PR TITLE
Fix Pitcher Plant and Torchflower Greenhouse recipes

### DIFF
--- a/kubejs/server_scripts/gregtech/greenhouse.js
+++ b/kubejs/server_scripts/gregtech/greenhouse.js
@@ -129,7 +129,6 @@ ServerEvents.recipes(event => {
         "oxeye_daisy",
         "azure_bluet",
         "white_tulip",
-        "pitcher_plant",
         "lily_pad",
         "weeping_vines",
         "twisting_vines",
@@ -145,8 +144,11 @@ ServerEvents.recipes(event => {
     flowers.forEach(flower => {
         Greenhouse("minecraft", flower, 640, [Item.of(flower, 48)], 0);
     })
-    // Torchflowers are grown from seeds
-    Greenhouse("minecraft", "torchflower_seeds", 640, [Item.of("torchflower", 48)], 0);
+
+    // Torchflowers, Pitcher plants are grown from seeds
+    Greenhouse("minecraft", "torchflower_seeds", 640, [Item.of("torchflower", 12), Item.of("torchflower_seeds", 6)], 0);
+    Greenhouse("minecraft", "pitcher_pod", 640, [Item.of("pitcher_plant", 12), Item.of("pitcher_pod", 6)], 0);
+
     // A way to get grass blocks
     event.recipes.gtceu.greenhouse("kubejs:grass_block")
         .circuit(1)


### PR DESCRIPTION
Makes Pitcher Plants grow from their seed pod instead of fully-grown flowers, and makes both Pitcher Plants and Torchflowers yield their seeds in the Greenhouse.