### PR TITLE
Lower PSS back down to mid-EV by replacing Iridium frames with Platinum

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -894,4 +894,7 @@ ServerEvents.recipes(event => {
         .itemOutputs("7x gtceu:tantalum_pentoxide_dust")
         .duration(200)
         .EUt(GTValues.VA[GTValues.HV])
+
+    // Re-tier Palladium Substation to mid-EV, before Platline
+    event.replaceInput({ id: "gtceu:assembler/casing_palladium_substation" }, "gtceu:iridium_frame", "gtceu:platinum_frame")
 })

--- a/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
@@ -51,6 +51,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     GTMaterials.Trinium.addFlags(GTMaterialFlags.GENERATE_SPRING)
     GTMaterials.Tritanium.addFlags(GTMaterialFlags.GENERATE_SPRING)
     GTMaterials.Iridium.addFlags(GTMaterialFlags.GENERATE_DENSE)
+    GTMaterials.Platinum.addFlags(GTMaterialFlags.GENERATE_FRAME)
 
     // Small Springs for Power Transformer recipes
     GTMaterials.RedAlloy.addFlags(GTMaterialFlags.GENERATE_SPRING_SMALL)


### PR DESCRIPTION
With the second half of platline (IrOs) being moved from EV into IV at the earliest, it pushes the PSS later in progression.
This undoes that side-effect and then some, moving the PSS pre-Platline (but still in EV)

This way, both the PSS and ATs are earlier in progression than in base GT. (mid-EV and IV compared to late-EV and LuV)