### PR TITLE
Add missing rewards to periodic table quests

### DIFF
--- a/config/ftbquests/quests/chapters/omnium.snbt
+++ b/config/ftbquests/quests/chapters/omnium.snbt
@@ -1376,6 +1376,11 @@
 			description: [""]
 			disable_toast: true
 			id: "7978CD633112BE89"
+			rewards: [{
+				id: "73BB2ACE769812E9"
+				item: "kubejs:moni_quarter"
+				type: "item"
+			}]
 			tasks: [{
 				count: 64L
 				id: "6472F5F5B0D7083E"
@@ -2015,6 +2020,11 @@
 		{
 			disable_toast: true
 			id: "2D788BE1CA9A2D69"
+			rewards: [{
+				id: "0710F33F597D462E"
+				item: "kubejs:moni_quarter"
+				type: "item"
+			}]
 			tasks: [{
 				count: 64L
 				id: "67A5E978C88BEAD3"


### PR DESCRIPTION
Iodine and Germanium were missing the Moninickel rewards.