### PR TITLE
Raise Memory Usage Warning threshold to effectively remove warnings

### DIFF
--- a/config/alltheleaks.json
+++ b/config/alltheleaks.json
@@ -5,6 +5,6 @@
   "debugItemStackModifications": false,
   "logIntervalInMinutes": 10,
   "showSummaryOnDebugScreen": true,
-  "memoryUsageWarningPercentage": 90,
+  "memoryUsageWarningPercentage": 99,
   "debugThreadsStuck": false
 }


### PR DESCRIPTION
AllTheLeaks recently introduced a system that warns players and identifies potential leaks when memory usage crosses a certain threshold.

Given how the Java garbage collector works, it's not uncommon for players to go above 90% memory usage, especially those with lower allocated totals. This makes the warning system more annoying than helpful.

This PR raises the threshold at which warnings are issued so they occur less often.