### PR TITLE
Remove Chisels And Bits.

### DIFF
--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -46,9 +46,6 @@ global.itemNukeList = [
     // CBMultipart
     /cb_microblock:.*/,
 
-    // Chisels & Bits
-    "chiselsandbits:block_bit",
-
     // EnderIO
     "enderio:alloy_smelter",
     "enderio:clayed_glowstone",

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -46,6 +46,9 @@ global.itemNukeList = [
     // CBMultipart
     /cb_microblock:.*/,
 
+    // Chisels & Bits
+    "chiselsandbits:block_bit",
+
     // EnderIO
     "enderio:alloy_smelter",
     "enderio:clayed_glowstone",

--- a/manifest.json
+++ b/manifest.json
@@ -381,11 +381,6 @@
       "required": true
     },
     {
-      "fileID": 7422964,
-      "projectID": 231095,
-      "required": true
-    },
-    {
       "fileID": 4774651,
       "projectID": 912099,
       "required": true

--- a/manifest.json
+++ b/manifest.json
@@ -381,6 +381,11 @@
       "required": true
     },
     {
+      "fileID": 7422964,
+      "projectID": 231095,
+      "required": false
+    },
+    {
       "fileID": 4774651,
       "projectID": 912099,
       "required": true


### PR DESCRIPTION
I think Chisels and Bits should be removed for several reasons, the main reason being that it enables the player to sink time into a task that has minimal aesthetic impact. A player could spend hours getting one architectural feature to pixel perfection, only to turn around and realize that their work only comprises a very small part of the base at large, potentially unnoticeable from most of the base.

This isn't to say that building is _distracting_ from other types of gameplay - I just think that we should encourage builders to operate on larger scales so that the same amount of time spent building covers a larger portion of the base (and thus has a more appreciable impact) especially with how large GT bases can get.

I think of Chisels and Bits as the SFM or Computercraft for building, in that:
- The mod encourages the user to sink large amounts of time into a singular task when there is work to do in other areas
- Alternatives exist that are simpler, but are faster to implement and still get the job done
- A very small fraction of the player base uses the mod in the first place, and those that do can easily add it back in.