### PR TITLE
nuke ev+ converters and lumium+ LIO overclockers

### DIFF
--- a/config/laserio-common.toml
+++ b/config/laserio-common.toml
@@ -41,16 +41,16 @@
 			#By adding values to this list, Energy Overclocker(s') will be generated (1 tier for each value).
 			#The maximum FE/operation for each tier is specified using this list. Ex: [512, 2000, 51873]
 			#Note: Since this is a feature meant for pack developers, no recipes will be generated
-			max_fe_tiers = [512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608, 134217728]
+			max_fe_tiers = [512, 2048, 8192, 32768]
 			#By adding values to this list, Energy Overclocker(s') name(s) can be chosen (1 value for each tier).
 			#Normal string rules apply. Ex: ["name", "longer name", "NaME wiTh CapiTAL lETters"]
 			#Note: Default names will be generated if this list is empty/doesn't contain enough elements
-			name_tiers = ["Conductive Iron FE Overclocker", "Energetic Alloy FE Overclocker", "Vibrant Alloy FE Overclocker", "End Steel FE Overclocker", "Lumium FE Overclocker", "Signalum FE Overclocker", "Enderium FE Overclocker", "Cryolobus FE Overclocker", "Sculk Superconductor FE Overclocker"]
+			name_tiers = ["Conductive Iron FE Overclocker", "Energetic Alloy FE Overclocker", "Vibrant Alloy FE Overclocker", "End Steel FE Overclocker"]
 			#By adding values to this list, Energy Overclocker(s') color(s) can be chosen (1 value for each tier).
 			#Each color must be provided as a string using its octal, decimal, or hexadecimal representation.
 			#Example with tier 1 as blue, 2 as green, and 3 as red: ["0377", "65280", "#ff0000"]
 			#Note: Default colors will be generated if this list is empty/doesn't contain enough elements
-			color_tiers = ["0xf7b29b", "0xffb545", "0xa4ff70", "0xd6d980", "0xf6ff99", "0xff7f0f", "0x1f6b62", "0x022C34", "0xffffff"]
+			color_tiers = ["0xf7b29b", "0xffb545", "0xa4ff70", "0xd6d980"]
 
 	#Chemical Card (only if Mekanism is installed)
 	[card.chemical_card]

--- a/kubejs/assets/laserio/lang/de_de.json
+++ b/kubejs/assets/laserio/lang/de_de.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "Leitfähiges Eisen FE-Übertakter",
     "item.laserio.energy_overclocker_card_tier_2": "Energetische Legierung FE-Übertakter",
     "item.laserio.energy_overclocker_card_tier_3": "Vibrant Alloy FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_5": "Lumium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_6": "Signalum FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_7": "Enderium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_8": "Cryolobus FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_9": "Sculk Superconductor FE Overclocker"
+    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker"
 }

--- a/kubejs/assets/laserio/lang/en_us.json
+++ b/kubejs/assets/laserio/lang/en_us.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "Conductive Iron FE Overclocker",
     "item.laserio.energy_overclocker_card_tier_2": "Energetic Alloy FE Overclocker",
     "item.laserio.energy_overclocker_card_tier_3": "Vibrant Alloy FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_5": "Lumium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_6": "Signalum FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_7": "Enderium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_8": "Cryolobus FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_9": "Sculk Superconductor FE Overclocker"
+    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker"
 }

--- a/kubejs/assets/laserio/lang/es_es.json
+++ b/kubejs/assets/laserio/lang/es_es.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "Overclockeador FE de hierro conductor",
     "item.laserio.energy_overclocker_card_tier_2": "Overclockeador FE de aleación energética",
     "item.laserio.energy_overclocker_card_tier_3": "Overclockeador FE de aleación vibrante",
-    "item.laserio.energy_overclocker_card_tier_4": "Overclockeador FE de acero del End",
-    "item.laserio.energy_overclocker_card_tier_5": "Overclockeador FE de lumio",
-    "item.laserio.energy_overclocker_card_tier_6": "Overclockeador FE de signalio",
-    "item.laserio.energy_overclocker_card_tier_7": "Overclockeador FE de enderio",
-    "item.laserio.energy_overclocker_card_tier_8": "Overclockeador FE de cryolobus",
-    "item.laserio.energy_overclocker_card_tier_9": "Overclockeador FE de superconductor Sculk"
+    "item.laserio.energy_overclocker_card_tier_4": "Overclockeador FE de acero del End"
 }

--- a/kubejs/assets/laserio/lang/fr_fr.json
+++ b/kubejs/assets/laserio/lang/fr_fr.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "Overclockeur FE en fer conducteur",
     "item.laserio.energy_overclocker_card_tier_2": "Overclockeur FE en alliage énergétique",
     "item.laserio.energy_overclocker_card_tier_3": "Overclockeur FE en alliage vibrant",
-    "item.laserio.energy_overclocker_card_tier_4": "Overclockeur FE en acier de l'End",
-    "item.laserio.energy_overclocker_card_tier_5": "Overclockeur FE en lumium",
-    "item.laserio.energy_overclocker_card_tier_6": "Overclockeur FE en signalum",
-    "item.laserio.energy_overclocker_card_tier_7": "Overclockeur FE en enderium",
-    "item.laserio.energy_overclocker_card_tier_8": "Overclockeur FE en cryolobus",
-    "item.laserio.energy_overclocker_card_tier_9": "Overclockeur FE en superconducteur sculk"
+    "item.laserio.energy_overclocker_card_tier_4": "Overclockeur FE en acier de l'End"
 }

--- a/kubejs/assets/laserio/lang/it_it.json
+++ b/kubejs/assets/laserio/lang/it_it.json
@@ -2,10 +2,5 @@
   "item.laserio.energy_overclocker_card_tier_1": "Overclocker di FE in Ferro Conduttivo",
   "item.laserio.energy_overclocker_card_tier_2": "Overclocker di FE in Lega Energetica",
   "item.laserio.energy_overclocker_card_tier_3": "Overclocker di FE in Lega Vibrante",
-  "item.laserio.energy_overclocker_card_tier_4": "Overclocker di FE in Acciaio dell'End",
-  "item.laserio.energy_overclocker_card_tier_5": "Overclocker di FE in Lumium",
-  "item.laserio.energy_overclocker_card_tier_6": "Overclocker di FE in Signalum",
-  "item.laserio.energy_overclocker_card_tier_7": "Overclocker di FE in Enderium",
-  "item.laserio.energy_overclocker_card_tier_8": "Overclocker di FE in Criolobo",
-  "item.laserio.energy_overclocker_card_tier_9": "Overclocker di FE in Superconduttore Sculk"
+  "item.laserio.energy_overclocker_card_tier_4": "Overclocker di FE in Acciaio dell'End"
 }

--- a/kubejs/assets/laserio/lang/ja_jp.json
+++ b/kubejs/assets/laserio/lang/ja_jp.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "伝導鉄FEオーバークロッカー",
     "item.laserio.energy_overclocker_card_tier_2": "エナジェティック合金FEオーバークロッカー",
     "item.laserio.energy_overclocker_card_tier_3": "ヴァイブラント合金FEオーバークロッカー",
-    "item.laserio.energy_overclocker_card_tier_4": "エンドスチールFEオーバークロッカー",
-    "item.laserio.energy_overclocker_card_tier_5": "ルミウムFEオーバークロッカー",
-    "item.laserio.energy_overclocker_card_tier_6": "シグナルムFEオーバークロッカー",
-    "item.laserio.energy_overclocker_card_tier_7": "エンダリウムFEオーバークロッカー",
-    "item.laserio.energy_overclocker_card_tier_8": "クリオロバスFEオーバークロッカー",
-    "item.laserio.energy_overclocker_card_tier_9": "スカルク超伝導体FEオーバークロッカー"
+    "item.laserio.energy_overclocker_card_tier_4": "エンドスチールFEオーバークロッカー"
 }

--- a/kubejs/assets/laserio/lang/ko_kr.json
+++ b/kubejs/assets/laserio/lang/ko_kr.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "Conductive Iron FE Overclocker",
     "item.laserio.energy_overclocker_card_tier_2": "Energetic Alloy FE Overclocker",
     "item.laserio.energy_overclocker_card_tier_3": "Vibrant Alloy FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_5": "Lumium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_6": "Signalum FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_7": "Enderium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_8": "Cryolobus FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_9": "Sculk Superconductor FE Overclocker"
+    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker"
 }

--- a/kubejs/assets/laserio/lang/nl_nl.json
+++ b/kubejs/assets/laserio/lang/nl_nl.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "Geleidend Ijzer FE Overklokker",
     "item.laserio.energy_overclocker_card_tier_2": "Energetische Legering FE Overklokker",
     "item.laserio.energy_overclocker_card_tier_3": "Levendige Legering FE Overklokker",
-    "item.laserio.energy_overclocker_card_tier_4": "Endstaal FE Overklokker",
-    "item.laserio.energy_overclocker_card_tier_5": "Lumium FE Overklokker",
-    "item.laserio.energy_overclocker_card_tier_6": "Signaalum FE Overklokker",
-    "item.laserio.energy_overclocker_card_tier_7": "Enderium FE Overklokker",
-    "item.laserio.energy_overclocker_card_tier_8": "Cryolobus FE Overklokker",
-    "item.laserio.energy_overclocker_card_tier_9": "Sculk Supergeleider FE Overklokker"
+    "item.laserio.energy_overclocker_card_tier_4": "Endstaal FE Overklokker"
 }

--- a/kubejs/assets/laserio/lang/pl_pl.json
+++ b/kubejs/assets/laserio/lang/pl_pl.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "Conductive Iron FE Overclocker",
     "item.laserio.energy_overclocker_card_tier_2": "Energetic Alloy FE Overclocker",
     "item.laserio.energy_overclocker_card_tier_3": "Vibrant Alloy FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_5": "Lumium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_6": "Signalum FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_7": "Enderium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_8": "Cryolobus FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_9": "Sculk Superconductor FE Overclocker"
+    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker"
 }

--- a/kubejs/assets/laserio/lang/pt_br.json
+++ b/kubejs/assets/laserio/lang/pt_br.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "Overclocker FE de Ferro Condutor",
     "item.laserio.energy_overclocker_card_tier_2": "Overclocker FE de Liga Energética",
     "item.laserio.energy_overclocker_card_tier_3": "Overclocker FE de Liga Vibrante",
-    "item.laserio.energy_overclocker_card_tier_4": "Overclocker FE de Aço do Fim",
-    "item.laserio.energy_overclocker_card_tier_5": "Overclocker FE de Lumium",
-    "item.laserio.energy_overclocker_card_tier_6": "Overclocker FE de Signalum",
-    "item.laserio.energy_overclocker_card_tier_7": "Overclocker FE de Enderium",
-    "item.laserio.energy_overclocker_card_tier_8": "Overclocker FE de Cryolobus",
-    "item.laserio.energy_overclocker_card_tier_9": "Overclocker FE de Supercondutor Sculk"
+    "item.laserio.energy_overclocker_card_tier_4": "Overclocker FE de Aço do Fim"
 }

--- a/kubejs/assets/laserio/lang/pt_pt.json
+++ b/kubejs/assets/laserio/lang/pt_pt.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "Conductive Iron FE Overclocker",
     "item.laserio.energy_overclocker_card_tier_2": "Energetic Alloy FE Overclocker",
     "item.laserio.energy_overclocker_card_tier_3": "Vibrant Alloy FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_5": "Lumium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_6": "Signalum FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_7": "Enderium FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_8": "Cryolobus FE Overclocker",
-    "item.laserio.energy_overclocker_card_tier_9": "Sculk Superconductor FE Overclocker"
+    "item.laserio.energy_overclocker_card_tier_4": "End Steel FE Overclocker"
 }

--- a/kubejs/assets/laserio/lang/ru_ru.json
+++ b/kubejs/assets/laserio/lang/ru_ru.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "FE-оверклокер из проводящего железа",
     "item.laserio.energy_overclocker_card_tier_2": "FE-оверклокер из энергетического сплава",
     "item.laserio.energy_overclocker_card_tier_3": "FE-оверклокер из яркого сплава",
-    "item.laserio.energy_overclocker_card_tier_4": "FE-оверклокер из стали Энда",
-    "item.laserio.energy_overclocker_card_tier_5": "FE-оверклокер из люмия",
-    "item.laserio.energy_overclocker_card_tier_6": "FE-оверклокер из сигналия",
-    "item.laserio.energy_overclocker_card_tier_7": "FE-оверклокер из эндерия",
-    "item.laserio.energy_overclocker_card_tier_8": "FE-оверклокер из криолобуса",
-    "item.laserio.energy_overclocker_card_tier_9": "FE-оверклокер из скалка"
+    "item.laserio.energy_overclocker_card_tier_4": "FE-оверклокер из стали Энда"
 }

--- a/kubejs/assets/laserio/lang/zh_cn.json
+++ b/kubejs/assets/laserio/lang/zh_cn.json
@@ -2,10 +2,5 @@
     "item.laserio.energy_overclocker_card_tier_1": "导电铁 FE 超频器",
     "item.laserio.energy_overclocker_card_tier_2": "充能合金 FE 超频器",
     "item.laserio.energy_overclocker_card_tier_3": "脉冲合金 FE 超频器",
-    "item.laserio.energy_overclocker_card_tier_4": "末影钢 FE 超频器",
-    "item.laserio.energy_overclocker_card_tier_5": "流明 FE 超频器",
-    "item.laserio.energy_overclocker_card_tier_6": "信素 FE 超频器",
-    "item.laserio.energy_overclocker_card_tier_7": "末影 FE 超频器",
-    "item.laserio.energy_overclocker_card_tier_8": "寒触合金 FE 超频器",
-    "item.laserio.energy_overclocker_card_tier_9": "幽匿超导 FE 超频器"
+    "item.laserio.energy_overclocker_card_tier_4": "末影钢 FE 超频器"
 }

--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -522,7 +522,7 @@ ServerEvents.recipes(event => {
 
     // Shortcut recipes for thrusters
     event.recipes.gtceu.assembler("kubejs:assembler_dark_soularium_thruster")
-        .itemInputs("4x gtceu:double_dark_soularium_plate", "6x gtceu:vibrant_alloy_plate", "2x enderio:weather_crystal", "2x enderio:prescient_crystal", "laserio:energy_overclocker_card_tier_8")
+        .itemInputs("4x gtceu:double_dark_soularium_plate", "6x gtceu:vibrant_alloy_plate", "2x enderio:weather_crystal", "2x enderio:prescient_crystal", "gtceu:cryolobus_double_wire")
         .itemOutputs("kubejs:dark_soularium_thruster")
         .duration(100)
         .EUt(GTValues.VA[GTValues.IV])

--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -522,7 +522,7 @@ ServerEvents.recipes(event => {
 
     // Shortcut recipes for thrusters
     event.recipes.gtceu.assembler("kubejs:assembler_dark_soularium_thruster")
-        .itemInputs("4x gtceu:double_dark_soularium_plate", "6x gtceu:vibrant_alloy_plate", "2x enderio:weather_crystal", "2x enderio:prescient_crystal", "gtceu:cryolobus_double_wire")
+        .itemInputs("4x gtceu:double_dark_soularium_plate", "6x gtceu:vibrant_alloy_plate", "2x enderio:weather_crystal", "2x enderio:prescient_crystal", "gtceu:cryolobus_frame")
         .itemOutputs("kubejs:dark_soularium_thruster")
         .duration(100)
         .EUt(GTValues.VA[GTValues.IV])

--- a/kubejs/server_scripts/gregtech/Post_UV_Components.js
+++ b/kubejs/server_scripts/gregtech/Post_UV_Components.js
@@ -3,59 +3,6 @@
  */
 
 ServerEvents.recipes(event => {
-    const converter = [
-        ["uev", "cable", "darconite", "hyperdegenerate_darconite", 1966080],
-        ["max", "wire", "monium", "monium", 80000000],
-    ]
-
-    converter.forEach(([tier, mat1, mat2, mat3, eut]) => {
-        event.remove({ output: [`gtceu:${tier}_1a_energy_converter`, `gtceu:${tier}_4a_energy_converter`, `gtceu:${tier}_8a_energy_converter`, `gtceu:${tier}_16a_energy_converter`] })
-        event.recipes.gtceu.shaped(Item.of(`gtceu:${tier}_1a_energy_converter`), [
-            " BB",
-            "AHC",
-            " BB"
-        ], {
-            A: "gtceu:red_alloy_single_cable",
-            B: `gtceu:${mat2}_single_${mat1}`,
-            H: `gtceu:${tier}_machine_hull`,
-            C: `#gtceu:circuits/${tier}`
-        }).addMaterialInfo()
-
-
-        event.recipes.gtceu.shaped(Item.of(`gtceu:${tier}_4a_energy_converter`), [
-            " BB",
-            "AHC",
-            " BB"
-        ], {
-            A: "gtceu:red_alloy_quadruple_cable",
-            B: `gtceu:${mat2}_quadruple_${mat1}`,
-            H: `gtceu:${tier}_machine_hull`,
-            C: `#gtceu:circuits/${tier}`
-        }).addMaterialInfo()
-
-        event.recipes.gtceu.shaped(Item.of(`gtceu:${tier}_8a_energy_converter`), [
-            " BB",
-            "AHC",
-            " BB"
-        ], {
-            A: "gtceu:red_alloy_octal_cable",
-            B: `gtceu:${mat2}_octal_${mat1}`,
-            H: `gtceu:${tier}_machine_hull`,
-            C: `#gtceu:circuits/${tier}`
-        }).addMaterialInfo()
-
-        event.recipes.gtceu.shaped(Item.of(`gtceu:${tier}_16a_energy_converter`), [
-            " BB",
-            "AHC",
-            " BB"
-        ], {
-            A: "gtceu:red_alloy_hex_cable",
-            B: `gtceu:${mat2}_hex_${mat1}`,
-            H: `gtceu:${tier}_machine_hull`,
-            C: `#gtceu:circuits/${tier}`
-        }).addMaterialInfo()
-    })
-
     // UHV components
     const plateFix = [
         /gtceu:.*casing_uhv/,

--- a/kubejs/server_scripts/mods/iron_jetpacks.js
+++ b/kubejs/server_scripts/mods/iron_jetpacks.js
@@ -59,7 +59,7 @@ ServerEvents.recipes(event => {
         "TTT"
     ], {
         I: "gtceu:double_dark_soularium_plate",
-        C: "laserio:energy_overclocker_card_tier_8",
+        C: "gtceu:cryolobus_single_wire",
         F: "enderio:weather_crystal",
         T: Item.of("kubejs:vibrant_thruster").weakNBT()
     }).id("kubejs:ironjetpacks/thrusters/dark_soularium")

--- a/kubejs/server_scripts/mods/iron_jetpacks.js
+++ b/kubejs/server_scripts/mods/iron_jetpacks.js
@@ -59,7 +59,7 @@ ServerEvents.recipes(event => {
         "TTT"
     ], {
         I: "gtceu:double_dark_soularium_plate",
-        C: "gtceu:cryolobus_single_wire",
+        C: "gtceu:cryolobus_frame",
         F: "enderio:weather_crystal",
         T: Item.of("kubejs:vibrant_thruster").weakNBT()
     }).id("kubejs:ironjetpacks/thrusters/dark_soularium")

--- a/kubejs/server_scripts/mods/laserio.js
+++ b/kubejs/server_scripts/mods/laserio.js
@@ -163,39 +163,4 @@ ServerEvents.recipes(event => {
         .itemOutputs("4x laserio:energy_overclocker_card_tier_4")
         .duration(80)
         .EUt(16)
-
-    // Lumium
-    event.recipes.gtceu.assembler("kubejs:lumium_card")
-        .itemInputs("2x gtceu:lumium_single_wire", "laserio:energy_overclocker_card_tier_4", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_5")
-        .duration(80)
-        .EUt(16)
-
-    // Signalum
-    event.recipes.gtceu.assembler("kubejs:signalum_card")
-        .itemInputs("2x gtceu:signalum_single_wire", "laserio:energy_overclocker_card_tier_5", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_6")
-        .duration(80)
-        .EUt(16)
-
-    // Enderium
-    event.recipes.gtceu.assembler("kubejs:enderium_card")
-        .itemInputs("2x gtceu:enderium_single_wire", "laserio:energy_overclocker_card_tier_6", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_7")
-        .duration(80)
-        .EUt(16)
-
-    // Cryolobus
-    event.recipes.gtceu.assembler("kubejs:cryolobus_card")
-        .itemInputs("2x gtceu:cryolobus_single_wire", "laserio:energy_overclocker_card_tier_7", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_8")
-        .duration(80)
-        .EUt(16)
-
-    // Sculk Superconductor
-    event.recipes.gtceu.assembler("kubejs:sculk_superconductor_card")
-        .itemInputs("2x gtceu:sculk_superconductor_single_wire", "laserio:energy_overclocker_card_tier_8", "6x gtceu:iron_plate")
-        .itemOutputs("4x laserio:energy_overclocker_card_tier_9")
-        .duration(80)
-        .EUt(16)
 })

--- a/kubejs/server_scripts/mods/optionalCompats/fluxnetworks.js
+++ b/kubejs/server_scripts/mods/optionalCompats/fluxnetworks.js
@@ -30,7 +30,7 @@ if (Platform.isLoaded("fluxnetworks")) {
         event.remove({ id: "fluxnetworks:fluxcore" })
         event.recipes.gtceu.assembler("fluxnetworks:fluxcore")
             .itemOutputs("2x fluxnetworks:flux_core")
-            .itemInputs("1x minecraft:ender_eye", "4x enderio:reinforced_obsidian_block", "4x fluxnetworks:flux_dust", "1x gtceu:luv_sensor", "1x gtceu:luv_emitter", "4x laserio:energy_overclocker_card_tier_8")
+            .itemInputs("1x minecraft:ender_eye", "4x enderio:reinforced_obsidian_block", "4x fluxnetworks:flux_dust", "1x gtceu:luv_sensor", "1x gtceu:luv_emitter", "4x gtceu:cryolobus_frame")
             .EUt(GTValues.VA[GTValues.LuV])
             .duration(200)
 

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -138,6 +138,7 @@ global.itemNukeList = [
     "gtceu:luv_solar_panel",
     "gtceu:zpm_solar_panel",
     "gtceu:uv_solar_panel",
+    /^gtceu:(ev|iv|luv|zpm|uv|uhv|uev|max)_\w+a_energy_converter/,
     /^gtceu:uiv/,
     /^gtceu:uxv/,
     /^gtceu:opv/,
@@ -211,6 +212,7 @@ global.itemNukeList = [
     // LaserIO
     "laserio:logic_chip",
     "laserio:logic_chip_raw",
+    /^laserio:energy_overclocker_card_tier_[5-9]/,
 
     // Megacells
     "megacells:mega_crafting_accelerator",

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -212,7 +212,6 @@ global.itemNukeList = [
     // LaserIO
     "laserio:logic_chip",
     "laserio:logic_chip_raw",
-    /^laserio:energy_overclocker_card_tier_[5-9]/,
 
     // Megacells
     "megacells:mega_crafting_accelerator",


### PR DESCRIPTION
Adds all converters of tiers EV and above to nukelist
Adds all LaserIO overclockers of tiers Lumium and above to nukelist
Cryolobus overclocker used in Dark Soularium Thruster replaced with cryolobus wire