### PR TITLE
Nerf Ender Air to yield less Tritium

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -48,6 +48,14 @@ ServerEvents.recipes(event => {
         .EUt(16)
         .duration(200)
 
+    // Nerfed Ender Air distillation - less Tritium
+    event.recipes.gtceu.distillation_tower("liquid_ender_air_distillation")
+        .inputFluids("gtceu:liquid_ender_air 200000")
+        .outputFluids("gtceu:nitrogen_dioxide 130000", "gtceu:deuterium 50000", "gtceu:helium 15000", "gtceu:tritium 2000", "gtceu:krypton 1000", "gtceu:xenon 1000", "gtceu:radon 1000")
+        .chancedOutput("gtceu:ender_pearl_dust", 1000, 0)
+        .EUt(GTValues.VA[GTValues.IV])
+        .duration(100 * 20)
+
     // Netherrack
     event.recipes.gtceu.chemical_reactor("dust_to_netherrack")
         .itemInputs("kubejs:dust")


### PR DESCRIPTION
A while ago there was a bit of discussion on rebalancing plasma as a power generation option.
Helium plasma is highly scalable, beating out later plasmas relatively easily.

This is a band-aid to address the issue by slashing the Tritium output from Ender Air.
This makes Helium plasma more expensive to scale, encouraging the usage of more advanced plasma types to consume less material.