### PR TITLE
Change non-gas programmed circuit for ABS recipe of Ruthenium Trinium Americium Neutronate

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/rtan_balance_tweak.js
+++ b/kubejs/server_scripts/fixes_tweaks/rtan_balance_tweak.js
@@ -13,7 +13,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.alloy_blast_smelter("ruthenium_trinium_americium_neutronate")
         .itemInputs("gtceu:ruthenium_dust", "2x gtceu:trinium_dust", "gtceu:americium_dust", "2x gtceu:neutronium_dust")
         .inputFluids("gtceu:oxygen 8000")
-        .circuit(15)
+        .circuit(5)
         .outputFluids("gtceu:molten_ruthenium_trinium_americium_neutronate 864")
         .duration(225 * 20)
         .EUt(GTValues.VA[GTValues.ZPM])


### PR DESCRIPTION
The non-gas programmed circuit for the ABS recipe of Ruthenium Trinium Americium Neutronate was set to 15, which should have been 5. This causes the non-gas version to be uncraftable as the neon gas version overrides it.