### PR TITLE
Many tweaks related to Thermal Series

### DIFF
--- a/kubejs/assets/emi/recipe/filters/hidecategories.json
+++ b/kubejs/assets/emi/recipe/filters/hidecategories.json
@@ -153,9 +153,6 @@
             "category": "thermal:crystallizer"
         },
         {
-            "category": "thermal:crucible"
-        },
-        {
             "category": "thermal:chiller"
         },
         {

--- a/kubejs/server_scripts/aa_planet_resources.js
+++ b/kubejs/server_scripts/aa_planet_resources.js
@@ -177,8 +177,8 @@ ServerEvents.recipes(event => {
     // Arsenopyrite metallurgy like Cobaltite
     event.recipes.gtceu.electric_blast_furnace("arsenopyrite_metallurgy")
         .itemInputs("gtceu:arsenopyrite_dust")
-        .inputFluids("gtceu:oxygen 2500")
-        .itemOutputs("2x gtceu:small_wrought_iron_dust", "gtceu:arsenic_trioxide_dust")
+        .inputFluids("gtceu:oxygen 3000")
+        .itemOutputs("gtceu:hematite_dust", "gtceu:arsenic_trioxide_dust")
         .outputFluids("gtceu:sulfur_dioxide 1000")
         .duration(100)
         .EUt(GTValues.VA[GTValues.MV])

--- a/kubejs/server_scripts/gregtech/Alloys_Recipes.js
+++ b/kubejs/server_scripts/gregtech/Alloys_Recipes.js
@@ -153,13 +153,26 @@ ServerEvents.recipes(event => {
             .blastFurnaceTemp(1200)
     })
 
-    // Replace default GTCEu glowstone separation recipe to match mixing recipe
-    event.replaceOutput({ id: "gtceu:centrifuge/glowstone_separation" }, "minecraft:redstone", "gtceu:tricalcium_phosphate_dust")
+    // Replace default GTCEu glowstone separation recipe to match composition
     event.recipes.gtceu.mixer("kubejs:glowstone_dust")
-        .itemInputs("gtceu:tricalcium_phosphate_dust", "#forge:dusts/gold")
-        .itemOutputs("2x minecraft:glowstone_dust")
+        .itemInputs("gtceu:tricalcium_phosphate_dust", "#forge:dusts/gold", "#forge:dusts/barite")
+        .itemOutputs("3x minecraft:glowstone_dust")
         .duration(80)
         .EUt(GTValues.VHA[GTValues.LV])
+    event.recipes.gtceu.centrifuge("glowstone_separation")
+        .itemInputs("4x minecraft:glowstone_dust")
+        .itemOutputs("gtceu:tricalcium_phosphate_dust", "gtceu:gold_dust", "gtceu:barite_dust")
+        .duration(976)  // Copied from the default Glowstone Separation recipe
+        .EUt(80)        // Copied from the default Glowstone Separation recipe
+
+    // Synthesis recipe for Barite since it's used for synthetic Glowstone
+    event.recipes.gtceu.chemical_reactor("barite_from_barium")
+        .itemInputs("gtceu:barium_dust")
+        .inputFluids("gtceu:sulfuric_acid 1000")
+        .itemOutputs("6x gtceu:barite_dust")
+        .outputFluids("gtceu:hydrogen 2000")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.ULV])
 
     // Remove old rhodium plated palladium recipe
     event.remove({ id: "gtceu:mixer/rhodium_plated_palladium" })

--- a/kubejs/server_scripts/gregtech/Alloys_Recipes.js
+++ b/kubejs/server_scripts/gregtech/Alloys_Recipes.js
@@ -160,7 +160,7 @@ ServerEvents.recipes(event => {
         .duration(80)
         .EUt(GTValues.VHA[GTValues.LV])
     event.recipes.gtceu.centrifuge("glowstone_separation")
-        .itemInputs("4x minecraft:glowstone_dust")
+        .itemInputs("5x minecraft:glowstone_dust")
         .itemOutputs("gtceu:tricalcium_phosphate_dust", "gtceu:gold_dust", "gtceu:barite_dust")
         .duration(976)  // Copied from the default Glowstone Separation recipe
         .EUt(80)        // Copied from the default Glowstone Separation recipe

--- a/kubejs/server_scripts/infinite_sources.js
+++ b/kubejs/server_scripts/infinite_sources.js
@@ -3,8 +3,7 @@
  */
 ServerEvents.recipes(event => {
     event.remove({ id: "watercollector:watercollector" })
-    event.remove({ id: "thermal:device_water_gen" })
-    event.remove({ id: "thermal:device_rock_gen" })
+
 
     if (!doHarderRecipes) {
         event.recipes.gtceu.shaped("watercollector:watercollector", [
@@ -15,53 +14,6 @@ ServerEvents.recipes(event => {
             A: "gtceu:wrought_iron_plate",
             B: "minecraft:water_bucket"
         }).addMaterialInfo()
-
-        event.recipes.gtceu.shaped("thermal:device_water_gen", [
-            " B ",
-            "CWC",
-            "GSG"
-        ], {
-            G: "gtceu:iron_gear",
-            B: "minecraft:bucket",
-            W: "watercollector:watercollector",
-            S: "enderio:fused_quartz",
-            C: "#forge:ingots/copper"
-        }).id("kubejs:device_water_gen").addMaterialInfo();
-
-        event.recipes.gtceu.shaped("thermal:device_rock_gen", [
-            " P ",
-            "PNP",
-            "GHG"
-        ], {
-            G: "gtceu:iron_gear",
-            P: "#forge:plates/steel",
-            N: "#forge:pistons",
-            H: "minecraft:hopper"
-        }).id("kubejs:device_rock_gen").addMaterialInfo();
-    } else {
-        event.recipes.gtceu.shaped("thermal:device_water_gen", [
-            " B ",
-            "CWC",
-            "GSG"
-        ], {
-            G: "gtceu:iron_gear",
-            B: "minecraft:bucket",
-            W: "#enderio:fused_quartz",
-            S: "thermal:redstone_servo",
-            C: "#forge:ingots/copper"
-        }).id("kubejs:device_water_gen").addMaterialInfo();
-
-        event.recipes.gtceu.shaped("thermal:device_rock_gen", [
-            " P ",
-            "INI",
-            "GSG"
-        ], {
-            G: "gtceu:iron_gear",
-            S: "thermal:redstone_servo",
-            P: "#forge:plates/steel",
-            I: "#forge:plates/invar",
-            N: "#forge:pistons"
-        }).id("kubejs:device_rock_gen").addMaterialInfo();
     }
 
     // Infinite Cobble/Water cells

--- a/kubejs/server_scripts/microverse/components.js
+++ b/kubejs/server_scripts/microverse/components.js
@@ -187,7 +187,7 @@ ServerEvents.recipes(event => {
 
     // Electrum Engine Core
     event.recipes.gtceu.canner("electrum_micro_miner_core")
-        .itemInputs("kubejs:electrum_micro_miner_frame", "2x minecraft:redstone_block")
+        .itemInputs("kubejs:electrum_micro_miner_frame", "1x minecraft:redstone_block")
         .itemOutputs("kubejs:electrum_micro_miner_core")
         .duration(500)
         .EUt(480)
@@ -195,7 +195,7 @@ ServerEvents.recipes(event => {
 
     // Signalum Engine Core
     event.recipes.gtceu.canner("signalum_micro_miner_core")
-        .itemInputs("kubejs:signalum_micro_miner_frame", "4x minecraft:redstone_block")
+        .itemInputs("kubejs:signalum_micro_miner_frame", "2x minecraft:redstone_block")
         .itemOutputs("kubejs:signalum_micro_miner_core")
         .duration(1000)
         .EUt(2000)
@@ -203,7 +203,7 @@ ServerEvents.recipes(event => {
 
     // Enderium Engine Core
     event.recipes.gtceu.canner("enderium_micro_miner_core")
-        .itemInputs("kubejs:enderium_micro_miner_frame", "8x minecraft:redstone_block")
+        .itemInputs("kubejs:enderium_micro_miner_frame", "4x minecraft:redstone_block")
         .itemOutputs("kubejs:enderium_micro_miner_core")
         .duration(2000)
         .EUt(8000)

--- a/kubejs/server_scripts/mods/Thermal_Series.js
+++ b/kubejs/server_scripts/mods/Thermal_Series.js
@@ -4,23 +4,22 @@
 ServerEvents.recipes(event => {
     event.remove({ output: ["systeams:steam_dynamo", "steamdynamo:steam_dynamo", "systeams:boiler_pipe", "thermal:rf_coil"] })
     event.remove({ output: ["thermal:dynamo_throttle_augment", "thermal:upgrade_augment_1", "thermal:upgrade_augment_2", "thermal:upgrade_augment_3"] })
-    event.remove({ output: ["thermal:machine_frame", "thermal:energy_cell_frame"] })
-    event.remove({ output: ["thermal:machine_furnace", "thermal:machine_sawmill", "thermal:machine_pulverizer", "thermal:machine_smelter", "thermal:machine_centrifuge", "thermal:machine_crucible", "thermal:machine_chiller", "thermal:machine_refinery", "thermal:machine_pyrolyzer", "thermal:machine_bottler", "thermal:machine_brewer", "thermal:machine_crystallizer"] })
+    event.remove({ output: ["thermal:machine_furnace", "thermal:machine_sawmill", "thermal:machine_pulverizer", "thermal:machine_smelter", "thermal:machine_centrifuge", "thermal:machine_chiller", "thermal:machine_refinery", "thermal:machine_pyrolyzer", "thermal:machine_bottler", "thermal:machine_brewer", "thermal:machine_crystallizer"] })
 
-    event.remove({ id: /thermal:[A-Za-z]+_dust_/ }) // I don't even know what recipes this line of code is supposed to target
-    event.remove({ id: /thermal:.*_cast/ })
+    // Magma Crucible for Lava only
+    event.remove({ type: "thermal:crucible", not: { id: /^thermal:machines\/crucible\/crucible_[\w_]+_to_lava$/ }})
+    // Igneous Extruder for Stone & Cobblestone only
+    event.remove({ type: "thermal:rock_gen", not: [{ id: "thermal:devices/rock_gen/rock_gen_cobblestone" }, { id: "thermal:devices/rock_gen/rock_gen_stone" }]})
+
+    event.remove({ id: /^thermal:.*_cast/ })
     event.remove({ id: /^thermal:dynamo_/}) // Remove non-downgrade recipes for Thermal dynamos
-    event.remove({ id: "thermal:fire_charge/obsidian_glass_2" })
-    event.remove({ id: "thermal:fire_charge/signalum_glass_2" })
-    event.remove({ id: "thermal:fire_charge/lumium_glass_2" })
-    event.remove({ id: "thermal:fire_charge/enderium_glass_2" })
+    event.remove({ id: "thermal:fire_charge/obsidian_glass_2" }) // Our recipe for Obsidian glass is different
 
     // Unify Thermal with GT rubber
-    event.smelting("gtceu:sticky_resin", "thermal:tar")
-    event.replaceInput({ id: /thermal:*/ }, ["thermal:cured_rubber"], ["#forge:rubber_plates"])
-    // Unify Thermal dies
+    event.replaceInput({ id: /^thermal:/ }, ["thermal:cured_rubber"], ["#forge:rubber_plates"])
 
-    event.recipes.gtceu.shaped("thermal:press_packing_2x2_die", [
+    // Unify packing dies (ReplaceInput does not work on tags)
+    event.shaped("thermal:press_packing_2x2_die", [
         " A ",
         "BCB",
         " A "
@@ -28,9 +27,9 @@ ServerEvents.recipes(event => {
         A: "gtceu:invar_plate",
         B: "gtceu:cupronickel_plate",
         C: "#minecraft:planks"
-    }).id("thermal:press_packing_2x2_die").addMaterialInfo()
+    }).id("thermal:press_packing_2x2_die")
 
-    event.recipes.gtceu.shaped("thermal:press_packing_3x3_die", [
+    event.shaped("thermal:press_packing_3x3_die", [
         " B ",
         "ACA",
         " B "
@@ -38,9 +37,9 @@ ServerEvents.recipes(event => {
         A: "gtceu:invar_plate",
         B: "gtceu:cupronickel_plate",
         C: "#minecraft:planks"
-    }).id("thermal:press_packing_3x3_die").addMaterialInfo()
+    }).id("thermal:press_packing_3x3_die")
 
-    event.recipes.gtceu.shaped("thermal:press_unpacking_die", [
+    event.shaped("thermal:press_unpacking_die", [
         "B A",
         " C ",
         "A B"
@@ -48,7 +47,7 @@ ServerEvents.recipes(event => {
         A: "gtceu:invar_plate",
         B: "gtceu:cupronickel_plate",
         C: "#minecraft:planks"
-    }).id("thermal:press_unpacking_die").addMaterialInfo()
+    }).id("thermal:press_unpacking_die")
 
 
     // Hardened Glass recipes
@@ -86,12 +85,12 @@ ServerEvents.recipes(event => {
         .inputFluids(Fluid.of("thermal:resin", 400))
         .itemOutputs("gtceu:sticky_resin")
         .chancedOutput("thermal:rosin", 6000, 0)
-        .outputFluids(Fluid.of("minecraft:water", 150), Fluid.of("thermal:tree_oil", 100))
+        .outputFluids(Fluid.of("thermal:tree_oil", 150), Fluid.of("minecraft:water", 150))
         .duration(200).EUt(20)
 
-    event.recipes.gtceu.distillation_tower("kubejs:sap_centrifuging")
+    event.recipes.gtceu.distillation_tower("kubejs:sap_distillation")
         .inputFluids(Fluid.of("thermal:sap", 200))
-        .outputFluids(Fluid.of("thermal:syrup", 25), Fluid.of("minecraft:water", 175))
+        .outputFluids(Fluid.of("thermal:syrup", 15), Fluid.of("minecraft:water", 175))
         .chancedOutput("minecraft:sugar", 1000, 0)
         .duration(10 * 20).EUt(2)
 
@@ -111,13 +110,14 @@ ServerEvents.recipes(event => {
         "BAB",
         "AB "
     ], {
-        A: "gtceu:gold_rod",
+        A: "#forge:rods/gold",
         B: "minecraft:redstone"
     })
     event.recipes.gtceu.assembler("thermal:rf_coil_assembly")
-        .itemInputs("#forge:rods/gold", "2x #forge:rings/gold", "3x #forge:dusts/redstone")
+        .itemInputs("#forge:springs/gold")
+        .inputFluids("gtceu:red_alloy 72")
         .itemOutputs("thermal:rf_coil")
-        .duration(200)
+        .duration(100)
         .EUt(30)
         .addMaterialInfo(true)
 
@@ -126,15 +126,25 @@ ServerEvents.recipes(event => {
         "BAB",
         "AB "
     ], {
-        A: "gtceu:silver_rod",
+        A: "#forge:rods/silver",
         B: "minecraft:redstone"
     })
     event.recipes.gtceu.assembler("kubejs:rf_transmission_coil_assembly")
-        .itemInputs("#forge:rods/silver", "2x #forge:rings/silver", "3x #forge:dusts/redstone")
+        .itemInputs("#forge:springs/silver")
+        .inputFluids("gtceu:red_alloy 72")
         .itemOutputs("kubejs:redstone_transmission_coil")
-        .duration(200)
+        .duration(100)
         .EUt(30)
         .addMaterialInfo(true)
+
+    // Insightful Crystal
+    event.remove({ id: "thermal:tools/xp_crystal" })
+    event.recipes.gtceu.autoclave("insightful_crystal")
+        .itemInputs("5x gtceu:lapotron_dust", "2x gtceu:emerald_dust")
+        .inputFluids("enderio:xp_juice 1000")
+        .itemOutputs("thermal:xp_crystal")
+        .duration(20 * 40)
+        .EUt(GTValues.VA[GTValues.MV])
 
     /* === AUGMENTS/UPGRADES ===*/
     event.recipes.gtceu.shaped("thermal:upgrade_augment_1", [
@@ -183,44 +193,48 @@ ServerEvents.recipes(event => {
 
     // Advanced Thermal Storage augments
     event.recipes.gtceu.shaped("thermal:rf_coil_augment_advanced", [
-        " G ",
+        "PGP",
         "SCS",
         " G "
     ], {
+        P: "#forge:plates/stainless_steel",
         S: "gtceu:sterling_silver_plate",
         C: "thermal:rf_coil",
-        G: "gtceu:rose_gold_plate"
+        G: "gtceu:rose_gold_plate",
     }).addMaterialInfo()
 
     event.recipes.gtceu.shaped("thermal:rf_coil_storage_augment_advanced", [
-        " S ",
+        "PSP",
         "GCG",
         " G "
     ], {
+        P: "#forge:plates/stainless_steel",
         S: "gtceu:sterling_silver_plate",
         C: "thermal:rf_coil",
         G: "gtceu:rose_gold_plate"
     }).addMaterialInfo()
 
     event.recipes.gtceu.shaped("thermal:rf_coil_xfer_augment_advanced", [
-        " S ",
+        "PSP",
         "SCS",
         " G "
     ], {
+        P: "#forge:plates/stainless_steel",
         S: "gtceu:sterling_silver_plate",
         C: "thermal:rf_coil",
         G: "gtceu:rose_gold_plate"
     }).addMaterialInfo()
 
     event.recipes.gtceu.shaped("thermal:fluid_tank_augment_advanced", [
-        " P ",
-        "RSR",
+        "PLP",
+        "RBR",
         " G "
     ], {
-        P: "#forge:plastic_plates",
+        P: "#forge:plates/stainless_steel",
+        L: "#forge:plastic_plates",
         R: "gtceu:silicone_rubber_ring",
         G: "#thermal:glass/hardened",
-        S: "gtceu:stainless_steel_normal_fluid_pipe"
+        B: "gtceu:bronze_normal_fluid_pipe"
     }).addMaterialInfo()
 
     // Temporary Reset NBT recipes
@@ -253,34 +267,12 @@ ServerEvents.recipes(event => {
         C: "kubejs:redstone_transmission_coil"
     }).id("thermal:augments/dynamo_output_augment").addMaterialInfo();
 
-    event.recipes.gtceu.shaped("thermal:machine_speed_augment", [
-        "NGN",
-        "PCP",
-        "NGN"
-    ], {
-        N: "#forge:nuggets/mythril",
-        G: "#forge:gears/black_steel",
-        P: "#forge:plates/electrum",
-        C: "thermal:rf_coil"
-    }).id("thermal:augments/machine_speed_augment").addMaterialInfo();
-
-    event.recipes.gtceu.shaped("thermal:machine_efficiency_augment", [
-        "NGN",
-        "PCP",
-        "NGN"
-    ], {
-        N: "#forge:nuggets/mythril",
-        G: "#forge:gears/nickel",
-        P: "#forge:plates/lumium",
-        C: "thermal:rf_coil"
-    }).id("thermal:augments/machine_efficiency_augment").addMaterialInfo();
-
     event.recipes.gtceu.shaped("thermal:machine_output_augment", [
         "MGM",
         "PCP",
         "MGM"
     ], {
-        M: "#forge:ingots/mythril",
+        M: "#forge:nuggets/mythril",
         G: "#forge:gears/bronze",
         P: "#forge:plates/invar",
         C: "thermal:redstone_servo"
@@ -325,7 +317,7 @@ ServerEvents.recipes(event => {
         A: "gtceu:signalum_gear",
         B: "gtceu:bronze_plate",
         C: "thermal:redstone_servo",
-        D: "gtceu:silver_plate"
+        D: "#forge:plates/stainless_steel"
     }).id("thermal:augments/machine_cycle_augment").addMaterialInfo()
 
     event.replaceInput({ id: "thermal:augments/item_filter_augment" }, "#forge:ingots/signalum", "gtceu:item_filter")
@@ -335,29 +327,18 @@ ServerEvents.recipes(event => {
     event.shaped("kubejs:excitationcoil", [
         " B ",
         "BAB",
-        "BAB"
+        "CAC"
     ], {
-        A: "thermal:rf_coil",
-        B: "gtceu:red_alloy_plate"
+        A: "kubejs:redstone_transmission_coil",
+        B: "#forge:plates/red_alloy",
+        C: "#forge:plates/tin"
     })
     event.recipes.gtceu.assembler("kubejs:excitationcoil_assembly")
-        .itemInputs("thermal:rf_coil", "2x gtceu:red_alloy_plate")
+        .itemInputs("kubejs:redstone_transmission_coil", "2x #forge:plates/red_alloy", "1x #forge:plates/tin")
         .itemOutputs("kubejs:excitationcoil")
         .duration(180)
         .EUt(30)
         .addMaterialInfo(true)
-
-    event.recipes.gtceu.shaped("steamdynamo:steam_dynamo", [
-        " A ",
-        "BCB",
-        "DED"
-    ], {
-        A: "kubejs:excitationcoil",
-        B: "gtceu:copper_plate",
-        C: "ironfurnaces:iron_furnace",
-        D: "gtceu:wrought_iron_gear",
-        E: "kubejs:redstone_transmission_coil"
-    }).addMaterialInfo()
 
     if (doBoilers) {
         event.recipes.gtceu.shaped("systeams:steam_dynamo", [
@@ -369,21 +350,19 @@ ServerEvents.recipes(event => {
             B: "gtceu:copper_plate",
             C: "ironfurnaces:iron_furnace",
             D: "gtceu:wrought_iron_gear",
-            E: "systeams:boiler_pipe"
+            E: "thermal:rf_coil"
         }).addMaterialInfo()
 
         event.recipes.gtceu.shaped("systeams:boiler_pipe", [
-            " C ",
-            "ABA",
-            " D "
+            "  A",
+            " B ",
+            "A  "
         ], {
             A: "gtceu:copper_plate",
-            B: "minecraft:bucket",
-            C: "gtceu:iron_gear",
-            D: "#enderio:fused_quartz"
+            B: "#enderio:fused_quartz"
         }).addMaterialInfo()
 
-        // Steam Dynamo upgrade (Does not work with the systeams:upgrade_shapeless recipe type sadly,
+        // Steam Dynamo upgrade (Does not work with the systeams:upgrade_shapeless recipe type in this direction,
         // so we recreate the special recipe stuff using KJS here)
         event.shapeless("systeams:stirling_boiler", ["steamdynamo:steam_dynamo", "systeams:boiler_pipe"])
             .modifyResult((grid, result) => {
@@ -413,50 +392,99 @@ ServerEvents.recipes(event => {
         event.remove({ id: /^systeams:boilers\/(?!upgrade)/ })
     }
 
-    event.recipes.gtceu.shaped("thermal:dynamo_magmatic", [
-        " A ",
-        "BCB",
-        "DED"
-    ], {
-        A: "kubejs:excitationcoil",
-        B: "gtceu:dark_steel_plate",
-        C: "ironfurnaces:copper_furnace",
-        D: "enderio:dark_bimetal_gear",
-        E: "kubejs:redstone_transmission_coil"
-    }).addMaterialInfo()
+    // Dynamo and Boiler recipes
+    function defineDynamoRecipes(asBoiler) {
+        event.recipes.gtceu.shaped(asBoiler ? "systeams:stirling_boiler" : "steamdynamo:steam_dynamo", [
+            " A ",
+            "BCB",
+            "DED"
+        ], {
+            A: "kubejs:excitationcoil",
+            B: "gtceu:wrought_iron_plate",
+            C: "ironfurnaces:iron_furnace",
+            D: "gtceu:wrought_iron_gear",
+            E: asBoiler ? "systeams:boiler_pipe" : "thermal:rf_coil"
+        }).addMaterialInfo()
 
-    event.recipes.gtceu.shaped("thermal:dynamo_compression", [
-        " A ",
-        "BCB",
-        "DED"
-    ], {
-        A: "kubejs:excitationcoil",
-        B: "gtceu:energetic_alloy_plate",
-        C: "ironfurnaces:gold_furnace",
-        D: "enderio:energized_gear",
-        E: "kubejs:redstone_transmission_coil"
-    }).addMaterialInfo()
+        event.recipes.gtceu.shaped(asBoiler ? "systeams:magmatic_boiler" : "thermal:dynamo_magmatic", [
+            " A ",
+            "BCB",
+            "DED"
+        ], {
+            A: "kubejs:excitationcoil",
+            B: "gtceu:dark_steel_plate",
+            C: "ironfurnaces:copper_furnace",
+            D: "enderio:dark_bimetal_gear",
+            E: asBoiler ? "systeams:boiler_pipe" : "thermal:rf_coil"
+        }).addMaterialInfo()
 
-    event.recipes.gtceu.shaped("thermal:dynamo_gourmand", [
-        " A ",
-        "BCB",
-        "DED"
-    ], {
-        A: "kubejs:excitationcoil",
-        B: "gtceu:blue_alloy_plate",
-        C: "ironfurnaces:silver_furnace",
-        D: "enderio:iron_gear",
-        E: "kubejs:redstone_transmission_coil"
-    }).addMaterialInfo()
+        event.recipes.gtceu.shaped(asBoiler ? "systeams:compression_boiler" : "thermal:dynamo_compression", [
+            " A ",
+            "BCB",
+            "DED"
+        ], {
+            A: "kubejs:excitationcoil",
+            B: "gtceu:energetic_alloy_plate",
+            C: "ironfurnaces:gold_furnace",
+            D: "enderio:energized_gear",
+            E: asBoiler ? "systeams:boiler_pipe" : "thermal:rf_coil"
+        }).addMaterialInfo()
+
+        event.recipes.gtceu.shaped(asBoiler ? "systeams:gourmand_boiler" : "thermal:dynamo_gourmand", [
+            " A ",
+            "BCB",
+            "DED"
+        ], {
+            A: "kubejs:excitationcoil",
+            B: "gtceu:blue_alloy_plate",
+            C: "ironfurnaces:silver_furnace",
+            D: "enderio:iron_gear",
+            E: asBoiler ? "systeams:boiler_pipe" : "thermal:rf_coil"
+        }).addMaterialInfo()
+
+        // Numis can have different recipes
+        if(doHarderRecipes) {
+            event.recipes.gtceu.shaped(asBoiler ? "systeams:numismatic_boiler" : "thermal:dynamo_numismatic", [
+                " A ",
+                "BCB",
+                "DED"
+            ], {
+                A: "kubejs:excitationcoil",
+                B: "gtceu:zeron_100_plate",
+                C: "ironfurnaces:diamond_furnace",
+                D: "enderio:vibrant_gear",
+                E: asBoiler ? "systeams:boiler_pipe" : "thermal:rf_coil"
+            }).addMaterialInfo()
+        } else {
+            event.recipes.gtceu.shaped(asBoiler ? "systeams:numismatic_boiler" : "thermal:dynamo_numismatic", [
+                " A ",
+                "BCB",
+                "DED"
+            ], {
+                A: "kubejs:excitationcoil",
+                B: "gtceu:vibrant_alloy_plate",
+                C: "ironfurnaces:diamond_furnace",
+                D: "enderio:vibrant_gear",
+                E: asBoiler ? "systeams:boiler_pipe" : "thermal:rf_coil"
+            }).addMaterialInfo()
+        }
+    }
+    /*
+    I had concluded that defining & calling a function
+    would be the best way to adhere to the DRY principle.
+    */
+    defineDynamoRecipes(false)
+    if(doBoilers) defineDynamoRecipes(true)
 
     // Machines
+    event.remove({ id: "thermal:machine_frame" })
     event.recipes.gtceu.shaped("thermal:machine_frame", [
         "SSS",
         "SMS",
         "III"
     ], {
-        M: "#forge:gears/mythril",
-        S: "#forge:plates/stainless_steel",
+        M: "#forge:gears/aluminium",
+        S: "#forge:plates/iron",
         I: "#forge:ingots/invar"
     }).addMaterialInfo()
 
@@ -467,23 +495,23 @@ ServerEvents.recipes(event => {
         "DED"
     ], {
         A: "minecraft:piston",
-        B: "#forge:ingots/bronze",
+        B: "#forge:ingots/cupronickel",
         C: "thermal:machine_frame",
-        D: "#forge:gears/copper",
+        D: "#forge:gears/bronze",
         E: "thermal:rf_coil"
     }).id("kubejs:machine_press").addMaterialInfo();
 
     // energetic infuser
     event.remove({ id: "thermal:charge_bench" });
     event.recipes.gtceu.shaped("thermal:charge_bench", [
-        " A ",
+        "AAA",
         "BCB",
         "DED"
     ], {
-        A: "#forge:gears/lead",
+        A: "#forge:ingots/electrum",
         B: "kubejs:redstone_transmission_coil",
         C: "thermal:machine_frame",
-        D: "#forge:gears/copper",
+        D: "#forge:rubber_plates",
         E: "thermal:rf_coil"
     }).id("kubejs:charge_bench").addMaterialInfo()
 
@@ -501,36 +529,31 @@ ServerEvents.recipes(event => {
         C: "#forge:gears/copper"
     }).id("thermal:machine_insolator").addMaterialInfo()
 
-    event.recipes.gtceu.shaped("thermal:device_potion_diffuser", [
-        " A ",
-        "BCB",
-        "DED"
-    ], {
-        A: "enderio:fused_quartz",
-        B: "gtceu:silver_ingot",
-        C: "thermal:machine_frame",
-        D: "gtceu:iron_gear",
-        E: "thermal:redstone_servo"
-    }).id("thermal:device_potion_diffuser").addMaterialInfo()
-
-    // energy cell
+    // Energy Cell
+    event.recipes.remove({ id: "thermal:energy_cell_frame" })
     event.recipes.gtceu.shaped("thermal:energy_cell_frame", [
         "ABA",
         "BCB",
         "ABA"
     ], {
-        A: "#forge:plates/lead",
-        B: "#forge:rods/electrum",
+        A: "#forge:ingots/lead",
+        B: "#forge:plates/electrum",
         C: "enderio:vibrant_crystal"
-    }).id("kubejs:energy_cell_frame").addMaterialInfo()
+    }).id("thermal:energy_cell_frame").addMaterialInfo()
 
     event.remove("thermal:energy_cell");
-    event.recipes.gtceu.canner("kubejs:energy_cell")
-        .itemInputs("thermal:energy_cell_frame", "#forge:storage_blocks/redstone")
-        .itemOutputs("thermal:energy_cell")
-        .duration(500)
-        .EUt(30)
-        .addMaterialInfo(true);
+    event.recipes.gtceu.shaped("thermal:energy_cell", [
+        "RBR",
+        "IFO",
+        "RCR"
+    ], {
+        R: "#forge:rubber_plates",
+        B: "#forge:storage_blocks/redstone",
+        F: "thermal:energy_cell_frame",
+        C: "#gtceu:circuits/ulv",
+        I: "thermal:rf_coil",
+        O: "kubejs:redstone_transmission_coil"
+    }).addMaterialInfo()
 
     // Diamond as Fuel
     event.recipes.thermal.numismatic_fuel("minecraft:diamond").energy(1200000)
@@ -553,35 +576,54 @@ ServerEvents.recipes(event => {
         .duration(80)
         .EUt(90)
 
-    // transformation
-    event.recipes.gtceu.chemical_reactor("elemental_reduction_bazalz")
-        .itemInputs("gtceu:coal_dust")
-        .inputFluids(Fluid.of("gtceu:elemental_reduction_fluid", 100))
-        .itemOutputs("thermal:basalz_powder")
-        .duration(80)
-        .EUt(90)
+    const elemental_essences = [
+        {name: "blaze", namespace: "minecraft", power_powder: "pyrotheum", reduction_source: "netherrack", aux: "#forge:dusts/sulfur"},
+        {name: "basalz", namespace: "thermal", power_powder: "petrotheum", reduction_source: "coal", aux: "#forge:dusts/obsidian"},
+        {name: "blizz", namespace: "thermal", power_powder: "cryotheum", reduction_source: "ice", aux: "minecraft:snowball"},
+        {name: "blitz", namespace: "thermal", power_powder: "aerotheum", reduction_source: "endstone", aux: "#forge:dusts/saltpeter"}
+    ]
 
-    event.recipes.gtceu.chemical_reactor("elemental_reduction_blaze")
-        .itemInputs("gtceu:netherrack_dust")
-        .inputFluids(Fluid.of("gtceu:elemental_reduction_fluid", 100))
-        .itemOutputs("minecraft:blaze_powder")
-        .duration(80)
-        .EUt(90)
+    elemental_essences.forEach(essence_type => {
+        // Elemental reduction recipe
+        event.recipes.gtceu.chemical_reactor(`elemental_reduction_${essence_type.name}`)
+            .itemInputs(`#forge:dusts/${essence_type.reduction_source}`)
+            .inputFluids(Fluid.of("gtceu:elemental_reduction_fluid", 100))
+            .itemOutputs(`${essence_type.namespace}:${essence_type.name}_powder`)
+            .duration(80)
+            .EUt(90)
 
-    event.recipes.gtceu.chemical_reactor("elemental_reduction_blitz")
-        .itemInputs("gtceu:endstone_dust")
-        .inputFluids(Fluid.of("gtceu:elemental_reduction_fluid", 100))
-        .itemOutputs("thermal:blitz_powder")
-        .duration(80)
-        .EUt(90)
+        // Combine into -theum dusts
+        event.shaped(`2x kubejs:${essence_type.power_powder}_dust`, [
+            "AA ",
+            "BC ",
+            "   "
+        ], {
+            A: `${essence_type.namespace}:${essence_type.name}_powder`,
+            B: "minecraft:redstone",
+            C: essence_type.aux
+        }).noMirror().noShrink()
 
-    event.recipes.gtceu.chemical_reactor("elemental_reduction_blizz")
-        .itemInputs("gtceu:ice_dust")
-        .inputFluids(Fluid.of("gtceu:elemental_reduction_fluid", 100))
-        .itemOutputs("thermal:blizz_powder")
-        .duration(80)
-        .EUt(90)
+        event.recipes.gtceu.mixer(`mixer_${essence_type.power_powder}`)
+            .itemInputs(`2x ${essence_type.namespace}:${essence_type.name}_powder`, "#forge:dusts/redstone", essence_type.aux)
+            .itemOutputs(`2x kubejs:${essence_type.power_powder}_dust`)
+            .duration(40)
+            .EUt(20)
 
+        // To and from Rod form (Mostly for HM Nether Star recipe)
+        event.recipes.gtceu.macerator(`macerate_${essence_type.name}_rod`)
+            .itemInputs(`${essence_type.namespace}:${essence_type.name}_rod`)
+            .itemOutputs(`4x ${essence_type.namespace}:${essence_type.name}_powder`)
+            .duration(4.4 * 20)
+            .EUt(2)
+            .category("gtceu:macerator_recycling");
+        event.recipes.gtceu.compressor(`${essence_type.name}_rod`)
+            .itemInputs(`4x ${essence_type.namespace}:${essence_type.name}_powder`)
+            .itemOutputs(`${essence_type.namespace}:${essence_type.name}_rod`)
+            .duration(200)
+            .EUt(2)
+    })
+
+    // Primal Mana
     event.shaped("4x kubejs:primal_mana", [
         "AAB",
         "DEB",
@@ -593,76 +635,11 @@ ServerEvents.recipes(event => {
         D: "kubejs:cryotheum_dust",
         E: "gtceu:diamond_dust"
     })
-
     event.recipes.gtceu.mixer("mixer_primal_mana")
         .itemInputs("2x kubejs:petrotheum_dust", "2x kubejs:pyrotheum_dust", "2x kubejs:aerotheum_dust", "2x kubejs:cryotheum_dust", "1x gtceu:diamond_dust")
         .itemOutputs("4x kubejs:primal_mana")
         .duration(100)
         .EUt(100)
-
-    event.shaped("2x kubejs:petrotheum_dust", [
-        "AA ",
-        "BC ",
-        "   "
-    ], {
-        A: "thermal:basalz_powder",
-        B: "minecraft:redstone",
-        C: "gtceu:obsidian_dust"
-    }).noMirror().noShrink()
-
-    event.recipes.gtceu.mixer("mixer_petrotheum")
-        .itemInputs("2x thermal:basalz_powder", "minecraft:redstone", "gtceu:obsidian_dust")
-        .itemOutputs("2x kubejs:petrotheum_dust")
-        .duration(40)
-        .EUt(20)
-
-    event.shaped("2x kubejs:pyrotheum_dust", [
-        "AA ",
-        "BC ",
-        "   "
-    ], {
-        A: "minecraft:blaze_powder",
-        B: "minecraft:redstone",
-        C: "gtceu:sulfur_dust"
-    }).noMirror().noShrink()
-
-    event.recipes.gtceu.mixer("mixer_pyrotheum")
-        .itemInputs("2x minecraft:blaze_powder", "minecraft:redstone", "gtceu:sulfur_dust")
-        .itemOutputs("2x kubejs:pyrotheum_dust")
-        .duration(40)
-        .EUt(20)
-
-    event.shaped("2x kubejs:aerotheum_dust", [
-        "AA ",
-        "BC ",
-        "   "
-    ], {
-        A: "thermal:blitz_powder",
-        B: "minecraft:redstone",
-        C: "gtceu:saltpeter_dust"
-    }).noMirror().noShrink()
-
-    event.recipes.gtceu.mixer("mixer_aerotheum")
-        .itemInputs("2x thermal:blitz_powder", "minecraft:redstone", "gtceu:saltpeter_dust")
-        .itemOutputs("2x kubejs:aerotheum_dust")
-        .duration(40)
-        .EUt(20)
-
-    event.shaped("2x kubejs:cryotheum_dust", [
-        "AA ",
-        "BC ",
-        "   "
-    ], {
-        A: "thermal:blizz_powder",
-        B: "minecraft:redstone",
-        C: "minecraft:snowball"
-    }).noMirror().noShrink()
-
-    event.recipes.gtceu.mixer("mixer_cryotheum")
-        .itemInputs("2x thermal:blizz_powder", "minecraft:redstone", "minecraft:snowball")
-        .itemOutputs("2x kubejs:cryotheum_dust")
-        .duration(40)
-        .EUt(20)
 
     // Clathrates
     event.recipes.gtceu.chemical_reactor("resonant_clathrate")
@@ -686,59 +663,34 @@ ServerEvents.recipes(event => {
         .duration(120)
         .EUt(75)
 
-    // Thermal Dusts
-    event.recipes.gtceu.macerator("dust_blitz")
-        .itemInputs("thermal:blitz_rod")
-        .itemOutputs("4x thermal:blitz_powder")
-        .duration(200)
-        .EUt(16)
-
-    event.recipes.gtceu.macerator("dust_blizz")
-        .itemInputs("thermal:blizz_rod")
-        .itemOutputs("4x thermal:blizz_powder")
-        .duration(200)
-        .EUt(16)
-
-    event.recipes.gtceu.macerator("dust_bazalz")
-        .itemInputs("thermal:basalz_rod")
-        .itemOutputs("4x thermal:basalz_powder")
-        .duration(200)
-        .EUt(16);
-
-    // Thermal Mobdrops (for HM nether star recipe mostly)
-    event.recipes.gtceu.compressor("blitz_rod")
-        .itemInputs("4x thermal:blitz_powder")
-        .itemOutputs("thermal:blitz_rod")
-        .duration(200)
-        .EUt(2)
-
-    event.recipes.gtceu.compressor("blizz_rod")
-        .itemInputs("4x thermal:blizz_powder")
-        .itemOutputs("thermal:blizz_rod")
-        .duration(200)
-        .EUt(2)
-
-    event.recipes.gtceu.compressor("basalz_rod")
-        .itemInputs("4x thermal:basalz_powder")
-        .itemOutputs("thermal:basalz_rod")
-        .duration(200)
-        .EUt(2)
-
     // Devices
-    event.remove({ type: "thermal:rock_gen", not: { output: "minecraft:cobblestone" } })
+    // Extractor, Fisher, and Composter have recipes unaffected thanks to Item Tags allowing for the use of GT gears
 
-    event.remove({ id: "thermal:device_nullifier" });
-    event.recipes.gtceu.shaped("thermal:device_nullifier", [
-        " A ",
-        "BCB",
-        "DED"
+    event.remove({ id: "thermal:device_water_gen" })
+    event.recipes.gtceu.shaped("thermal:device_water_gen", [
+        " B ",
+        "CWC",
+        "GSG"
     ], {
-        A: "minecraft:lava_bucket",
-        B: "#chipped:bricks",
-        C: "thermal:machine_frame", // casing
-        D: "gtceu:iron_gear",
-        E: "thermal:redstone_servo"
-    }).id("kubejs:device_nullifier").addMaterialInfo();
+        G: "#forge:gears/iron",
+        B: "minecraft:bucket",
+        W: "#enderio:fused_quartz",
+        S: "thermal:redstone_servo",
+        C: "#forge:ingots/copper"
+    }).id("kubejs:device_water_gen").addMaterialInfo();
+
+    event.remove({ id: "thermal:device_rock_gen" })
+    event.recipes.gtceu.shaped("thermal:device_rock_gen", [
+        " P ",
+        "INI",
+        "GSG"
+    ], {
+        G: "#forge:gears/iron",
+        S: "thermal:redstone_servo",
+        P: "#forge:plates/steel",
+        I: "#forge:plates/invar",
+        N: "#forge:pistons"
+    }).id("kubejs:device_rock_gen").addMaterialInfo();
 
     event.remove({ id: "thermal:device_collector" });
     event.recipes.gtceu.shaped("thermal:device_collector", [
@@ -748,33 +700,35 @@ ServerEvents.recipes(event => {
     ], {
         A: "minecraft:hopper",
         B: "#forge:ingots/tin",
-        C: "enderio:vacuum_chest", // casing
-        D: "gtceu:iron_gear",
+        C: "#forge:gems/ender_pearl",
+        D: "#forge:gears/iron",
         E: "thermal:redstone_servo"
     }).id("kubejs:device_collector").addMaterialInfo();
 
-    event.remove({ id: "thermal:device_fisher" });
-    event.recipes.gtceu.shaped("thermal:device_fisher", [
-        "DAD",
+    event.remove({ id: "thermal:device_nullifier" });
+    event.recipes.gtceu.shaped("thermal:device_nullifier", [
+        " A ",
         "BCB",
         "DED"
     ], {
-        A: "minecraft:fishing_rod",
-        B: "#forge:glass",
-        C: "thermal:machine_frame", // casing
-        D: "#minecraft:planks",
+        A: "#forge:double_plates/lead",
+        B: "#chipped:bricks",
+        C: "minecraft:lava_bucket",
+        D: "#forge:gears/iron",
         E: "thermal:redstone_servo"
-    }).id("thermal:device_fisher").addMaterialInfo();
+    }).id("kubejs:device_nullifier").addMaterialInfo();
 
-    event.remove({ output: ["thermal:item_filter_augment"] })
-    event.recipes.gtceu.shaped("thermal:item_filter_augment", [
-        " I ",
-        "IVI",
-        " I "
+    event.recipes.gtceu.shaped("thermal:device_potion_diffuser", [
+        " A ",
+        "BCB",
+        "DED"
     ], {
-        I: "gtceu:invar_nugget",
-        V: "gtceu:item_filter",
-    }).addMaterialInfo()
+        A: "enderio:fused_quartz",
+        B: "#forge:ingots/silver",
+        C: "#forge:springs/cupronickel",
+        D: "#forge:gears/iron",
+        E: "thermal:redstone_servo"
+    }).id("thermal:device_potion_diffuser").addMaterialInfo()
 
     /* === THERMAL TOOLS ===*/
     event.remove({ id: "thermal:tools/wrench" })
@@ -788,9 +742,18 @@ ServerEvents.recipes(event => {
     }).id("kubejs:tools/wrench");
 
     // detonator, locked to mv
-    event.replaceInput({ id: "thermal:tools/detonator" }, ["#forge:gears/signalum"], ["#gtceu:circuits/mv"])
+    event.remove({ id: "thermal:tools/detonator" })
+    event.recipes.gtceu.shaped("thermal:detonator", [
+        " R ",
+        "NCN",
+        "NNN"
+    ], {
+        R: "#forge:rods/silver",
+        N: "#forge:nuggets/iron",
+        C: "#gtceu:circuits/mv"
+    }).id("kubejs:tools/detonator").addMaterialInfo();
 
-    // Fluxbore
+    // Fluxbore and Fluxsaw
     event.remove([{ id: "thermal:drill_head" }, { id: "thermal:flux_drill" }])
     if (doFluxbore) {
         if (doHarderFluxBore) {
@@ -801,9 +764,9 @@ ServerEvents.recipes(event => {
             ], {
                 A: "gtceu:stainless_steel_drill_head",
                 B: "#forge:ingots/silver",
-                C: "gtceu:mv_power_unit",
+                C: "gtceu:lv_power_unit",
                 D: "#forge:ingots/tin",
-                E: "gtceu:iron_gear"
+                E: "#forge:gears/iron"
             }).id("kubejs:flux_drill");
         } else {
             event.shaped("thermal:flux_drill", [
@@ -815,7 +778,7 @@ ServerEvents.recipes(event => {
                 B: "#forge:ingots/silver",
                 C: "gtceu:lv_power_unit",
                 D: "#forge:ingots/tin",
-                E: "gtceu:iron_gear"
+                E: "#forge:gears/iron"
             }).id("kubejs:flux_drill");
         }
     }
@@ -830,14 +793,14 @@ ServerEvents.recipes(event => {
         B: "#forge:ingots/silver",
         C: "gtceu:lv_power_unit",
         D: "#forge:ingots/tin",
-        E: "gtceu:iron_gear"
+        E: "#forge:gears/iron"
     }).id("kubejs:flux_saw");
 
     event.remove({ id: "thermal:flux_capacitor" });
     event.recipes.gtceu.shaped("thermal:flux_capacitor", [
-        " A ",
+        "ADA",
         "BCB",
-        "ADA"
+        " A "
     ], {
         A: "#forge:dusts/redstone",
         B: "#forge:ingots/lead",
@@ -845,22 +808,15 @@ ServerEvents.recipes(event => {
         D: "#forge:dusts/sulfur"
     }).id("kubejs:flux_capacitor");
 
-    // revert this change so it only requires redstone
-    event.replaceInput({ id: "thermal:flux_magnet" }, ["thermal:rf_coil"], ["#forge:dusts/redstone"]);
-
-    // lock
     event.remove({ id: "thermal:tools/lock" });
     event.recipes.gtceu.shaped("thermal:lock", [
         " A ",
         "ABA",
         "AAA"
     ], {
-        A: "#forge:nuggets/signalum",
-        B: "#forge:ingots/signalum"
-    }).id("kubejs:lock").addMaterialInfo();
-
-    // Workbench
-    event.replaceInput({ id: "thermal:tinker_bench" }, "minecraft:crafting_table", "gtceu:lv_machine_hull")
+        A: "#forge:nuggets/iron",
+        B: "#forge:nuggets/signalum"
+    }).addMaterialInfo();
 
     /* === misc thermals ===*/
     event.remove({ output: "thermal:phytogro" });
@@ -888,4 +844,69 @@ ServerEvents.recipes(event => {
         "#forge:dusts/saltpeter",
         "2x #forge:dusts/apatite"
     ]).id("kubejs:phytogro_coal_dusts_apatite");
+
+    // Change Aqua Chow recipes to use Flour instead of raw Wheat
+    event.replaceInput([{ id: "thermal:aquachow_4"}, {id: "thermal:deep_aquachow_4" }], "minecraft:wheat", "#forge:dusts/wheat")
+
+    // More recipes for Igneous Extruder
+    event.custom({
+        "type": "thermal:rock_gen",
+        "adjacent": "minecraft:water",
+        "below": "minecraft:andesite",
+        "result": {
+            "item": "minecraft:andesite"
+        }
+    })
+    event.custom({
+        "type": "thermal:rock_gen",
+        "adjacent": "minecraft:water",
+        "below": "minecraft:calcite",
+        "result": {
+            "item": "minecraft:calcite"
+        }
+    })
+    event.custom({
+        "type": "thermal:rock_gen",
+        "adjacent": "minecraft:water",
+        "below": "minecraft:diorite",
+        "result": {
+            "item": "minecraft:diorite"
+        }
+    })
+    event.custom({
+        "type": "thermal:rock_gen",
+        "adjacent": "minecraft:water",
+        "below": "minecraft:granite",
+        "result": {
+            "item": "minecraft:granite"
+        }
+    })
+
+    // Rockwool as IRL Mineral Wool
+    event.remove({ output: "thermal:white_rockwool"})
+    event.recipes.gtceu.alloy_smelter("aluminosilicate_rockwool_from_sapphire")
+        .itemInputs("gtceu:sapphire_dust", "gtceu:silicon_dioxide_dust")
+        .itemOutputs("3x thermal:white_rockwool")
+        .duration(8 * 20)
+        .EUt(GTValues.VA[GTValues.LV])
+    event.recipes.gtceu.alloy_smelter("aluminosilicate_rockwool_from_green_sapphire")
+        .itemInputs("gtceu:green_sapphire_dust", "gtceu:silicon_dioxide_dust")
+        .itemOutputs("3x thermal:white_rockwool")
+        .duration(8 * 20)
+        .EUt(GTValues.VA[GTValues.LV])
+    event.recipes.gtceu.alloy_smelter("slag_rockwool_from_slag")
+        .itemInputs("thermal:slag", "gtceu:basalt_dust")
+        .itemOutputs("4x thermal:white_rockwool")
+        .duration(8 * 20)
+        .EUt(GTValues.VA[GTValues.LV])
+    event.recipes.gtceu.alloy_smelter("dolomite_rockwool_from_marble")
+        .itemInputs("gtceu:marble_dust", "gtceu:basalt_dust")
+        .itemOutputs("4x thermal:white_rockwool")
+        .duration(8 * 20)
+        .EUt(GTValues.VA[GTValues.LV])
+    event.recipes.gtceu.centrifuge("rockwool_from_asbestos")
+        .itemInputs("gtceu:asbestos_dust")
+        .itemOutputs("5x thermal:white_rockwool")
+        .duration(6 * 20)
+        .EUt(GTValues.VA[GTValues.LV])
 });

--- a/kubejs/server_scripts/normal_mode.js
+++ b/kubejs/server_scripts/normal_mode.js
@@ -146,30 +146,6 @@ ServerEvents.recipes(event => {
     }
 
     if(doHarderRecipes) {
-        event.recipes.gtceu.shaped("thermal:dynamo_numismatic", [
-            " A ",
-            "BCB",
-            "DED"
-        ], {
-            A: "kubejs:excitationcoil",
-            B: "gtceu:zeron_100_plate",
-            C: "ironfurnaces:diamond_furnace",
-            D: "enderio:vibrant_gear",
-            E: "kubejs:redstone_transmission_coil"
-        }).addMaterialInfo()
-    } else {
-        event.recipes.gtceu.shaped("thermal:dynamo_numismatic", [
-            " A ",
-            "BCB",
-            "DED"
-        ], {
-            A: "kubejs:excitationcoil",
-            B: "gtceu:vibrant_alloy_plate",
-            C: "ironfurnaces:diamond_furnace",
-            D: "enderio:vibrant_gear",
-            E: "kubejs:redstone_transmission_coil"
-        }).addMaterialInfo()
-
         // Make clay electrolysis an LV recipe
         event.remove({ id: "gtceu:electrolyzer/decomposition_electrolyzing_clay" })
         event.recipes.gtceu.electrolyzer("clay_electrolysis_lv")

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -422,7 +422,7 @@ ServerEvents.recipes(event => {
 
     // Resonating Crystal recipes
     event.recipes.gtceu.alloy_smelter("kubejs:resonating_redstone")
-        .itemInputs("minecraft:redstone_block", "kubejs:ender_shard")
+        .itemInputs("4x minecraft:redstone", "kubejs:ender_shard")
         .itemOutputs("kubejs:resonating_crystal")
         .duration(180)
         .EUt(16)

--- a/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/material_modifications.js
@@ -62,6 +62,9 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     GTMaterials.Silver.addFlags(GTMaterialFlags.GENERATE_GEAR)
     GTMaterials.Lead.addFlags(GTMaterialFlags.GENERATE_GEAR)
 
+    // Spring for Thermal Transmission Coil
+    GTMaterials.Silver.addFlags(GTMaterialFlags.GENERATE_SPRING)
+
     // Radioactive materials that get liquid forms and/or a new color
     addFluid(GTMaterials.Berkelium, $FluidStorageKeys.LIQUID, 1259);
     GTMaterials.Berkelium.setMaterialARGB(0xa33f20);
@@ -126,8 +129,8 @@ GTCEuStartupEvents.materialModification(event => {
     // Change materials' components
     GTMaterials.EchoShard.setComponents(GTMaterials.Quartzite.multiply(3), GTMaterials.Sculk.multiply(2))
 
-    GTMaterials.Glowstone.setComponents(GTMaterials.TricalciumPhosphate.multiply(1), GTMaterials.Gold.multiply(1))
-    GTMaterials.Glowstone.setFormula("AuCa3(PO4)2", true)
+    GTMaterials.Glowstone.setComponents(GTMaterials.TricalciumPhosphate.multiply(1), GTMaterials.Gold.multiply(1), GTMaterials.Barite.multiply(1))
+    GTMaterials.Glowstone.setFormula("AuCa3(PO4)2BaSO4", true)
 
     GTMaterials.RhodiumPlatedPalladium.setComponents(GTMaterials.Palladium.multiply(3), GTMaterials.Rhodium.multiply(1), "2x lumium")
     GTMaterials.RhodiumPlatedPalladium.setFormula("Pd3Rh(SnFe)4(CuAg4)2", true)

--- a/kubejs/startup_scripts/gregtech_material_registry/other_mods.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/other_mods.js
@@ -62,7 +62,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .blastTemp(1250, "low", 120, 400)
         .components("2x gold", "redstone", "glowstone")
         .cableProperties(128, 1, 0, true)
-        .formula("Au2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2)");
+        .formula("Au2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2BaSO4)");
 
     event.create("vibrant_alloy")
         .ingot().fluid()
@@ -71,7 +71,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .blastTemp(1350, "low", 120, 400)
         .components("energetic_alloy", "ender_pearl")
         .cableProperties(512, 2, 0, true)
-        .formula("Au2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2)(BeK4N5)");
+        .formula("Au2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2BaSO4)(BeK4N5)");
 
     event.create("pulsating_alloy") // Pulsating Iron
         .ingot().fluid()
@@ -94,7 +94,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .toolStats(new ToolProperty(4.0, 3.5, 1024, 3, []))
         .cableProperties(2048, 2, 0, true)
         .components("dark_steel", "endstone", "vibrant_alloy")
-        .formula("Fe(SiO2)(Au2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2)(BeK4N5))");
+        .formula("Fe(SiO2)(Au2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2BaSO4)(BeK4N5))");
 
     event.create("soularium")
         .ingot().fluid()
@@ -286,7 +286,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .components("2x steel", "glowstone", "redstone", "deuterium")
         .blastTemp(1700, "mid", 120, 600)
         .cableProperties(128, 4, 2, false)
-        .formula("Fe2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2)D");
+        .formula("Fe2(Si(FeS2)5(CrAl2O3)Hg3)(AuCa3(PO4)2BaSO4)D");
 
     // Ardite isn't here since it's more closely related to nethline than actually being a TiC material.
 })

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -287,6 +287,7 @@ global.itemNukeList = [
     "thermal:sawdust",
     "thermal:sulfur",
     "thermal:tar",
+    "thermal:tar_block",
     "thermal:refined_fuel_bucket",
     /^thermal:.*_cast$/,
 
@@ -296,7 +297,6 @@ global.itemNukeList = [
     "thermal:machine_pulverizer",
     "thermal:machine_smelter",
     "thermal:machine_centrifuge",
-    "thermal:machine_crucible",
     "thermal:machine_chiller",
     "thermal:machine_refinery",
     "thermal:machine_pyrolyzer",

--- a/kubejs/startup_scripts/registry/item_registry.js
+++ b/kubejs/startup_scripts/registry/item_registry.js
@@ -471,9 +471,9 @@ StartupEvents.registry("item", event => {
     event.createCustom("thermal:upgrade_augment_3",() =>new $AugmentItem(new $Item$Properties(), {Type: "Upgrade", BaseMod: 12}))
 
     // Advanced Thermal Storage augments
-    event.createCustom("thermal:rf_coil_augment_advanced",() =>new $AugmentItem(new $Item$Properties(), {Type: "RF", RFMax: 8, RFXfer: 8}))
-    event.createCustom("thermal:rf_coil_storage_augment_advanced",() =>new $AugmentItem(new $Item$Properties(), {Type: "RF", RFMax: 10, RFXfer: 4}))
-    event.createCustom("thermal:rf_coil_xfer_augment_advanced",() =>new $AugmentItem(new $Item$Properties(), {Type: "RF", RFMax: 4, RFXfer: 10}))
+    event.createCustom("thermal:rf_coil_augment_advanced",() =>new $AugmentItem(new $Item$Properties(), {Type: "RF", RFXfer: 8, RFMax: 8}))
+    event.createCustom("thermal:rf_coil_storage_augment_advanced",() =>new $AugmentItem(new $Item$Properties(), {Type: "RF", RFXfer: 4, RFMax: 10}))
+    event.createCustom("thermal:rf_coil_xfer_augment_advanced",() =>new $AugmentItem(new $Item$Properties(), {Type: "RF", RFXfer: 10, RFMax: 4}))
     event.createCustom("thermal:fluid_tank_augment_advanced",() =>new $AugmentItem(new $Item$Properties(), {Type: "Fluid", FluidMax: 10}))
 
     // EnderIO Capacitors


### PR DESCRIPTION
Including but not limited to:
- Un-nuke Thermal's Magma Crucible as yet another method to produce Lava (but it's harder to scale due to not being GT)
- Add Barite to Glowstone composition and add a recipe to synthesize Barite dust using Barium and Sulfuric Acid so earlygame players can reasonably synthesize the stuff
- Move Thermal's Insightful Crystal from Crafting Table to HV Autoclave with tier-appropriate recipe
- Add Stainless Steel Plates to Advanced Thermal RF/tank augments 
- Change around Thermal Dynamo and Boiler recipes slightly so that the Boiler counterparts can crafted directly and keep bidirectional conversion recipes without any difference in material cost
- Remove Mythril and Stainless Steel from the Thermal Machine Frame, (replaced with Aluminium and Iron respectively) thereby making all Thermal Expansion machines accessible in LV which gives them more time to be relevant before they inevitably get outcompeted
- Change Vacuumulator recipe to not require the EnderIO Vacuum Chest
- Add a bunch of other basic-ish recipes to the Igneous Extruder (Granite, Diorite, Andesite, Calcite, Stone)
- Recipes to make Rockwool from Asbestos, Basalt, or Silica and some other random rock-themed items