### PR TITLE
Add fusion recipe for Iridium

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -910,4 +910,11 @@ ServerEvents.recipes(event => {
         .itemOutputs("3x gtceu:caesium_hydroxide_dust")
         .outputFluids("gtceu:hydrogen 1000")
         .duration(20).EUt(GTValues.VA[GTValues.MV])
+
+    event.recipes.gtceu.fusion_reactor("fuse_iridium_from_tantalum_beryllium")
+        .inputFluids("gtceu:tantalum 16", "gtceu:beryllium 16")
+        .outputFluids("gtceu:iridium 16")
+        .duration(64)
+        .EUt(0.75 * GTValues.V[GTValues.LuV])
+        .fusionStartEU(300000000)
 })


### PR DESCRIPTION
Recipe uses Tantalum and Beryllium.

If the recipe is left unused, switch to a cheaper option from the original poll: https://discord.com/channels/914926812948234260/1229929078547550238/1492714110943494196
If this results in the Ir/Os ores on Glacio becoming useless, consider buffing them to be layered veins instead of veiny veins.

If neither of the above occurs, good.