### PR TITLE
Update FAQ and KNOWN-ISSUES.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,10 +8,9 @@
 
 The main path of progression is fully playable - multiple groups have obtained the Creative Chest in Normal Mode.
 
-**Q. Where can I download Monifactory?**
+**Q. Is Monifactory still being updated?**
 
-Stable releases of Monifactory can be downloaded from CurseForge using any launcher of your choice (PrismLauncher, CurseForge, etc.)
-Bleeding edge builds can be found [here](https://github.com/ThePansmith/Monifactory/releases).
+Refer to the `main` branch of the repository on Github. The latest commit is an indicator of the last time a contribution to the modpack has been made.
 
 **Q. What's the difference between Monifactory and Nomifactory CEu?**
 
@@ -31,7 +30,7 @@ Yes! Peaceful mode is the intended playstyle for Monifactory. Playing with mobs 
 
 **Q. Can I port my Nomifactory world to Monifactory?**
 
-Technically? Yes. In a practical sense? No. Loading the 1.12 world in 1.20.1 Monifactory *does* load vanilla Minecraft items and blocks and some GT ores properly, but it voids every other modded item or block - you will essentially be sent back to the stone age.
+For all intents and purposes, No. Loading the 1.12 world in 1.20.1 Monifactory *does* load vanilla Minecraft items and blocks and some GT ores properly, but it voids every other modded item or block - you will essentially be sent back to the stone age.
 
 **Q. Will Monifactory be ported to 'X' Minecraft version?**
 
@@ -39,11 +38,11 @@ Monifactory will not be backported to any versions before 1.20.1. Porting the pa
 
 **Q. Will Monifactory be ported to Fabric?**
 
-Monifactory will not be ported to Fabric. Some mods necessary to the modpack are not available on Fabric, so a port to Fabric is not an option available to us.
+Monifactory will not be ported to Fabric. Some mods necessary to the modpack are not available on Fabric, so a port to Fabric is not an option.
 
 **Q. Will Monifactory be released on Modrinth?**
 
-Monifactory will not be released on Modrinth. Some mods necessary to the modpack are not available on Modrinth, so releasing on their platform is not an option available to us.
+Monifactory will not be released on Modrinth. Some mods necessary to the modpack are not available on Modrinth, so releasing on their platform is not an option.
 
 **Q. Is Create in the modpack?**
 
@@ -57,19 +56,24 @@ No, but we have their respective port and fork, Radium and Embeddium.
 
 Not by default. Oculus is included to load your shaders of choice, however.
 
-**Q. Can you create or add 'X' mod to Monifactory?**
+**Q. Can you add \[X\] mod to Monifactory?**
 
-Create a feature request on the GitHub.
+Create a feature request on the GitHub for the mod to be considered.
 
-**Q. Can I add 'X' mod to my instance of Monifactory?**
+**Q. Can I add \[X\] mod to my instance of Monifactory?**
 
-By default, Monifactory only supports the mods included with it, and has *optional compat* for various mods, such as Create. Any other mods added may break progression and/or deviate from the intended experience. Note that support will not be provided for bugs related to mods not shipped with the pack.
+By default, Monifactory only supports the mods included with it, and has *optional compat* for various mods, such as Create. While it is your prerogative to alter the pack as you desire, any mods added to the pack may break progression and/or deviate from the intended experience. Support will not be provided for bugs related to mods not shipped with the pack.
 
 <hr>
 
 ## How Do I...?
 
-**Q. How do I play Monifactory Hard Mode/Expert Mode?**
+**Q. How do I download Monifactory?**
+
+Stable releases of Monifactory can be downloaded from CurseForge using any launcher of your choice (PrismLauncher, CurseForge, etc.)
+Bleeding edge builds can be found [here](https://github.com/ThePansmith/Monifactory/releases).
+
+**Q. How do I play Hard Mode/Expert Mode?**
 
 [Instructions can be found here](https://github.com/ThePansmith/Monifactory?tab=readme-ov-file#hardexpert-mode-installation)
 
@@ -107,28 +111,25 @@ For the old Gregtech textures, look into [Threefold's Modern GregTech](https://m
 
 Lost Cities generates those ruins. To disable them, it is easiest to remove the mod entirely.
 
-<hr>
+## Help Section
 
-## Tech Support
+**Q. Where are the quests in the Questbook?**
 
-### Gameplay
+You have installed or updated the modpack incorrectly. Refer to the installation instructions above.
 
-**Q. Where should I build my base?**
+**A quest is not showing as completed?!?**
 
-This is your decision to make - You don't ask others to decide what you should eat for lunch!
-If you want a comparison of the available dimensions:
-- Overworld: Pretty landscapes & easy access to resources, but some find the terrain difficult to build around.
-- Void Dimension: Always day, but featureless and nothing to build off of. Good for potato computers.
-- Luna, Mars, Mercury, or Venus: Mostly featureless, flat terrain. You need Oxygen and a spacesuit to breathe.
-- Planetary Orbit dimensions: Similar to the Void Dimension, but you need Oxygen and a spacesuit to breathe.
-- Lost Cities Dimension: Cities cover most terrain, and are damaged. No Ores.
-- Nether/End: Rich in resources, but potentially hazardous. Same generation as in Vanilla but with GregTech ores.
-- AE2 Spatial Storage: 128x128 size limit. Can be combined & traversed in creative ways.
+Check all dependencies and ensure they are completed with a green checkmark. Some dependencies may not be on the same quest page or may not be connected with a line.
+If that does not work, then go into edit mode by changing the game mode to Creative, then clicking the pencil in the bottom right of the quest UI. In edit mode, you can right-click a quest and select "Complete Instantly".
 
 **Q. I can't light my Nether portal?!?**
 
 In Monifactory, both the Nether and End portals are disabled.
 TelePastries' cakes are used to move between dimensions instead.
+
+**KubeJS errors found!**
+
+You have installed or updated the modpack incorrectly. Refer to the installation instructions above.
 
 **Q. What happened to Ender IO?!?**
 Support for Ender IO in 1.20.1 has discontinued despite some major aspects of the mod being left in a buggy state. As such, those portions of the mod have been removed so as to not confuse or irritate players.

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -1,16 +1,7 @@
 ## Other Frequently Asked Questions:
 See more at [FAQ.md](FAQ.md)
 
-**FTBQuests not showing as completed**
-
-Check all dependencies and ensure they are completed with a green checkmark. Some dependencies may not be on the same quest page, and will therefore not be connected with a line.
-If that does not work, then go into edit mode by changing the game mode to Creative, then clicking the pencil in the bottom right of the quest UI. In edit mode, you can right-click a quest and select "Complete Instantly".
-
-**Quark (quark) has failed to load correctly.**
-
-This is the result of an adverse interaction between Quark and ModernFix's Dynamic Resources mixin.
-Restarting the modpack a few times resolves the issue.
-If it annoys you enough, then you can go into the Modernfix config and disable it.
+## Issues you may encounter while playing the game:
 
 **Game crashes when generating a superflat world.**
 
@@ -22,57 +13,60 @@ Monifactory tweaks Wythers' worldgen with a datapack to prevent some confusing a
 
 It is located in `kubejs/data/minecraft/worldgen` if you wish to remove it.
 
-**Game crashes on MacOS**
+**Game crashes on MacOS or Linux**
 
 Remove Spark and ensure you are using an ARM64 version of Java 17 or higher.
 
 **Mod versions do not match when connecting to server ([example pictured here](https://imgur.com/GL1GdwW))**
 
-Odds are your config doesn't match the ones on the server. Pack modes (Normal, Hard, Expert) change configs, so double-check and make sure that the client and server are on the same mode!
+Odds are your config doesn't match the ones on the server. Pack modes (Normal, Hard, Expert) change configs, so make sure that the client and server are on the same mode!
 
 **"Connection Lost - Invalid player data" error message**
 
 No cause has been identified, but the leading theory is that you may have favorited or bookmarked a recipe or item that no longer exists in EMI. Download a new instance of Monifactory from scratch, test it to ensure it works, and if so then transfer over your files in chunks while repeatedly checking to ensure the error doesn't re-occur.
 
-**GregTech textures are all switched around**
+**Textures are switched around**
 
-GregTech uses dynamically generated textures - reloading your resource packs may break this. Restart your game to fix it.
-
-**KubeJS errors when updating on Prism Launcher**
-
-Update to Prism 9.0. Previous versions of Prism don't delete files from the previous version of Moni when updating, so any file that should be removed in a modpack update won't necessarily be deleted on your end. This can cause problems.
+GregTech uses dynamically generated textures - reloading resource packs may break this. Restart the game to fix it.
 
 **EMI and/or AE2 having issues with GregTech tools**
 
-These mods don't handle NBT or tool-based crafting perfectly all the time, so you may encounter this issue occasionally. Try to transition to Assemblers or other machines ASAP. Machine crafting also offers improved material efficiency over tool crafting
+These mods don't handle NBT or tool-based crafting perfectly all the time, so you may encounter this issue occasionally. Transition to Assemblers or other machines ASAP. Machine crafting also offers improved material efficiency over tool crafting.
 
-**UI elements overlapping with EMI**
+**UI elements overlapping with the recipe viewer**
 
 Switch to a lower GUI scale or tweak EMI's UI configs to your liking. Alternatively, disable EMI temporarily using Ctrl + O
 
 **Discord Rich Presence integration doesn't match my voltage tier**
 
-The Rich Presence integration relies on the completion of certain quests in the Progression tab to track your voltage tier. Ensure that the quest with the Machine Hull corresponding to your tier is completed, and then wait a few minutes for it to update.
+The Rich Presence integration relies on the completion of certain quests in the Progression tab to track your voltage tier. Navigate to the chapter and ensure that the quest with the Machine Hull corresponding to your tier is completed, then wait a few minutes for it to update.
 Additionally, there are some reports of problems from players that use Java 22 - consider switching to Java 17 if it remains an issue.
 
 ## Other Issues with Mods
 Monifactory contains multiple mods that are at different stages of completion - it is not uncommon for a bug to be caused by one of these mods instead of Monifactory specifically.
-If you are unsure whether a specific mod may be causing a bug, try to replicate the bug on a *new instance with only the mods necessary to re-create the issue.* If you can do this, then the bug should be reported to that mod's developers instead of those of Monifactory
+
+If you create a report that should go to one of these mods instead of Monifactory, then your report may be closed with no action taken. To have the best chance of solving the issue you're facing, make sure you confirm the source of the issue and make the report directly to the root cause.
+
+If you are unsure whether a specific mod may be causing a bug, try to replicate the bug on a *new instance with only the mods necessary to re-create the issue.* If you can do this, then the bug should be reported to that mod's developers instead of those of Monifactory.
 
 The most frequent offenders are listed below:
+
+**Issues with [Gregtech CEu: Modern](https://github.com/GregTechCEu/GregTech-Modern)**
+
+GTM is being actively developed. You may run into bugs, but these are addressed relatively quickly. Please ensure you aren't creating a duplicate report before notifying the devs of an issue or submitting a bug report to the Github page above.
 
 **Issues with [Nuclearcraft: Neoteric](https://github.com/igentuman/NuclearCraft-Neoteric)**
 
 Nuclearcraft: Neoteric is not in a great state. Many features (including some aspects of fission reactors!) are incomplete or buggy
 
+**Issues with [LaserIO](https://github.com/Direwolf20-MC/LaserIO/issues)**
+
+Occasionally, there can be the occasional issue or feature request you may have. Send these to LaserIO directly. 
+
 **Issues with [EnderIO Modern](https://github.com/Team-EnderIO/EnderIO)**
 
 EnderIO 1.20.1 is not feature complete - things may be missing, have bugs or cause crashes.
 If you encounter any issues, please properly isolate the issue and submit a bug report to the Github page above.
-
-**Issues with [Gregtech CEu: Modern](https://github.com/GregTechCEu/GregTech-Modern)**
-
-GTM is being actively developed. You are likely run into bugs, but these are addressed relatively quickly. Please ensure you aren't creating a duplicate report before notifying the devs of an issue or submitting a bug report to the Github page above.
 
 **Issues with [AE2](https://github.com/AppliedEnergistics/Applied-Energistics-2/)**
 


### PR DESCRIPTION
Slight reorganization of FAQ and KNOWN-ISSUES.

Now, KNOWN-ISSUES is limited to issues afflicting Moni or the mods it depends on, while the FAQ is for PEBCAC or &t bold "issues".

The content of these docs have also been updated to reflect the issues more recent players are likely to encounter.