### PR TITLE
Change Actinium to the Radioactive icon set

### DIFF
--- a/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
@@ -30,8 +30,10 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     GTMaterials.Lutetium.setProperty($PropertyKey.INGOT, new $IngotProperty())
 
     GTMaterials.Actinium.setProperty($PropertyKey.INGOT, new $IngotProperty())
-    GTMaterials.Actinium.setMaterialARGB(0xaa3399)
+    GTMaterials.Actinium.setMaterialARGB(0xa034a8)
+    GTMaterials.Actinium.setMaterialSecondaryARGB(0x1e8ccc)
     GTMaterials.Actinium.addFlags(GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_LONG_ROD, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_ROUND, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_SMALL_GEAR, GTMaterialFlags.GENERATE_SPRING, GTMaterialFlags.GENERATE_BOLT_SCREW)
+    GTMaterials.Actinium.setMaterialIconSet(GTMaterialIconSet.RADIOACTIVE)
 
     GTMaterials.Germanium.setProperty($PropertyKey.DUST, new $DustProperty())
     GTMaterials.Germanium.setMaterialARGB(0x66806d)


### PR DESCRIPTION
Changes Actinium to use the "Radioactive" material icon set. Also tweaks the primary & secondary material colors so that the combination resembles both the current color and the UHV component color.

Current:
<img width="652" height="115" alt="image" src="https://github.com/user-attachments/assets/644f3884-bd5f-4923-9007-40ad2bbbf9ea" />

Proposed:
<img width="653" height="117" alt="image" src="https://github.com/user-attachments/assets/438ce282-eee1-4f3e-9fa3-a96c8fb6a27c" />

Misplaced radioactive particles around the Spring and Plate (and the lack thereof on certain other parts) are due to an issue with the Radioactive icon set native to GTM.
