### PR TITLE
Rebalance remaining plasmas and add Beryllium Plasma

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/plasma_rebalance.js
+++ b/kubejs/server_scripts/fixes_tweaks/plasma_rebalance.js
@@ -1,0 +1,50 @@
+/**
+ * In Moni, some types of plasma from base GregTech: Modern are over- or under-powered.
+ * This file rebalances some of their recipes so that there's a more meaningful progression.
+ */
+
+ServerEvents.recipes(event => {
+    // Nerf Helium Plasma EU per mB to a little under half its original value
+    event.recipes.gtceu.plasma_generator("helium")
+        .inputFluids("gtceu:helium_plasma 1")
+        .outputFluids("gtceu:helium 1")
+        .EUt(-GTValues.V[GTValues.EV])
+        .duration(0.8 * 20)
+
+    // Change plasma fusion recipes to input/output multiples of 144mB for metals instead of 16mB
+    event.findRecipes({ id: /gtceu:fusion_reactor\/\w+_and_\w+_to_\w+_plasma/}).forEach(recipe => {
+        let fluidIngredients = recipe.json.getAsJsonObject("inputs").getAsJsonArray("fluid")
+        fluidIngredients.forEach(fluidIngredient => {
+            let content = fluidIngredient.getAsJsonObject("content")
+            let amount = content.getAsJsonPrimitive("amount").asInt
+            if(amount == 16) {
+                content.remove("amount")
+                content["addProperty(java.lang.String,java.lang.Number)"]("amount", 144)
+            }
+        })
+
+        let fluidOutputs = recipe.json.getAsJsonObject("outputs").getAsJsonArray("fluid")
+        fluidOutputs.forEach(fluidOutput => {
+            let content = fluidOutput.getAsJsonObject("content")
+            let amount = content.getAsJsonPrimitive("amount").asInt
+            if(amount == 16) {
+                content.remove("amount")
+                content["addProperty(java.lang.String,java.lang.Number)"]("amount", 144)
+            }
+        })
+    })
+
+    // Add Beryllium Plasma
+    event.recipes.gtceu.fusion_reactor("lithium_and_deuterium_to_beryllium_plasma")
+        .inputFluids("gtceu:lithium 144", "gtceu:deuterium 125")
+        .outputFluids("gtceu:beryllium_plasma 144")
+        .EUt(0.75 * GTValues.VA[GTValues.IV])
+        .duration(1.6 * 20)
+        .fusionStartEU(100000000)
+
+    event.recipes.gtceu.plasma_generator("beryllium")
+        .inputFluids("gtceu:beryllium_plasma 1")
+        .outputFluids("gtceu:beryllium 1")
+        .EUt(-GTValues.V[GTValues.IV])
+        .duration(0.8 * 20)
+})

--- a/kubejs/server_scripts/processing_lines/naquadah_fuels.js
+++ b/kubejs/server_scripts/processing_lines/naquadah_fuels.js
@@ -17,8 +17,8 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:hydrogen 125", "gtceu:quadium 125")
         .outputFluids("gtceu:helium_plasma 125")
         .duration(8)
-        .EUt(GTValues.VHA[GTValues.IV])
-        .fusionStartEU(20000000)
+        .EUt(GTValues.VH[GTValues.IV])
+        .fusionStartEU(160000000)
 
     // Liquid Fuel recipes
 

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -51,7 +51,7 @@ ServerEvents.recipes(event => {
     // Nerfed Ender Air distillation - less Tritium
     event.recipes.gtceu.distillation_tower("distill_liquid_ender_air")
         .inputFluids("gtceu:liquid_ender_air 200000")
-        .outputFluids("gtceu:nitrogen_dioxide 130000", "gtceu:deuterium 50000", "gtceu:helium 15000", "gtceu:tritium 2000", "gtceu:krypton 1000", "gtceu:xenon 1000", "gtceu:radon 1000")
+        .outputFluids("gtceu:nitrogen_dioxide 128000", "gtceu:deuterium 50000", "gtceu:helium 15000", "gtceu:tritium 4000", "gtceu:krypton 1000", "gtceu:xenon 1000", "gtceu:radon 1000")
         .chancedOutput("gtceu:ender_pearl_dust", 1000, 0)
         .EUt(GTValues.VA[GTValues.IV])
         .duration(100 * 20)

--- a/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
@@ -79,6 +79,10 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     addFluid(GTMaterials.Actinium, $FluidStorageKeys.LIQUID, 1324);
     GTMaterials.Americium.setMaterialSecondaryARGB(0x083946);
 
+    // Beryllium Plasma
+    let beryllium_plasma_prop = GTMaterials.Beryllium.getProperty($PropertyKey.FLUID)
+    beryllium_plasma_prop.getStorage().enqueueRegistration($FluidStorageKeys.PLASMA, new $FluidBuilder())
+
     // Liquid Sculk
     let liquid_sculk_prop = new $FluidProperty();
     liquid_sculk_prop.getStorage().enqueueRegistration($FluidStorageKeys.LIQUID, new $FluidBuilder().temperature(310).customStill())


### PR DESCRIPTION
Nerfs Helium plasma, adds Beryllium Plasma, and makes metal plasmas a lot more viable by changing fusion reactor plasma recipes to I/O metals in multiples of 144mB instead of 16mB. This may have the unintended consequence of making certain plasmas more expensive to produce at scale (e.g. Argon)

See the Google Sheet for an overview of the changes' effects on balance for power production:
https://docs.google.com/spreadsheets/d/1rbHj25fnSbCnQPCsrONB3_iDcGOpr-QDRA_WMrrqL6Y/edit?usp=sharing