### PR TITLE
Nerf CsOH loop and make it available to all modes

### DIFF
--- a/kubejs/server_scripts/_hardmode/hardmode_processing.js
+++ b/kubejs/server_scripts/_hardmode/hardmode_processing.js
@@ -291,13 +291,6 @@ ServerEvents.recipes(event => {
             .itemOutputs("7x gtceu:naquadah_hydroxide_dust", "3x gtceu:sodium_dust")
             .duration(480).EUt(480)
 
-        event.recipes.gtceu.chemical_reactor("caesium_hydroxide")
-            .itemInputs("gtceu:caesium_dust")
-            .inputFluids("minecraft:water 1000")
-            .itemOutputs("3x gtceu:caesium_hydroxide_dust")
-            .outputFluids("gtceu:hydrogen 1000")
-            .duration(5).EUt(7)
-
         event.recipes.gtceu.large_chemical_reactor("neocryolite")
             .itemInputs("9x gtceu:caesium_hydroxide_dust", "7x gtceu:naquadah_hydroxide_dust")
             .notConsumable("gtceu:signalum_dust")

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -881,4 +881,12 @@ ServerEvents.recipes(event => {
 
     // Re-tier Palladium Substation to mid-EV, before Platline
     event.replaceInput({ id: "gtceu:assembler/casing_palladium_substation" }, "gtceu:iridium_frame", "gtceu:platinum_frame")
+
+    // recipe for Caesium Hydroxide loop
+    event.recipes.gtceu.chemical_reactor("caesium_hydroxide")
+        .itemInputs("gtceu:caesium_dust")
+        .inputFluids("minecraft:water 1000")
+        .itemOutputs("3x gtceu:caesium_hydroxide_dust")
+        .outputFluids("gtceu:hydrogen 1000")
+        .duration(20).EUt(GTValues.VA[GTValues.MV])
 })


### PR DESCRIPTION
The Caesium Hydroxide loop is a method of producing Oxygen and Hydrogen from water using the synthesis of Caesium Hydroxide from water, then electrolyzing the Caesium Hydroxide to get back Hydrogen and Oxygen and the Caesium needed to continue the loop.

It wound up being far better than intended due to a lack of attention paid when making the recipe, but is exclusive to HM and EM. This PR nerfs it to "only" be more than 2x as efficient as Sodium Hydroxide synthesis from water but available in all modes.