### PR TITLE
Add an alternate method to produce Glycerol

### DIFF
--- a/kubejs/server_scripts/processing_lines/sculk_bioalloy.js
+++ b/kubejs/server_scripts/processing_lines/sculk_bioalloy.js
@@ -2,6 +2,17 @@
  * Sculk Bioalloy processing line
  */
 ServerEvents.recipes(event => {
+    // Auxillary production method for Glycerol
+    // IRL saponification also works, but in Moni we have no representative item for "fat" nor any use for "soap"
+    event.recipes.gtceu.large_chemical_reactor("glycerol_from_sugar_hydrogenolysis")
+        .notConsumable("gtceu:ultimet_rod")
+        .itemInputs("4x minecraft:sugar")
+        .chancedInput("gtceu:soda_ash_dust", 1000, 0)
+        .inputFluids("gtceu:hydrogen 8000", "minecraft:water 1000")
+        .outputFluids("gtceu:glycerol 4000")
+        .duration(1600)
+        .EUt(GTValues.VA[GTValues.HV])
+
     event.recipes.gtceu.mixer("experience_attuned_dust")
         .itemInputs("7x gtceu:amethyst_dust", "2x gtceu:dark_soularium_dust", "4x gtceu:lapis_dust")
         .itemOutputs("13x gtceu:experience_attuned_dust")


### PR DESCRIPTION
Glycerol for Sculk Bioalloy can be quite annoying - this adds another way to produce it beyond Biodiesel for players in a pinch.