### PR TITLE
Tweaks to combustion fuels' effectiveness

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/combustion_rebalancing.js
+++ b/kubejs/server_scripts/fixes_tweaks/combustion_rebalancing.js
@@ -1,0 +1,33 @@
+/**
+ * Replaces some base GregTech combustion recipes with more balanced versions.
+ * Well, "balanced" in a pack where synthetic Octane and JEAN exist.
+ */
+ServerEvents.recipes(event => {
+    // For a reference point, Gasoline is 50 ticks per mB or 1600 EU/mB.
+    // Similarly, High Octane Gasoline is 100 ticks per mB or 3200 EU/mB.
+
+    event.recipes.gtceu.combustion_generator("naphtha")
+        .inputFluids("gtceu:naphtha 1")
+        .duration(8)    // 20% less than default GT
+        .EUt(-GTValues.V[GTValues.LV])
+
+    event.recipes.gtceu.combustion_generator("biodiesel")
+        .inputFluids("gtceu:bio_diesel 1")
+        .duration(15)    // 87.5% more than default GT
+        .EUt(-GTValues.V[GTValues.LV])
+
+    event.recipes.gtceu.combustion_generator("diesel")
+        .inputFluids("gtceu:diesel 1")
+        .duration(20)    // 33% more than default GT
+        .EUt(-GTValues.V[GTValues.LV])
+
+    event.recipes.gtceu.combustion_generator("cetane_diesel")
+        .inputFluids("gtceu:cetane_boosted_diesel 1")   // -50% cost compared to default GT
+        .duration(45)
+        .EUt(-GTValues.V[GTValues.LV])
+
+    event.recipes.gtceu.combustion_generator("rocket_fuel")
+        .inputFluids("gtceu:rocket_fuel 8")   // -50% cost compared to default GT
+        .duration(125)
+        .EUt(-GTValues.V[GTValues.LV])
+})

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -143,8 +143,8 @@ ServerEvents.recipes(event => {
     event.remove({ id: "gtceu:electric_blast_furnace/blast_cryolobus" })
     event.remove({ id: "gtceu:electric_blast_furnace/blast_cryolobus_gas" })
     const cryolobusFuels = [
-        [1000, 1800, "gtceu:cetane_boosted_diesel"],
-        [800, 1800, "gtceu:gasoline"],
+        [500, 1600, "gtceu:cetane_boosted_diesel"],
+        [400, 1600, "gtceu:gasoline"],
         [250, 1200, "gtceu:high_octane_gasoline"],
         [150, 900, "gtceu:jean_gasoline"]
     ]


### PR DESCRIPTION
Boosts off-meta combustion options: Diesel, Biodiesel, CBD, and Rocket Fuel.
Also nerfs Naphtha slightly, but other fuels intended to be intermediate products are unaffected.