### PR TITLE
Fixed update-mods-folder target to replace deprecated call

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -109,7 +109,7 @@ export const UpdateModsFolder = new Juke.Target({
     executes: () => {
         try {
             // Nuking mods folder before re-adding them in order to stay up to date
-            if(fs.existsSync("mods/")) fs.rmdirSync("mods/", { recursive: true })
+            if(fs.existsSync("mods/")) fs.rmSync("mods/", { recursive: true })
             fs.mkdirSync("mods/", { recursive: true })
             cpMods("mods/")
         } catch (error) {


### PR DESCRIPTION
Latest version of node seems to cause update-mods-folder to break, if anyone has an older version of node see if it works there as well!