### PR TITLE
Remove Project Red - Transmission from optional add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,9 @@ To spice up your Monifactory experience, you can add any of the following mods t
 3. [Tempad](https://www.curseforge.com/minecraft/mc-mods/tempad)
 4. [XNet](https://www.curseforge.com/minecraft/mc-mods/xnet)
 5. [Flux Networks](https://www.curseforge.com/minecraft/mc-mods/flux-networks)
-6. [Project Red: Transmission](https://www.curseforge.com/minecraft/mc-mods/project-red-transmission)
-7. [Modular Routers](https://www.curseforge.com/minecraft/mc-mods/modular-routers)
-8. [Compact Machines](https://www.curseforge.com/minecraft/mc-mods/compact-machines)
-9. [Architect's Palette](https://www.curseforge.com/minecraft/mc-mods/architects-palette)
+6. [Modular Routers](https://www.curseforge.com/minecraft/mc-mods/modular-routers)
+7. [Compact Machines](https://www.curseforge.com/minecraft/mc-mods/compact-machines)
+8. [Architect's Palette](https://www.curseforge.com/minecraft/mc-mods/architects-palette)
 
 ### Dedicated Server Installation:
 1. Download a server.zip file from the releases page.


### PR DESCRIPTION
Project Red - Transmission is now included in the project manifest.json (fileID 6868149) and so should not be suggested in the README.md list of optional add-ons.