### PR TITLE
Nerf TBU fuel to have less fuel energy than LEU-235

### DIFF
--- a/config/NuclearCraft/fission_fuel/thorium.json
+++ b/config/NuclearCraft/fission_fuel/thorium.json
@@ -5,7 +5,7 @@
     "forge_energy": 4800,
     "heat": 27,
     "criticality": 234,
-    "depletion": 720,
+    "depletion": 480,
     "efficiency": 125,
     "isotopes": [232, 232]
   }


### PR DESCRIPTION
So it turns out that TBU fuel has 69M FE per pellet and LEU-235 has 62M FE per pellet.
This nerfs TBU fuel depletion time by 33% to put its fuel energy below Uranium.

With this, Fission shouldn't be so OP when scaled & the need to scale would be lessened (since players would be incentivized to use higher-output fuels, which require smaller reactors for the same power output)