### PR TITLE
Add circuit to Eltz EBF recipes to eliminate recipe conflict

### DIFF
--- a/kubejs/server_scripts/processing_lines/eltzline.js
+++ b/kubejs/server_scripts/processing_lines/eltzline.js
@@ -223,6 +223,7 @@ ServerEvents.recipes(event => {
             .duration(1540)
             .blastFurnaceTemp(10600)
             .EUt(GTValues.VA[GTValues.UV])
+            .circuit(1)
 
         // Gas-boosted
         event.recipes.gtceu.electric_blast_furnace(`eltz_from_${form}_gas`)
@@ -234,5 +235,6 @@ ServerEvents.recipes(event => {
             .duration(1155)
             .blastFurnaceTemp(10600)
             .EUt(GTValues.VA[GTValues.UV])
+            .circuit(2)
     })
 })


### PR DESCRIPTION
Currently, there's a recipe conflict between the gas and non-gas Eltz recipes. This conflict also causes one of the four recipes to be hidden in EMI thanks to GT auto-hiding recipes with conflicts.

This PR adds a circuit to the recipes, resolving the conflict.