### PR TITLE
Adjust the LV Power Storage quest lang

### DIFF
--- a/kubejs/assets/ftbquests/lang/de_de.json
+++ b/kubejs/assets/ftbquests/lang/de_de.json
@@ -164,7 +164,7 @@
     "moni.quest.07706AB24D866D7F.title": "Element 071: Lutetium",
     "moni.quest.077AA27F26B7831F.description1": "&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy.",
     "moni.quest.077AA27F26B7831F.description2": "Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making.",
-    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r.",
+    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r — you'll also want to buy Stibnite for the Antimony needed in &6Battery Alloy&r.",
     "moni.quest.077AA27F26B7831F.description3.expert": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.description3.hardmode": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.title": "LV Power Storage",

--- a/kubejs/assets/ftbquests/lang/en_us.json
+++ b/kubejs/assets/ftbquests/lang/en_us.json
@@ -193,7 +193,7 @@
     "moni.quest.07706AB24D866D7F.title": "Element 071: Lutetium",
     "moni.quest.077AA27F26B7831F.description1": "&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy.",
     "moni.quest.077AA27F26B7831F.description2": "Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making.",
-    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r.",
+    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r — you'll also want to buy Stibnite for the Antimony needed in &6Battery Alloy&r.",
     "moni.quest.077AA27F26B7831F.description3.expert": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.description3.hardmode": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.title": "LV Power Storage",

--- a/kubejs/assets/ftbquests/lang/es_es.json
+++ b/kubejs/assets/ftbquests/lang/es_es.json
@@ -164,7 +164,7 @@
     "moni.quest.07706AB24D866D7F.title": "Elemento 071: Lutecio",
     "moni.quest.077AA27F26B7831F.description1": "&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy.",
     "moni.quest.077AA27F26B7831F.description2": "Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making.",
-    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r.",
+    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r — you'll also want to buy Stibnite for the Antimony needed in &6Battery Alloy&r.",
     "moni.quest.077AA27F26B7831F.description3.expert": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.description3.hardmode": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.title": "LV Power Storage",

--- a/kubejs/assets/ftbquests/lang/fr_fr.json
+++ b/kubejs/assets/ftbquests/lang/fr_fr.json
@@ -164,7 +164,7 @@
     "moni.quest.07706AB24D866D7F.title": "Element 071: Lutetium",
     "moni.quest.077AA27F26B7831F.description1": "&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy.",
     "moni.quest.077AA27F26B7831F.description2": "Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making.",
-    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r.",
+    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r — you'll also want to buy Stibnite for the Antimony needed in &6Battery Alloy&r.",
     "moni.quest.077AA27F26B7831F.description3.expert": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.description3.hardmode": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.title": "LV Power Storage",

--- a/kubejs/assets/ftbquests/lang/nl_nl.json
+++ b/kubejs/assets/ftbquests/lang/nl_nl.json
@@ -192,7 +192,7 @@
     "moni.quest.07706AB24D866D7F.title": "Element 071: Lutetium",
     "moni.quest.077AA27F26B7831F.description1": "&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy.",
     "moni.quest.077AA27F26B7831F.description2": "Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making.",
-    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r.",
+    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r — you'll also want to buy Stibnite for the Antimony needed in &6Battery Alloy&r.",
     "moni.quest.077AA27F26B7831F.description3.expert": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.description3.hardmode": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.title": "LV Power Storage",

--- a/kubejs/assets/ftbquests/lang/pl_pl.json
+++ b/kubejs/assets/ftbquests/lang/pl_pl.json
@@ -174,7 +174,7 @@
     "moni.quest.07706AB24D866D7F.title": "Element 071: Lutetium",
     "moni.quest.077AA27F26B7831F.description1": "&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy.",
     "moni.quest.077AA27F26B7831F.description2": "Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making.",
-    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r.",
+    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r — you'll also want to buy Stibnite for the Antimony needed in &6Battery Alloy&r.",
     "moni.quest.077AA27F26B7831F.description3.expert": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.description3.hardmode": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.title": "LV Power Storage",

--- a/kubejs/assets/ftbquests/lang/pt_br.json
+++ b/kubejs/assets/ftbquests/lang/pt_br.json
@@ -164,7 +164,7 @@
     "moni.quest.07706AB24D866D7F.title": "Element 071: Lutetium",
     "moni.quest.077AA27F26B7831F.description1": "&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy.",
     "moni.quest.077AA27F26B7831F.description2": "Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making.",
-    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r.",
+    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r — you'll also want to buy Stibnite for the Antimony needed in &6Battery Alloy&r.",
     "moni.quest.077AA27F26B7831F.description3.expert": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.description3.hardmode": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.title": "LV Power Storage",

--- a/kubejs/assets/ftbquests/lang/pt_pt.json
+++ b/kubejs/assets/ftbquests/lang/pt_pt.json
@@ -193,7 +193,7 @@
     "moni.quest.07706AB24D866D7F.title": "Element 071: Lutetium",
     "moni.quest.077AA27F26B7831F.description1": "&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy.",
     "moni.quest.077AA27F26B7831F.description2": "Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making.",
-    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r.",
+    "moni.quest.077AA27F26B7831F.description3": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension. Consider \"buying\" some Lithium with &9Monicoins&r — you'll also want to buy Stibnite for the Antimony needed in &6Battery Alloy&r.",
     "moni.quest.077AA27F26B7831F.description3.expert": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.description3.hardmode": "&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are only found in the End dimension.",
     "moni.quest.077AA27F26B7831F.title": "LV Power Storage",


### PR DESCRIPTION
Now that Stibnite/Tetrahedrite veins were removed from the Overworld, this PR adds a comment for NM players (who have yet to visit the Nether) to buy Stibnite for Battery Alloy to make LV batteries in the corresponding quest.