### PR TITLE
Band-aid fixing the broken platinum ore recipe

### DIFF
--- a/kubejs/server_scripts/monicoins/ores.js
+++ b/kubejs/server_scripts/monicoins/ores.js
@@ -653,8 +653,8 @@ ServerEvents.recipes(event => {
         }).noMirror().noShrink()
 
         event.shaped(Item.of("gtceu:platinum_ore", 32), [
-            "A  ",
-            "A  ",
+            " A ",
+            " A ",
             "   "
         ], {
             A: "kubejs:moni_quarter"


### PR DESCRIPTION
This is simular to #2466 and #2028.
This is another symptom of https://github.com/emilyploszaj/emi/issues/798 .

The actual crafting recipe of Platnium Ore using monicoins is different from the recipe registered in emi.
This is whats in the KJS files:
```javascript
            "A  ",
            "   ",
            "A  "
```
but in EMI, this is displayed:
<img width="354" height="242" alt="image" src="https://github.com/user-attachments/assets/82b2bda9-dbfc-4d49-ae84-8e88dc89115e" />
