### PR TITLE
Rebalance Turbine Rotors

### DIFF
--- a/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
@@ -135,6 +135,7 @@ GTCEuStartupEvents.materialModification(event => {
     // We keep Ingots in the material definition so we can replace it in the Ore Processing Diagram with vanilla Netherite Scrap, then remove it here.
     TagPrefix.ingot.setIgnored(GTMaterials.get("netherite_scrap"), Ingredient.of("minecraft:netherite_scrap"))
 
+    // Reduce the abnormal spike in base GTM pipe properties as progression continues
     GTMaterials.Neutronium.getProperty(PropertyKey.FLUID_PIPE).setThroughput(400)
     GTMaterials.Neutronium.getProperty(PropertyKey.FLUID_PIPE).setMaxFluidTemperature(10000)
     GTMaterials.Ultimet.getProperty(PropertyKey.ITEM_PIPE).setTransferRate(4)
@@ -154,4 +155,42 @@ GTCEuStartupEvents.materialModification(event => {
 
     // Change Fluix block to only have 4 gems instead of 9
     TagPrefix.block.modifyMaterialAmount(GTMaterials.get("fluix"), 4)
+
+    // Buff turbine durability across the board to make turbine replacement play like maintenance - rare enough to be *nearly* negligible.
+    // Preferential treatment is given to rotors with lower durability and low power or efficiency but high durability.
+    GTMaterials.Ultimet.getProperty(PropertyKey.ROTOR).setDurability(6500)              // Now 240000, Previously 113600
+    GTMaterials.Iron.getProperty(PropertyKey.ROTOR).setDurability(1650)                 // Now 98400,  Previously 28800
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setDurability(13000)          // Now 377600, Previously 149600
+    GTMaterials.Steel.getProperty(PropertyKey.ROTOR).setDurability(2750)                // Now 137600, Previously 45600
+    GTMaterials.Tritanium.getProperty(PropertyKey.ROTOR).setDurability(14350)           // Now 402400, Previously 323200
+    GTMaterials.Osmium.getProperty(PropertyKey.ROTOR).setDurability(3750)               // Now 168000, Previously 83200
+    GTMaterials.BlackBronze.getProperty(PropertyKey.ROTOR).setDurability(1900)          // Now 108000, Previously 28800
+    GTMaterials.CobaltBrass.getProperty(PropertyKey.ROTOR).setDurability(2000)          // Now 111200, Previously 28800
+    GTMaterials.Chromium.getProperty(PropertyKey.ROTOR).setDurability(2400)             // Now 125600, Previously 45600
+    GTMaterials.RoseGold.getProperty(PropertyKey.ROTOR).setDurability(1200)             // Now 80000,  Previously 20800
+    GTMaterials.Tungsten.getProperty(PropertyKey.ROTOR).setDurability(11250)            // Now 343200, Previously 131200
+    GTMaterials.VanadiumSteel.getProperty(PropertyKey.ROTOR).setDurability(8750)        // Now 292000, Previously 108800
+    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR).setDurability(4500)             // Now 188800, Previously 83200
+    GTMaterials.Brass.getProperty(PropertyKey.ROTOR).setDurability(800)                 // Now 61600,  Previously 20800
+    GTMaterials.Invar.getProperty(PropertyKey.ROTOR).setDurability(2500)                // Now 128800, Previously 45600
+    GTMaterials.RhodiumPlatedPalladium.getProperty(PropertyKey.ROTOR).setDurability(4500) // Now 188800, Previously 72000
+    GTMaterials.HSSG.getProperty(PropertyKey.ROTOR).setDurability(7800)                 // Now 270400, Previously 175200
+    GTMaterials.Manganese.getProperty(PropertyKey.ROTOR).setDurability(4000)            // Now 175200, Previously 45600
+    GTMaterials.Magnalium.getProperty(PropertyKey.ROTOR).setDurability(2250)            // Now 120000, Previously 28800
+    GTMaterials.Molybdenum.getProperty(PropertyKey.ROTOR).setDurability(4000)           // Now 175200, Previously 45600
+    GTMaterials.StainlessSteel.getProperty(PropertyKey.ROTOR).setDurability(1800)       // Now 104000, Previously 44000
+    GTMaterials.Neutronium.getProperty(PropertyKey.ROTOR).setDurability(34000)          // Now 704800, Previously 4828000. Deliberately nerfed because Neutronium is kinda nutty in several ways
+    GTMaterials.SterlingSilver.getProperty(PropertyKey.ROTOR).setDurability(1500)       // Now 92800,  Previously 24000
+    GTMaterials.HSSS.getProperty(PropertyKey.ROTOR).setDurability(4000)                 // Now 175200, Previously 145600
+    GTMaterials.Bronze.getProperty(PropertyKey.ROTOR).setDurability(1350)               // Now 86400,  Previously 24000
+    GTMaterials.HSSE.getProperty(PropertyKey.ROTOR).setDurability(6000)                 // Now 228000, Previously 205600
+    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR).setDurability(11650)       // Now 351200, Previously 205600
+    GTMaterials.Iridium.getProperty(PropertyKey.ROTOR).setDurability(11350)             // Now 345600, Previously 131200
+    GTMaterials.TungstenSteel.getProperty(PropertyKey.ROTOR).setDurability(8100)        // Now 277600, Previously 131200
+    GTMaterials.WroughtIron.getProperty(PropertyKey.ROTOR).setDurability(1750)          // Now 102400, Previously 37600
+    GTMaterials.Neodymium.getProperty(PropertyKey.ROTOR).setDurability(4000)            // Now 175200, Previously 45600
+    GTMaterials.Aluminium.getProperty(PropertyKey.ROTOR).setDurability(1000)            // Now 71200,  Previously 18400
+    GTMaterials.Titanium.getProperty(PropertyKey.ROTOR).setDurability(7350)             // Now 260000, Previously 96000
+    GTMaterials.BismuthBronze.getProperty(PropertyKey.ROTOR).setDurability(1350)        // Now 86400,  Previously 28800
+    GTMaterials.TungstenCarbide.getProperty(PropertyKey.ROTOR).setDurability(4000)      // Now 175200, Previously 83200
 })


### PR DESCRIPTION
Buffs turbine rotor durability across the board.

Objective:
Durability values should result in turbine rotor replacement playing like the maintenance mechanic: By the time your rotors start to break, the average player would have unlocked a better material to make rotors with. Exceptions should be limited to players that progress particularly slow, players that are on servers, players that poorly manage their turbines' duty cycles, and players that deliberately use rotors with lower durability values for higher efficiency or power output stats. Even then, replacing broken rotors with new ones of the same material should only happen a few times per playthrough rather than a few times per voltage tier.

The guiding principles I used to balance this are as follows:
1. Buff rotors with low base durability, low efficiency, and _especially_ rotors with low power output harder than rotors with high stats.
2. All rotors should get a net increase in durability, except Neutronium

Desmos graph used for calculations:
https://www.desmos.com/calculator/itkapmavv6