### PR TITLE
Nuke NCN moderators

### DIFF
--- a/kubejs/server_scripts/mods/NuclearCraft.js
+++ b/kubejs/server_scripts/mods/NuclearCraft.js
@@ -104,16 +104,6 @@ ServerEvents.recipes(event => {
             .addMaterialInfo(true)
     }
 
-    function canmod(name, input) {
-        event.remove({ output: `nuclearcraft:${name}_block` })
-        event.recipes.gtceu.canner(`${name}_heat_sink`)
-            .itemInputs("nuclearcraft:empty_heat_sink", `9x ${input}`)
-            .itemOutputs(`nuclearcraft:${name}_block`)
-            .duration(400)
-            .EUt(2)
-            .addMaterialInfo(true)
-    }
-
     canfluid("water", "minecraft:water")
     cansolid("redstone", "minecraft:redstone")
     cansolid("quartz", "gtceu:nether_quartz_dust")
@@ -129,8 +119,6 @@ ServerEvents.recipes(event => {
     cansolid("tin", "gtceu:tin_dust")
     cansolid("aluminum", "gtceu:aluminium_dust")
     cansolid("manganese", "gtceu:manganese_dust")
-    canmod("graphite", "gtceu:graphite_dust")
-    canmod("beryllium", "gtceu:beryllium_dust")
 
     event.remove({ id: "nuclearcraft:empty_heat_sink" })
     event.recipes.gtceu.shaped("nuclearcraft:empty_heat_sink", [

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -435,6 +435,9 @@ global.itemNukeList = [
     "nuclearcraft:empty_active_heat_sink",
     /^nuclearcraft:active_[\w_]+_heat_sink$/,
 
+    "nuclearcraft:graphite_block",
+    "nuclearcraft:beryllium_block",
+
     "nuclearcraft:heat_exchanger",
 
     // Nuclearcraft Machines


### PR DESCRIPTION
I'm aware that NCN is set to be gotten rid of in favor of Phoenix Fission, but I've found evidence to suggest that some of NCN's spontaneous reactor explosions are the result of moderator heat calculations changing for some unknown reason.

Thus, for those who don't intend to migrate to Phoenix Fission for any reason, this PR removes moderators so players don't stumble into that issue.