### PR TITLE
Let NM use Flux Gem recipes for QFlux

### DIFF
--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -407,21 +407,6 @@ ServerEvents.recipes(event => {
             .chancedOutput("gtceu:europium_dust", 600, 0)
             .duration(50).EUt(GTValues.VA[GTValues.UV])
 
-        // Quantum Flux Recipe
-        event.recipes.gtceu.mixer("quantum_flux_hm")
-            .itemInputs("redstone_arsenal:flux_gem")
-            .inputFluids(Fluid.of("gtceu:mana", 250))
-            .itemOutputs("8x kubejs:quantum_flux")
-            .duration(100)
-            .EUt(480)
-
-        event.recipes.gtceu.large_chemical_reactor("kubejs:omnic_quantum_flux")
-            .itemInputs("redstone_arsenal:flux_gem", "4x kubejs:primal_mana", "gtceu:nether_star_dust")
-            .inputFluids("gtceu:dragon_breath 500")
-            .itemOutputs("64x kubejs:quantum_flux")
-            .duration(50)
-            .EUt(GTValues.VA[GTValues.EV])
-
         // Rocketry
         event.recipes.gtceu.chemical_reactor("kubejs:chemical_reactor/durene_hm")
             .inputFluids(Fluid.of("gtceu:dimethylbenzene", 1000), Fluid.of("gtceu:chloromethane", 1000))

--- a/kubejs/server_scripts/mods/HostileNeuralNetworks.js
+++ b/kubejs/server_scripts/mods/HostileNeuralNetworks.js
@@ -148,6 +148,15 @@ ServerEvents.recipes(event => {
             .duration(100)
             .EUt(3000)
 
+        event.shaped("kubejs:quantum_flux", [
+            " B ",
+            "BAB",
+            " B "
+        ], {
+            A: "enderio:pulsating_crystal",
+            B: "hostilenetworks:end_prediction"
+        })
+
         // LAIR DATA
         let lairs = [
             ["deep_dark", "overworld", "deepslate"],

--- a/kubejs/server_scripts/mods/gregtech.js
+++ b/kubejs/server_scripts/mods/gregtech.js
@@ -55,16 +55,20 @@ ServerEvents.recipes(event => {
         .duration(20)
         .EUt(30)
 
-    if (doHNN) {
-        event.shaped("kubejs:quantum_flux", [
-            " B ",
-            "BAB",
-            " B "
-        ], {
-            A: "enderio:pulsating_crystal",
-            B: "hostilenetworks:end_prediction"
-        })
-    }
+    // Other Quantum Flux Recipes
+    event.recipes.gtceu.mixer("quantum_flux_hm")
+        .itemInputs("redstone_arsenal:flux_gem")
+        .inputFluids(Fluid.of("gtceu:mana", 250))
+        .itemOutputs("8x kubejs:quantum_flux")
+        .duration(100)
+        .EUt(480)
+
+    event.recipes.gtceu.large_chemical_reactor("kubejs:omnic_quantum_flux")
+        .itemInputs("redstone_arsenal:flux_gem", "4x kubejs:primal_mana", "gtceu:nether_star_dust")
+        .inputFluids("gtceu:dragon_breath 500")
+        .itemOutputs("64x kubejs:quantum_flux")
+        .duration(50)
+        .EUt(GTValues.VA[GTValues.EV])
 
     // Remove Hot MV ingots (And molten fluid counterpart)
     event.remove([


### PR DESCRIPTION
Adds the Flux Gem recipes for Quantum Flux to Normal Mode.

Also moves the NM-only QFlux recipe that uses HNN items to the HNN script.