### PR TITLE
Fix jetpack quests

### DIFF
--- a/config/ftbquests/quests/chapters/progression.snbt
+++ b/config/ftbquests/quests/chapters/progression.snbt
@@ -840,6 +840,7 @@
 					}
 				}
 				type: "item"
+				weak_nbt_match: true
 			}]
 			x: 15.5d
 			y: -8.5d
@@ -868,6 +869,7 @@
 					}
 				}
 				type: "item"
+				weak_nbt_match: true
 			}]
 			x: 14.0d
 			y: -8.5d
@@ -895,6 +897,7 @@
 					}
 				}
 				type: "item"
+				weak_nbt_match: true
 			}]
 			title: "{moni.quest.7B1D349ADD9D1140.title}"
 			x: 14.0d
@@ -924,6 +927,7 @@
 					}
 				}
 				type: "item"
+				weak_nbt_match: true
 			}]
 			title: "{moni.quest.15A43AB700CADF2D.title}"
 			x: 14.0d
@@ -949,6 +953,7 @@
 					}
 				}
 				type: "item"
+				weak_nbt_match: true
 			}]
 			x: 15.5d
 			y: -7.0d
@@ -2402,6 +2407,7 @@
 					}
 				}
 				type: "item"
+				weak_nbt_match: true
 			}]
 			x: 15.5d
 			y: -5.5d

--- a/kubejs/server_scripts/mods/iron_jetpacks.js
+++ b/kubejs/server_scripts/mods/iron_jetpacks.js
@@ -213,3 +213,10 @@ ServerEvents.recipes(event => {
         D: "kubejs:pyrotheum_dust"
     }).id("kubejs:ironjetpacks/cells/resonant");
 })
+
+
+ServerEvents.tags("item", event => {
+    // Mark regular jetpacks from the ironjetpacks mod to include the NBT data when FTB Quests
+    // checks for task completion.
+    event.add("itemfilters:check_nbt", "ironjetpacks:jetpack");
+});


### PR DESCRIPTION
Because ironjetpacks only differentiates jetpacks via NBT rather than individual item IDs, acquiring any jetpack will count as completing all unlocked jetpack tasks. This pull request fixes this by adding "ironjetpacks:jetpack" to "#itemfilters:check_nbt" and turning on "Weak NBT Match" for all jetpack tasks.

This addresses https://github.com/ThePansmith/Monifactory/issues/28#issuecomment-3764199586