### PR TITLE
Tweaks to AE2 recipes

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -1,5 +1,5 @@
 /**
- * Custom recipes for AE2
+ * Custom recipes for AE2 & addons
  */
 ServerEvents.recipes(event => {
 
@@ -133,12 +133,13 @@ ServerEvents.recipes(event => {
     event.shaped(Item.of("merequester:requester"), [
         "ABA",
         "CDC",
-        "AAA"
+        "AFA"
     ], {
         A: "gtceu:rhodium_plated_palladium_plate",
         B: "gtceu:luv_robot_arm",
         C: "#gtceu:circuits/zpm",
         D: "gtceu:luv_machine_hull",
+        F: "gtceu:fluix_plate"
     }).id("kubejs:ae2/requster")
 
     // Quantum Ring
@@ -235,17 +236,19 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:distilled_water 100")
         .itemOutputs("ae2:charged_certus_quartz_crystal")
         .duration(20)
-        .EUt(480)
+        .EUt(GTValues.VA[GTValues.HV])
 
     // Matter Condenser
     event.remove({ id: "ae2:network/blocks/io_condenser" })
     event.shaped(Item.of("ae2:condenser"), [
-        "AAA",
-        "ABA",
-        "AAA"
+        "APA",
+        "FBF",
+        "APA"
     ], {
-        A: "gtceu:titanium_plate",
-        B: "gtceu:quantum_star"
+        A: "gtceu:double_titanium_plate",
+        B: "gtceu:quantum_star",
+        F: "gtceu:fluix_plate",
+        P :"gtceu:mv_field_generator"
     }).id("kubejs:ae2/matter_condensor")
 
     // Storage Components
@@ -309,7 +312,7 @@ ServerEvents.recipes(event => {
             )
             .inputFluids(Fluid.of(curIngredients[3], 144 * curIngredients[4]))
             .itemOutputs(curTier)
-            .EUt(240)
+            .EUt(GTValues.VHA[GTValues.HV])
             .duration(200)
             .cleanroom(CleanroomType.CLEANROOM)
     }
@@ -533,7 +536,7 @@ ServerEvents.recipes(event => {
         .itemInputs("gtceu:steel_bolt")
         .itemOutputs("2x ae2:cable_anchor")
         .duration(20)
-        .EUt(16)
+        .EUt(GTValues.VHA[GTValues.LV])
 
     // Cables
     event.remove({ id: "ae2:network/parts/quartz_fiber_part" })
@@ -544,14 +547,14 @@ ServerEvents.recipes(event => {
         .itemInputs("ae2:certus_quartz_crystal")
         .itemOutputs("ae2:quartz_fiber")
         .duration(50)
-        .EUt(16)
+        .EUt(GTValues.VHA[GTValues.LV])
         .addMaterialInfo(true)
 
     event.recipes.gtceu.alloy_smelter("kubejs:ae2/fluix_cable")
         .itemInputs(["ae2:fluix_dust", "ae2:quartz_fiber"])
         .itemOutputs("2x ae2:fluix_glass_cable")
         .duration(50)
-        .EUt(16)
+        .EUt(GTValues.VHA[GTValues.LV])
         .addMaterialInfo(true)
 
 
@@ -568,14 +571,14 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:distilled_water 100")
         .itemOutputs("ae2:flawless_budding_quartz")
         .duration(20)
-        .EUt(480)
+        .EUt(GTValues.VA[GTValues.HV])
 
     event.recipes.gtceu.mixer("fluix")
         .itemInputs("ae2:charged_certus_quartz_crystal", "minecraft:redstone", "minecraft:quartz")
         .inputFluids(Fluid.of("minecraft:water", 100))
         .itemOutputs("2x ae2:fluix_crystal")
         .duration(20)
-        .EUt(7)
+        .EUt(GTValues.VA[GTValues.ULV])
         .circuit(3)
 
     event.recipes.gtceu.compressor("fluix_plate")
@@ -669,7 +672,7 @@ ServerEvents.recipes(event => {
             .notConsumable(lens)
             .itemOutputs(press)
             .duration(1600)
-            .EUt(120)
+            .EUt(GTValues.VA[GTValues.MV])
     }
 
     pressengrave("kubejs:ae2/engineering_processor_press", "ae2:engineering_processor_press", "#forge:lenses/red");
@@ -685,7 +688,7 @@ ServerEvents.recipes(event => {
         .notConsumable("#forge:lenses/magenta")
         .itemOutputs("megacells:accumulation_processor_press")
         .duration(1600)
-        .EUt(240)
+        .EUt(GTValues.VHA[GTValues.HV])
         .cleanroom(CleanroomType.CLEANROOM)
 
     event.remove({ id: "megacells:inscriber/accumulation_processor_print" })
@@ -752,7 +755,7 @@ ServerEvents.recipes(event => {
         .itemInputs("4x gtceu:stainless_steel_plate", "8x gtceu:aluminium_plate", "gtceu:mv_emitter", "gtceu:mv_sensor", "2x #gtceu:circuits/mv")
         .inputFluids("gtceu:soldering_alloy 144")
         .itemOutputs("8x megacells:cell_dock")
-        .EUt(240)
+        .EUt(GTValues.VHA[GTValues.HV])
         .duration(200)
 
     event.remove({ id: "megacells:crafting/mega_crafting_unit" })
@@ -836,7 +839,7 @@ ServerEvents.recipes(event => {
                 .itemInputs("4x " + wafer[0] + wafer[1])
                 .itemOutputs(Item.of("ae2:printed_silicon", 4 * (2 ** tier)))
                 .duration(10)
-                .EUt(2048)
+                .EUt(GTValues.VA[GTValues.EV])
         })
     } else {
         event.recipes.gtceu.forming_press("ae2_printed_silicon_greg")
@@ -844,61 +847,40 @@ ServerEvents.recipes(event => {
             .itemInputs("4x ae2:silicon")
             .itemOutputs("4x ae2:printed_silicon")
             .duration(10)
-            .EUt(2048)
+            .EUt(GTValues.VA[GTValues.EV])
     }
 
-    event.recipes.gtceu.forming_press("ae2_printed_engineering_greg")
-        .notConsumable("ae2:engineering_processor_press")
-        .itemInputs("4x minecraft:diamond")
-        .itemOutputs("4x ae2:printed_engineering_processor")
-        .duration(10)
-        .EUt(2048)
+    // Processors
+    const processor_info = [
+        {type: "engineering", material:"minecraft:diamond"},
+        {type: "logic", material:"minecraft:gold_ingot"},
+        {type: "calculation", material:"ae2:certus_quartz_crystal"},
+    ]
 
-    event.recipes.gtceu.forming_press("ae2_printed_logic_greg")
-        .notConsumable("ae2:logic_processor_press")
-        .itemInputs("4x minecraft:gold_ingot")
-        .itemOutputs("4x ae2:printed_logic_processor")
-        .duration(10)
-        .EUt(2048)
+    processor_info.forEach(processorType => {
+        event.recipes.gtceu.forming_press(`ae2_printed_${processorType.type}_greg`)
+            .notConsumable(`ae2:${processorType.type}_processor_press`)
+            .itemInputs(Item.of(processorType.material, 4))
+            .itemOutputs(`4x ae2:printed_${processorType.type}_processor`)
+            .duration(10)
+            .EUt(GTValues.VA[GTValues.EV])
 
-    event.recipes.gtceu.forming_press("ae2_printed_calcuation_greg")
-        .notConsumable("ae2:calculation_processor_press")
-        .itemInputs("4x ae2:certus_quartz_crystal")
-        .itemOutputs("4x ae2:printed_calculation_processor")
-        .duration(10)
-        .EUt(2048)
+        event.recipes.gtceu.circuit_assembler(`ae2_${processorType.type}_processor_greg`)
+            .itemInputs(`ae2:printed_${processorType.type}_processor`, "ae2:printed_silicon", "#gtceu:circuits/lv")
+            .inputFluids("gtceu:redstone 72")
+            .itemOutputs(`2x ae2:${processorType.type}_processor`)
+            .duration(50)
+            .EUt(2560)
+            .cleanroom(CleanroomType.CLEANROOM)
+    })
 
+    // Accumulation processor done separately
     event.recipes.gtceu.forming_press("mega_printed_accumulation_greg")
         .notConsumable("megacells:accumulation_processor_press")
         .itemInputs("4x gtceu:black_steel_plate")
         .itemOutputs("4x megacells:printed_accumulation_processor")
         .duration(10)
-        .EUt(2048)
-
-    // Processors
-    event.recipes.gtceu.circuit_assembler("ae2_engineering_processor_greg")
-        .itemInputs("ae2:printed_engineering_processor", "ae2:printed_silicon", "#gtceu:circuits/lv")
-        .inputFluids("gtceu:redstone 72")
-        .itemOutputs("2x ae2:engineering_processor")
-        .duration(50)
-        .EUt(2560)
-        .cleanroom(CleanroomType.CLEANROOM)
-
-    event.recipes.gtceu.circuit_assembler("ae2_logic_processor_greg")
-        .itemInputs("ae2:printed_logic_processor", "ae2:printed_silicon", "#gtceu:circuits/lv")
-        .inputFluids("gtceu:redstone 72")
-        .itemOutputs("2x ae2:logic_processor")
-        .duration(50)
-        .EUt(2560)
-        .cleanroom(CleanroomType.CLEANROOM)
-
-    event.recipes.gtceu.circuit_assembler("ae2_calculation_processor_greg")
-        .itemInputs("ae2:printed_calculation_processor", "ae2:printed_silicon", "#gtceu:circuits/lv")
-        .inputFluids("gtceu:redstone 72")
-        .itemOutputs("2x ae2:calculation_processor")
-        .duration(50)
-        .EUt(2560)
-        .cleanroom(CleanroomType.CLEANROOM)
+        .EUt(GTValues.VA[GTValues.EV])
 
     event.recipes.gtceu.circuit_assembler("mega_accumulation_processor_greg")
         .itemInputs("megacells:printed_accumulation_processor", "ae2:printed_silicon", "#gtceu:circuits/hv")
@@ -907,7 +889,8 @@ ServerEvents.recipes(event => {
         .duration(100)
         .EUt(2560)
         .cleanroom(CleanroomType.CLEANROOM)
-    // ExtendedAE
+
+    /** ExtendedAE **/
 
     // Pattern Modifier (NAE2's Pattern Multitool)
     event.remove({ id: "expatternprovider:pattern_modifier" })
@@ -919,7 +902,7 @@ ServerEvents.recipes(event => {
         .itemInputs("2x ae2:pattern_provider", "2x ae2:capacity_card", "4x gtceu:aluminium_plate")
         .itemOutputs("expatternprovider:ex_pattern_provider")
         .duration(180)
-        .EUt(128)
+        .EUt(GTValues.VA[GTValues.MV])
         .circuit(4)
 
     event.remove({ id: "expatternprovider:epp_upgrade" })
@@ -927,7 +910,7 @@ ServerEvents.recipes(event => {
         .itemInputs("ae2:pattern_provider", "2x ae2:capacity_card", "4x gtceu:aluminium_plate")
         .itemOutputs("expatternprovider:pattern_provider_upgrade")
         .duration(180)
-        .EUt(128)
+        .EUt(GTValues.VA[GTValues.MV])
         .circuit(3)
 
     // Extended Interface
@@ -936,7 +919,7 @@ ServerEvents.recipes(event => {
         .itemInputs("2x ae2:interface", "2x ae2:capacity_card", "4x gtceu:aluminium_plate")
         .itemOutputs("expatternprovider:ex_interface")
         .duration(180)
-        .EUt(128)
+        .EUt(GTValues.VA[GTValues.MV])
         .circuit(4)
 
     event.remove({ id: "expatternprovider:ei_upgrade" })
@@ -944,7 +927,7 @@ ServerEvents.recipes(event => {
         .itemInputs("ae2:interface", "2x ae2:capacity_card", "4x gtceu:aluminium_plate")
         .itemOutputs("expatternprovider:interface_upgrade")
         .duration(180)
-        .EUt(128)
+        .EUt(GTValues.VA[GTValues.MV])
         .circuit(3)
 
     // Oversize Interface
@@ -953,7 +936,7 @@ ServerEvents.recipes(event => {
         .itemInputs("8x expatternprovider:ex_interface", "8x ae2:capacity_card", "8x gtceu:stainless_steel_plate")
         .itemOutputs("expatternprovider:oversize_interface")
         .duration(240)
-        .EUt(512)
+        .EUt(GTValues.VA[GTValues.HV])
 
     // Extended MA
     event.remove({ id: "expatternprovider:ex_molecular_assembler" })
@@ -961,7 +944,7 @@ ServerEvents.recipes(event => {
         .itemInputs("8x ae2:molecular_assembler", "8x gtceu:fluix_plate", "8x ae2:capacity_card")
         .itemOutputs("expatternprovider:ex_molecular_assembler")
         .duration(240)
-        .EUt(512)
+        .EUt(GTValues.VA[GTValues.HV])
 
     // Extended Inscriber
     event.remove({ id: "expatternprovider:ex_inscriber" })
@@ -969,7 +952,7 @@ ServerEvents.recipes(event => {
         .itemInputs("4x ae2:inscriber", "2x ae2:capacity_card")
         .itemOutputs("expatternprovider:ex_inscriber")
         .duration(180)
-        .EUt(32)
+        .EUt(GTValues.VA[GTValues.LV])
 
     // Extended Charger
     event.remove({ id: "expatternprovider:ex_charger" })
@@ -977,7 +960,7 @@ ServerEvents.recipes(event => {
         .itemInputs("4x ae2:charger", "2x ae2:capacity_card")
         .itemOutputs("expatternprovider:ex_charger")
         .duration(180)
-        .EUt(32)
+        .EUt(GTValues.VA[GTValues.LV])
 
     // Tag storage bus
     event.remove({ id: "expatternprovider:tag_storage_bus" })
@@ -985,7 +968,7 @@ ServerEvents.recipes(event => {
         .itemInputs("ae2:storage_bus", "2x gtceu:aluminium_plate", "ae2:logic_processor")
         .itemOutputs("expatternprovider:tag_storage_bus")
         .duration(180)
-        .EUt(32)
+        .EUt(GTValues.VA[GTValues.LV])
 
     // Mod storage bus
     event.remove({ id: "expatternprovider:mod_storage_bus" })
@@ -993,7 +976,7 @@ ServerEvents.recipes(event => {
         .itemInputs("ae2:storage_bus", "2x gtceu:aluminium_plate", "ae2:calculation_processor")
         .itemOutputs("expatternprovider:mod_storage_bus")
         .duration(180)
-        .EUt(32)
+        .EUt(GTValues.VA[GTValues.LV])
 
     // Extended Pattern Access Terminal
     // Note that the terminal doesn't have a fullblock version.
@@ -1019,7 +1002,7 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:polyethylene 288")
         .itemOutputs("4x expatternprovider:assembler_matrix_frame")
         .duration(150)
-        .EUt(1920)
+        .EUt(GTValues.VA[GTValues.EV])
         .addMaterialInfo(true)
 
     // Assembler Matrix Wall
@@ -1029,7 +1012,7 @@ ServerEvents.recipes(event => {
         .itemOutputs("expatternprovider:assembler_matrix_wall")
         .circuit(1)
         .duration(100)
-        .EUt(1920)
+        .EUt(GTValues.VA[GTValues.EV])
         .addMaterialInfo(true)
 
     // Assembler Matrix Glass
@@ -1039,7 +1022,7 @@ ServerEvents.recipes(event => {
         .itemOutputs("expatternprovider:assembler_matrix_glass")
         .circuit(2)
         .duration(100)
-        .EUt(1920)
+        .EUt(GTValues.VA[GTValues.EV])
         .addMaterialInfo(true)
 
     // Assembler Matrix Pattern Core
@@ -1049,7 +1032,7 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:polyethylene 288")
         .itemOutputs("expatternprovider:assembler_matrix_pattern")
         .duration(150)
-        .EUt(1920)
+        .EUt(GTValues.VA[GTValues.EV])
         .addMaterialInfo(true)
 
     // Assembler Matrix Craft Core
@@ -1059,7 +1042,7 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:polyethylene 288")
         .itemOutputs("expatternprovider:assembler_matrix_crafter")
         .duration(150)
-        .EUt(1920)
+        .EUt(GTValues.VA[GTValues.EV])
         .addMaterialInfo(true)
 
     // Assembler Matrix Speed Core
@@ -1069,7 +1052,7 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:polyethylene 288")
         .itemOutputs("expatternprovider:assembler_matrix_speed")
         .duration(150)
-        .EUt(1920)
+        .EUt(GTValues.VA[GTValues.EV])
         .addMaterialInfo(true)
 
     // Misc stuff
@@ -1091,7 +1074,7 @@ ServerEvents.recipes(event => {
         .itemInputs("2x ae2:drive", "4x gtceu:fluix_plate", "ae2:capacity_card")
         .itemOutputs("expatternprovider:ex_drive")
         .duration(240)
-        .EUt(128)
+        .EUt(GTValues.VA[GTValues.MV])
         .circuit(4)
 
     event.remove({ id: "expatternprovider:ex_drive_upgrade" })
@@ -1099,7 +1082,7 @@ ServerEvents.recipes(event => {
         .itemInputs("1x ae2:drive", "4x gtceu:fluix_plate", "ae2:capacity_card")
         .itemOutputs("expatternprovider:drive_upgrade")
         .duration(240)
-        .EUt(128)
+        .EUt(GTValues.VA[GTValues.MV])
         .circuit(3)
 
     // Quantum Bridge Card

--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -585,7 +585,7 @@ ServerEvents.recipes(event => {
         .itemInputs("ae2:fluix_dust")
         .itemOutputs("gtceu:fluix_plate")
         .duration(400)
-        .EUt(2)
+        .EUt(0.25 * GTValues.V[GTValues.ULV])
 
     // Cable Recipes
     event.remove({ id: "ae2:network/cables/covered_fluix" })
@@ -870,7 +870,7 @@ ServerEvents.recipes(event => {
             .inputFluids("gtceu:redstone 72")
             .itemOutputs(`2x ae2:${processorType.type}_processor`)
             .duration(50)
-            .EUt(2560)
+            .EUt(1.25 * GTValues.V[GTValues.EV])
             .cleanroom(CleanroomType.CLEANROOM)
     })
 
@@ -887,7 +887,7 @@ ServerEvents.recipes(event => {
         .inputFluids("gtceu:indium_gallium_phosphide 36")
         .itemOutputs("2x megacells:accumulation_processor")
         .duration(100)
-        .EUt(2560)
+        .EUt(1.25 * GTValues.V[GTValues.EV])
         .cleanroom(CleanroomType.CLEANROOM)
 
     /** ExtendedAE **/


### PR DESCRIPTION
This PR does 3 things:
1. Tweak Requester and Matter Condenser recipes, adding a Fluix plate to the former and making the latter more interesting.
2. Change gregified AE2 Processor recipes definitions to better adhere to the DRY principle
3. Change most 'magic numbers' for power in the AE2 recipe file to use energy constants from GTValues.