### PR TITLE
Fix Better Dynamo Placement script to work on converters

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/Better_Dynamo_Placement.js
+++ b/kubejs/server_scripts/fixes_tweaks/Better_Dynamo_Placement.js
@@ -1,4 +1,7 @@
 /** Shamelessly stolen from A&B :) */
+
+const MetaMachine = Java.loadClass("com.gregtechceu.gtceu.api.machine.MetaMachine")
+
 function opposite(face) {
     if (face.equals("down"))
         return "up"
@@ -16,12 +19,9 @@ function opposite(face) {
 BlockEvents.placed(event => {
     let block = event.getBlock()
 
-    // gtceu blocks
-    if (block.getId().startsWith("gtceu:")) {
-        // Set energy converters to feToEu mode when placed
-        if (block.getId().endsWith("_energy_converter")) {
-            block.mergeEntityData({ energyContainer: { feToEu: true } })
-        }
+    // Set energy converters to feToEu mode when placed
+    if (block.getId().startsWith("gtceu:") && block.getId().endsWith("_energy_converter")) {
+        MetaMachine.getMachine(event.getLevel(), event.getBlock().pos).setFeToEu(true)
     }
 
     // Blocks below these line only get their placements altered if they were placed by an entity


### PR DESCRIPTION
Fixes the script so that Converters, when placed, are actually in FE->EU mode by default (rather than Jade lying to you)

Quite proud of this one. Thought it wasn't possible with KJS for a bit.