### PR TITLE
Remove sterile cr recipes

### DIFF
--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -288,6 +288,7 @@ ServerEvents.recipes(event => {
     // LCR is a separate recipemap, and singleblocks cannot get the sterile hatch.
     event.remove({ id: "gtceu:chemical_reactor/stem_cells" })
     event.remove({ id: "gtceu:chemical_reactor/collagen_from_bone" })
+    event.remove({ id: "gtceu:chemical_reactor/collagen_from_bone_meal" })
     event.remove({ id: "gtceu:chemical_reactor/bacterial_sludge" })
 
 


### PR DESCRIPTION
With the Sterile Cleanroom removed, it's only possible to run Sterile recipes in multiblocks with Sterile Cleaning Hatches. Thus, this PR removes all the regular (singleblock) chemical reactor recipes that require the Sterile Cleaning Hatch because it's not possible to add hatches to a singleblock and therefore not possible to run these recipes.