### PR TITLE
Reduce Phosphoric Acid cost of Luminessence

### DIFF
--- a/kubejs/server_scripts/mods/extended_crafting.js
+++ b/kubejs/server_scripts/mods/extended_crafting.js
@@ -314,8 +314,8 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.mixer("luminessence")
         .itemInputs("minecraft:redstone", "minecraft:glowstone_dust", "2x gtceu:aluminium_dust")
-        .inputFluids("gtceu:phosphoric_acid 4000")
-        .itemOutputs("8x extendedcrafting:luminessence")
+        .inputFluids("gtceu:phosphoric_acid 2000")
+        .itemOutputs("6x extendedcrafting:luminessence")
         .duration(20)
         .EUt(30)
 })


### PR DESCRIPTION
Some feedback in the #moni-dev channel pointed out that Nether Stars and Lumium were expensive due in part to their Phosphorus cost. This should alleviate that component of the problem.