### PR TITLE
Change circuit value from 11 to 12 in pyrolyse oven for phenol logs

### DIFF
--- a/kubejs/server_scripts/Early_Game.js
+++ b/kubejs/server_scripts/Early_Game.js
@@ -106,7 +106,7 @@ ServerEvents.recipes(event => {
         .itemInputs("16x #minecraft:logs_that_burn")
         .itemOutputs("2x gtceu:ash_dust")
         .outputFluids("gtceu:phenol 500")
-        .circuit(12)
+        .circuit(11)
         .duration(1280)
         .EUt(30)
 
@@ -115,7 +115,7 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:nitrogen 1000")
         .itemOutputs("2x gtceu:ash_dust")
         .outputFluids("gtceu:phenol 500")
-        .circuit(11)
+        .circuit(12)
         .duration(640)
         .EUt(30)
 


### PR DESCRIPTION
Based on issue #2430, I went and made a MR to change the value of the circuit if the recipe is intended to exist. If this is not the case please feel free to close this MR!

I saw no other circuit here use 12 so I just chose that as a +1 over the old recipe. Not sure if there are any guidelines on what number to give to a circuit in a recipe.

closes: #2430 