### PR TITLE
Fix multiplied recipes from tiered recipe generator

### DIFF
--- a/kubejs/server_scripts/gregtech/tiered_recipes.js
+++ b/kubejs/server_scripts/gregtech/tiered_recipes.js
@@ -195,6 +195,7 @@ function parseRecipe(recipe) {
             if(matters)
                 for(let matter of matters)
                     matter.amount *= by
+        duration *= by
     }
     /** @param {number} by */
     let isRecipeDivisible = by =>
@@ -202,7 +203,7 @@ function parseRecipe(recipe) {
             .filter(matters => matters)
             .every(matters => matters.every(
                 matter => matter.amount % by === 0
-            ))
+            )) && duration % by === 0
 
     /**
      * @param {() => void} cb


### PR DESCRIPTION
Currently, Complex SMD recipes can sometimes multiply input and output batch size to make up for the fact that some inputs aren't divisible by a certain factor when generating recipes.
Despite multiplying batch size, the _duration_ of the recipe wasn't multiplied, leading to modified recipes being faster than expected.

This PR fixes that.