### PR TITLE
Laser cable recipe fix

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/active_transformer.js
+++ b/kubejs/server_scripts/fixes_tweaks/active_transformer.js
@@ -37,4 +37,5 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:polytetrafluoroethylene 144")
         .itemOutputs("gtceu:normal_laser_pipe")
         .duration(100).EUt(GTValues.VA[GTValues.IV]).addMaterialInfo(true)
+        .cleanroom(CleanroomType.CLEANROOM)
 })


### PR DESCRIPTION
Removes duplicate laser pipe recipe and adds missing Cleanroom requirement to intended recipe.