### PR TITLE
Fix mod path error in build-dev

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -195,7 +195,7 @@ export const BuildDevTarget = getZipModPackTarget("dev", PackSwitchTarget => [
 
                 fs.mkdirSync("dist/dev/overrides", { recursive: true })
                 cpMods("dist/.devtmp")
-                fs.cpSync("mods", "dist/.devtmp", { recursive: true })
+                fs.cpSync("../mods", "dist/.devtmp", { recursive: true })
                 return
             }
 
@@ -206,7 +206,7 @@ export const BuildDevTarget = getZipModPackTarget("dev", PackSwitchTarget => [
 
             // "merge" both mod folders
             cpMods("dist/.devtmp")
-            fs.cpSync("mods", "dist/.devtmp", { recursive: true, force: true })
+            fs.cpSync("../mods", "dist/.devtmp", { recursive: true, force: true })
             symlinkSync(resolve("dist/.devtmp"), resolve("dist/dev/overrides/mods"))
             // fs.cpSync('dist/.devtmp', 'dist/dev/mods', { recursive: true });
             fs.cpSync("config", "dist/dev/overrides/config", { recursive: true })


### PR DESCRIPTION
The build script referenced just `mods`, when it needed to be `../mods` to get the mod dir from the root of the repo.
This fixes the error when running the `build-dev` target:
```
:: Skipping 'build-modlist' (up to date)
=> Starting 'group-dev-files'
:: Only updating mods as dist/dev exists
=> Target 'group-dev-files' failed in 0.011s, unhandled exception:
Error: ENOENT: no such file or directory, lstat 'mods'
    at cpSyncFn (node:internal/fs/cp/cp-sync:56:13)
    at Object.cpSync (node:fs:3131:3)
    at Target.executes (file:///home/drake/dev/MoniLive/build/index.ts:198:20)
    at Worker.process (/home/drake/dev/MoniLive/build/node_modules/juke-build/dist/index.js:5006:27) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: 'mods'
}
=> Target 'build-dev' failed
```
