### PR TITLE
Fix LV Age trophy accent to distinguish from ZPM Age

### DIFF
--- a/kubejs/data/monifactory/trofers/steel.json
+++ b/kubejs/data/monifactory/trofers/steel.json
@@ -26,6 +26,6 @@
     },
     "colors": {
         "base": "#6B8F85",
-        "accent": "#1e2420"
+        "accent": "#7A7A7A"
     }
 }


### PR DESCRIPTION
Changes the accent color of LV trophies to be a brighter grey. Currently the color is nearly black, making it indistinguishable from the ZPM trophy by accent color alone. This is visible in the trophy wall on the IM run.

The two trophies side-by-side without the PR applied:
<img width="586" height="389" alt="image" src="https://github.com/user-attachments/assets/3ba4027f-fb61-4662-8720-2e15f1452c44" />

With the PR applied:
<img width="606" height="462" alt="image" src="https://github.com/user-attachments/assets/c90a2a2c-fa53-48fe-a38c-6a377ab6404f" />
