### PR TITLE
Add the Monium easter egg

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -901,4 +901,11 @@ ServerEvents.recipes(event => {
         .itemOutputs("7x gtceu:tantalum_pentoxide_dust")
         .duration(200)
         .EUt(GTValues.VA[GTValues.HV])
+
+    // Monium as a mixture of gadolinium and terbium (easter egg)
+    event.recipes.gtceu.electrolyzer("electrolyze_monium_dust")
+        .itemInputs("2x gtceu:monium_dust")
+        .itemOutputs("gtceu:terbium_dust", "gtceu:gadolinium_dust")
+        .duration(6000)
+        .EUt(GTValues.VA[GTValues.UEV])
 })

--- a/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
@@ -43,6 +43,9 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     GTMaterials.Terbium.setProperty($PropertyKey.BLAST, new $BlastProperty(7200, "higher", 524288, 900, -1, -1));
     GTMaterials.Terbium.addFlags(GTMaterialFlags.GENERATE_LONG_ROD, GTMaterialFlags.GENERATE_RING)
 
+    GTMaterials.Gadolinium.setProperty($PropertyKey.DUST, new $DustProperty())
+    GTMaterials.Gadolinium.setMaterialARGB(0xBAC7A0)
+
     // Existing materials that get new material forms
     GTMaterials.Neutronium.addFlags(GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.GENERATE_LONG_ROD, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_SMALL_GEAR, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.GENERATE_DENSE)
     GTMaterials.Graphite.addFlags(GTMaterialFlags.GENERATE_PLATE)


### PR DESCRIPTION
Monium, later renamed to [Victorium](https://en.wikipedia.org/wiki/Victorium), is a chemical that upon discovery was identified as a new chemical element; later it turned out to be a mixture of gadolinium and terbium. This PR adds a reference to this coincidence in naming, allowing monium dust to be electrolyzed into gadolinium and terbium. It also adds gadolinium dust, which (intentionally) has no intended use.