### PR TITLE
Fix AE2 being unable to autocraft jetpacks from Iron Jetpacks

### DIFF
--- a/kubejs/server_scripts/mods/iron_jetpacks.js
+++ b/kubejs/server_scripts/mods/iron_jetpacks.js
@@ -126,7 +126,7 @@ ServerEvents.recipes(event => {
     ]
 
     jetpackBase.forEach(([newTier, middlePart, plate, energyCapacitor]) => {
-        event.shaped(Item.of("ironjetpacks:jetpack", `{Id:"ironjetpacks:${newTier}"}`).strongNBT(), [
+        event.shaped(Item.of("ironjetpacks:jetpack", `{Id:"ironjetpacks:${newTier}",Throttle:1.0d}`).strongNBT(), [
             "PEP",
             "PSP",
             "T T"


### PR DESCRIPTION
Fix #2434 

The recipes for the jetpacks in the `jetpackBase` list (i.e. leadstone and conductive iron) now give a `Throttle: 1.0d` nbt to the output item, which matches the item that is actually obtained as the output of the recipe and fixes AE2 not recognizing that the item it obtained is the same as the one it asked for and not completing the autocraft.