### PR TITLE
LaserIO Card Update

### DIFF
--- a/kubejs/server_scripts/mods/laserio.js
+++ b/kubejs/server_scripts/mods/laserio.js
@@ -37,14 +37,13 @@ ServerEvents.recipes(event => {
                 T: "gtceu:tin_plate"
             }).id(`laserio:card_${card[0]}`)
 
-            // temporarily removed because LaserIO cards can't stack
-            /*
+
             event.recipes.gtceu.assembler(`laserio:card_${card[0]}`)
                 .itemInputs(card[1], cardChip, "3x gtceu:tin_plate", "6x minecraft:gold_nugget")
                 .itemOutputs(`2x laserio:card_${card[0]}`)
                 .duration(80)
                 .EUt(16)
-            */
+            
         })
 
         // Overclockers

--- a/kubejs/startup_scripts/modify_items.js
+++ b/kubejs/startup_scripts/modify_items.js
@@ -49,7 +49,21 @@ ItemEvents.modification(event => {
         item.maxStackSize = 64
     })
 
-
+    // Increase the maximum stack size of LaserIO Cards to 16
+    const Cards = [
+        ["item"],
+        ["fluid"],
+        ["energy"],
+        ["redstone"]
+    ]
+    
+    Cards.forEach(card => {
+        event.modify(`laserio:card_${card[0]}`, item => {
+            item.maxStackSize = 16  
+        })
+    
+    })
+    
     // Make Infinity and Ultimate tools work as unbreakable crafting tools
     const toolTypes = [
         "file",


### PR DESCRIPTION
Increases LaserIO stack size to 16 and adds assembler recipes back to work with new stack size.