### PR TITLE
Make Germanium easier

### DIFF
--- a/kubejs/assets/gtceu/lang/en_us.json
+++ b/kubejs/assets/gtceu/lang/en_us.json
@@ -428,6 +428,7 @@
     "material.gtceu.advanced_soldering_alloy": "Advanced Soldering Alloy",
     "material.gtceu.living_solder_base": "Living Solder Base",
     "material.gtceu.living_soldering_alloy": "Living Solder",
+    "material.gtceu.silicon_germanium": "Silicon-Germanium",
     "item.gtceu.mythril_ingot": "§bMythril§r",
     "block.gtceu.shock_proof_cutting_casing": "Shock Proof Casing",
     "curios.identifier.gtceu_magnet": "Magnet",

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -807,14 +807,35 @@ ServerEvents.recipes(event => {
         .blastFurnaceTemp(1700)
         .EUt(480)
 
-    // Germanium is used in diodes
-    event.replaceInput({ output: "gtceu:diode"}, "gtceu:silicon_wafer", "gtceu:tiny_germanium_dust")
+    // Germanium can be used in diodes
+    event.recipes.gtceu.mixer("silicon_germanium_mixing")
+        .itemInputs("4x gtceu:silicon_dust", "1x gtceu:germanium_dust")
+        .itemOutputs("5x gtceu:silicon_germanium_dust")
+        .EUt(GTValues.VA[GTValues.LV])
+        .duration(10 * 20)
+
+    event.replaceInput({ output: "gtceu:diode"}, "gtceu:silicon_wafer", "gtceu:tiny_silicon_germanium_dust")
     event.recipes.gtceu.assembler("germanium_smd_diode")
-        .itemInputs("1x gtceu:small_germanium_dust", "4x gtceu:fine_platinum_wire")
+        .itemInputs("1x gtceu:small_silicon_germanium_dust", "4x gtceu:fine_platinum_wire")
         .inputFluids("gtceu:polyethylene 144")
         .itemOutputs("64x gtceu:smd_diode")
         .duration(100)
         .EUt(GTValues.VA[GTValues.HV])
+
+    // Germanium fusion
+    event.recipes.gtceu.fusion_reactor("argon_and_silicon_to_germanium")
+        .inputFluids("gtceu:argon 125", "gtceu:silicon 16")
+        .outputFluids("gtceu:germanium 16")
+        .duration(128)
+        .EUt(0.75 * GTValues.V[GTValues.LuV])
+        .fusionStartEU(220000000)
+
+    // No dust mold, sadly
+    event.recipes.gtceu.fluid_solidifier("solidify_germanium_to_dust")
+        .inputFluids("gtceu:germanium 144")
+        .itemOutputs("gtceu:germanium_dust")
+        .duration(20)
+        .EUt(GTValues.VA[GTValues.ULV])
 
     event.recipes.gtceu.fluid_solidifier("petri_dish_borosilicate")
         .notConsumable("gtceu:cylinder_casting_mold")

--- a/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
@@ -36,6 +36,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     GTMaterials.Germanium.setProperty($PropertyKey.DUST, new $DustProperty())
     GTMaterials.Germanium.setMaterialARGB(0x66806d)
     GTMaterials.Germanium.setMaterialSecondaryARGB(0x5d5e3a)
+    addFluid(GTMaterials.Germanium, $FluidStorageKeys.LIQUID, 1211);
 
     GTMaterials.Terbium.setProperty($PropertyKey.INGOT, new $IngotProperty())
     GTMaterials.Terbium.setMaterialARGB(0x8C8F7A)

--- a/kubejs/startup_scripts/gregtech_material_registry/progression_tweaks.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/progression_tweaks.js
@@ -45,4 +45,9 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .iconSet("dull")
         .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
         .components(GTMaterials.get("living_solder_base").multiply(7), GTMaterials.Meat.multiply(3))
+
+    event.create("silicon_germanium")
+        .dust()
+        .color(0x6B7873)
+        .components(GTMaterials.Silicon.multiply(4), GTMaterials.Germanium.multiply(1))
 })


### PR DESCRIPTION
This PR makes the player experience surrounding Germanium easier by adding a fusion recipe for Germanium and drastically reducing Germanium consumption for alternate Diode recipes.

The one area this PR does not change, unfortunately, is the area that it's needed the most: Coal Fly Ash line.
CFA is longer than Platline, required at nearly the same time, and its products are less useful outside of Moni-specific progression gates. Coal Fly Ash is overall a poor choice for Germanium production in its current state & location in progression. There is currently an ore available for Germanium in EV which is helpful as a workaround (and a popular choice for that reason) but I am in need of ideas on how to improve the situation.

As a side note, I can understand that fixing CFA line may make this PR redundant - if action is taken to fix CFA, I don't mind having this PR closed as it's mostly a band-aid to cover up a deeper issue.