### PR TITLE
Allow blocks outside the Naquadah Refinery to be Predicates.any()

### DIFF
--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -579,7 +579,7 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
             .aisle("CCCCCCCCC", "CP#III#PC", "#P#SSS#P#", "#PSPPPSP#", "#S  E  S#", "#V  E  V#", "#G  E  G#", "#V  E  V#", "#S  E  S#", "##SPPPS##", "###SMS###")
             .aisle("CCCCCCCCC", "C##III##C", "###SSS###", "##SPPPS##", "#S K K S#", "#V K K V#", "#G K K G#", "#V K K V#", "#S K K S#", "##SPPPS##", "###SSS###")
             .aisle("CCCCCCCCC", "CCF###FCC", "##F###F##", "##FSSSF##", "##S   S##", "##V   V##", "##G   G##", "##V   V##", "##S   S##", "###SSS###", "#########")
-            .aisle("#CCCCCCC#", " CC#P#CC ", "####P####", "####P####", "###SSS###", "###VVV###", "###GGG###", "###VVV###", "###SSS###", "#########", "#########")
+            .aisle("#CCCCCCC#", "#CC#P#CC#", "####P####", "####P####", "###SSS###", "###VVV###", "###GGG###", "###VVV###", "###SSS###", "#########", "#########")
             .aisle("##CC@CC##", "##CCCCC##", "#########", "#########", "#########", "#########", "#########", "#########", "#########", "#########", "#########")
             .where("@", Predicates.controller(Predicates.blocks(definition.get())))
             .where("C", Predicates.blocks("gtceu:stress_proof_casing").setMinGlobalLimited(85)


### PR DESCRIPTION
Currently, there are two blocks (marked yellow in the first image below) that are set to be `Predicates.air()` when they are clearly outside the naq refinery. This causes the multiblock to break when a non-air block is placed there. This PR changes those blocks to have the rule `Predicates.any()`.

Those could be common spots for cables (GT power or AE2 or otherwise) which would break the multiblock for some users.
([Unless I'm the only idiot who couldn't figure it out](https://discord.com/channels/914926812948234260/1229854271613436066/1451773795462287380))

<img width="1606" height="1220" alt="image" src="https://github.com/user-attachments/assets/09729a88-3815-48e7-8303-b537a4eed225" />

<img width="1182" height="1048" alt="image" src="https://github.com/user-attachments/assets/5aa9248f-5487-4b4c-8187-87d78b00bde3" />
