### PR TITLE
Remove duplicate/deprecated items from Guardian model

### DIFF
--- a/kubejs/data/hostilenetworks/data_models/guardian.json
+++ b/kubejs/data/hostilenetworks/data_models/guardian.json
@@ -28,14 +28,6 @@
         {
             "item": "minecraft:wet_sponge",
             "count": 2
-        },
-        {
-            "item": "kubejs:guardian_scale",
-            "count": 4
-        },
-        {
-            "item": "minecraft:wet_sponge",
-            "count": 2
         }
     ]
 }


### PR DESCRIPTION
Removes the duplicate Wet Sponge fabrication and deprecated Guardian Scale fabrication from HNN Guardian Models, from the singleblock Loot Fabricators.
Why were these there? I don't know, but they shouldn't be anymore.