### PR TITLE
Tweak Microminer kit recipes

### DIFF
--- a/kubejs/server_scripts/microverse/components.js
+++ b/kubejs/server_scripts/microverse/components.js
@@ -248,7 +248,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.assembler("basic_drilling_kit")
         .itemOutputs("kubejs:basic_drilling_kit")
         .itemInputs("3x gtceu:double_steel_plate", "gtceu:mv_electric_motor", "2x #gtceu:circuits/lv", "2x minecraft:glass")
-        .inputFluids("gtceu:glue 200")
+        .inputFluids("gtceu:lubricant 20")
         .EUt(GTValues.VA[GTValues.HV])
         .duration(300)
 
@@ -276,8 +276,7 @@ ServerEvents.recipes(event => {
     explosives.forEach(explosive => {
         event.recipes.gtceu.assembler(`blasting_kit_${explosive[2]}`)
             .itemOutputs("kubejs:blasting_kit")
-            .itemInputs("3x gtceu:double_black_steel_plate", `${explosive[0]}x ${explosive[1]}:${explosive[2]}`, "3x #gtceu:circuits/lv", "2x #enderio:fused_quartz")
-            .inputFluids("gtceu:reinforced_epoxy_resin 576")
+            .itemInputs("3x gtceu:double_black_steel_plate", `${explosive[0]}x ${explosive[1]}:${explosive[2]}`, "3x #gtceu:circuits/lv", "2x gtceu:reinforced_epoxy_resin_plate", "2x #enderio:fused_quartz")
             .EUt(GTValues.VA[GTValues.EV])
             .duration(400)
     })


### PR DESCRIPTION
This PR changes the recipe for Microminer kits in two ways:

1. Replace liquid Reinforced Epoxy Resin with Reinforced Epoxy Resin plates. This actually saves players an Extractor recipe, since the liquid form can only be made via the plates anyways. It also costs less Reinforced Epoxy Resin.
2. Replace Glue in the Basic Drilling Kit with Lubricant. With Glue being almost useless outside of this one use at this point in progression, removing it from the recipe will allow players to get rid of their Glue production.