### PR TITLE
Remove Glue tiered recipe generation in favor of one conversion recipe

### DIFF
--- a/kubejs/server_scripts/gregtech/PECA.js
+++ b/kubejs/server_scripts/gregtech/PECA.js
@@ -137,4 +137,12 @@ ServerEvents.recipes(event => {
         .itemOutputs("4x gtceu:petri_dish")
         .duration(0.5 * 20)
         .EUt(GTValues.VA[GTValues.HV])
+
+    // Glue from ECA
+    event.recipes.gtceu.mixer("glue_from_ethyl_cyanoacrylate")
+        .inputFluids("gtceu:ethyl_cyanoacrylate 2000")
+        .itemInputs("gtceu:small_silicon_dioxide_dust")
+        .outputFluids("gtceu:glue 10000")
+        .duration(3 * 20)
+        .EUt(GTValues.VA[GTValues.ULV])
 })

--- a/kubejs/server_scripts/gregtech/tiered_recipes.js
+++ b/kubejs/server_scripts/gregtech/tiered_recipes.js
@@ -384,43 +384,6 @@ function generateAlternatives(event, javaRecipe) {
         r.register(event, recipeName + "/complex_smd", machineName)
     }
 
-    // Ethyl Cyanoacrylate is Krazy Glue
-    if(recipe.inputs?.fluid && recipe.inputs.fluid.some(i =>
-        i.content.value.some(v => "tag" in v
-            ? v.tag === "forge:glue"
-            : v.fluid === "gtceu:glue"
-        )
-    )) {
-        let r1 = parseRecipe(recipe)
-        r1.useMultiplier(() => {
-            // Replace all old solder with better one
-            for (let inp of r1.newInputFluids) {
-                if (inp.id !== "gtceu:glue") continue
-                inp.id = "gtceu:epoxy"
-                inp.amount *= (1 / 5)
-            }
-        }, 4, 2)
-        r1.register(
-            event,
-            recipeName + "/epoxy",
-            machineName,
-        )
-        let r2 = parseRecipe(recipe)
-        r2.useMultiplier(() => {
-            // Replace all old solder with better one
-            for (let inp of r2.newInputFluids) {
-                if (inp.id !== "gtceu:glue") continue
-                inp.id = "gtceu:ethyl_cyanoacrylate"
-                inp.amount *= (1 / 25)
-            }
-        }, 4, 2)
-        r2.register(
-            event,
-            recipeName + "/krazy_glue",
-            machineName,
-        )
-    }
-
     // Oxalic Acid etchant
     if(recipe.inputs?.fluid && recipe.inputs.fluid.some(i =>
         i.content.value.some(v => "tag" in v


### PR DESCRIPTION
For the most part, Glue becomes obsolete by the time Epoxy or PECA is made. For the remaining uses, there exists the recipe that uses Polyvinyl Acetate and Methyl Acetate -  the tiered recipe generation is simply bloat.

This removes the tiered recipe generation and replaces it with one Ethyl Cyanoacrylate -> Glue recipe to keep the nod to IRL applications without having so much recipe bloat.