### PR TITLE
Switch to using the kubejs method `.adjacentFluids`.

### DIFF
--- a/kubejs/server_scripts/gregtech/rock_cycle_simulator.js
+++ b/kubejs/server_scripts/gregtech/rock_cycle_simulator.js
@@ -47,13 +47,13 @@ ServerEvents.recipes(event => {
     RockCycle("myalite", "quark:myalite", "quark:myalite", 60)
 
     function DimensionalRockCrushing(namespace, output, EUt, dimension, waterReplacement) {
-        if(waterReplacement == undefined) waterReplacement = "minecraft:water"
+        if (waterReplacement === undefined) waterReplacement = "minecraft:water"
         event.recipes.gtceu.rock_breaker(`${output}`)
             .notConsumable(`${namespace}:${output}`)
             .itemOutputs(`${namespace}:${output}`)
             .duration(16)
             .EUt(EUt)
-            ["adjacentFluid(net.minecraft.world.level.material.Fluid[])"](["minecraft:lava", waterReplacement])
+            .adjacentFluids("minecraft:lava", waterReplacement)
             .dimension(dimension)
 
         event.recipes.gtceu.rock_cycle_simulator(`${output}`)

--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -560,7 +560,7 @@ ServerEvents.recipes(event => {
         .itemOutputs("enderio:grains_of_infinity")
         .duration(16)
         .EUt(GTValues.VA[GTValues.MV])
-        ["adjacentFluid(net.minecraft.world.level.material.Fluid[])"]("minecraft:lava", "enderio:dew_of_the_void")
+        .adjacentFluids("minecraft:lava", "enderio:dew_of_the_void")
         .posY(-64, -59)
 
     event.recipes.gtceu.rock_cycle_simulator("kubejs:rock_cycle_simulator_grains_of_infinity")

--- a/kubejs/server_scripts/mods/gregtech.js
+++ b/kubejs/server_scripts/mods/gregtech.js
@@ -96,7 +96,7 @@ ServerEvents.recipes(event => {
             .itemOutputs(stoneItem)
             .duration(16)
             .EUt(60)
-            ["adjacentFluid(net.minecraft.world.level.material.Fluid[])"]("minecraft:lava", "minecraft:water")
+            .adjacentFluids("minecraft:lava", "minecraft:water")
     }
 
     generateRockBreakerStoneRecipe("minecraft:calcite")

--- a/kubejs/server_scripts/mods/optionalCompats/create.js
+++ b/kubejs/server_scripts/mods/optionalCompats/create.js
@@ -191,7 +191,7 @@ if (Platform.isLoaded("create")) {
             return event.recipes.gtceu.rock_breaker(`kubejs:${itemName}`)
                 .notConsumable(`${modName}:${itemName}`)
                 .itemOutputs(`${modName}:${itemName}`)
-                ["adjacentFluid(net.minecraft.world.level.material.Fluid[])"]("minecraft:lava", "minecraft:water")
+                .adjacentFluids("minecraft:lava", "minecraft:water")
                 .duration(16)
                 .EUt(EUt)
         }


### PR DESCRIPTION
Previously, the code was using a deprecated java method, which was removed in 7.5.0, but the new method was introduced in 7.2.1.

This is necessary to update to 7.5.0+, but should work in earlier versions (though I've only tested against 7.5.1). This appears to be the only change required for 7.5.0, other than updating mods: (https://github.com/NegaNote/GregTech-Modern-Utilities/pull/27, https://github.com/NegaNote/MoniLabs/pull/42, https://github.com/ThePansmith/steamadditions/pull/22)