### PR TITLE
Force upright Greenhouses

### DIFF
--- a/kubejs/startup_scripts/registry/multiblock_registry.js
+++ b/kubejs/startup_scripts/registry/multiblock_registry.js
@@ -288,6 +288,7 @@ GTCEuStartupEvents.registry("gtceu:machine", event => {
     // Greenhouse
     event.create("greenhouse", "multiblock")
         .rotationState(RotationState.NON_Y_AXIS)
+        .allowExtendedFacing(false)
         .recipeTypes("greenhouse")
         .appearanceBlock(GTBlocks.CASING_STEEL_SOLID)
         .recipeModifiers([GTRecipeModifiers.OC_NON_PERFECT, GTRecipeModifiers.BATCH_MODE])


### PR DESCRIPTION
Currently, Greenhouses have a render that grow crops atop the dirt blocks, but can be rotated any which way. This results in the renders sometimes creating unexpected or unrealistic visuals.
<img width="658" height="586" alt="image" src="https://github.com/user-attachments/assets/6bf0c5b2-5726-40cb-b4b5-7bcb61a9e8a1" />
This PR forces Greenhouses to form upright like Distillation towers to ensure the renders are always visible on the inside of the greenhouse and grow upwards from the dirt, just like real greenhouses.
