### PR TITLE
Remove remaining Ir/Os requirements from GCyM multiblocks

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -903,6 +903,11 @@ ServerEvents.recipes(event => {
     // Re-tier Palladium Substation to mid-EV, before Platline
     event.replaceInput({ id: "gtceu:assembler/casing_palladium_substation" }, "gtceu:iridium_frame", "gtceu:platinum_frame")
 
+    // Re-tier the Gregicality multiblocks of IV to be after platline Pt1, but before platline pt2
+    event.replaceInput({ id: "gtceu:shaped/large_distillery"}, "gtceu:iridium_large_fluid_pipe", "gtceu:tungsten_carbide_large_fluid_pipe")
+    event.replaceInput({ id: "gtceu:shaped/large_mixer"}, "gtceu:osmiridium_rotor", "gtceu:rhodium_plated_palladium_rotor")
+    event.replaceInput({ id: "gtceu:shaped/large_electromagnet"}, "gtceu:osmium_quadruple_wire", "gtceu:niobium_nitride_quadruple_wire")
+
     // recipe for Caesium Hydroxide loop
     event.recipes.gtceu.chemical_reactor("caesium_hydroxide")
         .itemInputs("gtceu:caesium_dust")

--- a/kubejs/startup_scripts/gregtech_crafting_components.js
+++ b/kubejs/startup_scripts/gregtech_crafting_components.js
@@ -9,9 +9,10 @@ GTCEuStartupEvents.craftingComponents(event => {
         UEV: "kubejs:extradimensional_processor_mainframe"
     })
 
-    // Make LuV+ electrolyzer wires not osmium for funsies :)
+    // Make IV+ electrolyzer wires not all osmium for funsies :)
     event.setMaterialEntries("wire_single", {
-        LuV: "wireGtSingle:vanadium_gallium",
+        IV: "wireGtSingle:neptunium_palladium_aluminium",
+        LuV: "wireGtSingle:osmium",
         ZPM: "wireGtSingle:naquadah_alloy",
         UV: "wireGtSingle:cryococcus",
         UHV: "wireGtSingle:omnium",


### PR DESCRIPTION
After platline was split in two parts, the primary concern since has been the GCyM machines that are locked behind LuV:
Large Mixer
Large Fractionating Distillery
Large Electrolysis Chamber
Large Electromagnet

This PR removes all Iridium and Osmium requirements to craft these machines so that they are unlocked at the same point as before the platline split, in IV.