### PR TITLE
Add ExtraAE2RecipeTransfers (esotericae2)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1124,6 +1124,11 @@
       "fileID": 8198871,
       "projectID": 1528726,
       "required": true
+    },
+    {
+      "fileID": 8338326,
+      "projectID": 1590433,
+      "required": true
     }
   ]
 }


### PR DESCRIPTION
This just adds my dinky little [AE2 QOL mod](https://www.curseforge.com/minecraft/mc-mods/esotericae2) *([source](https://git.quantumgarbage.com/bop/esotericae2/))* that allows auto-filling interfaces and other AE2 parts with the EMI `+` button.

Eventually:tm: I plan to add support for GregTech's ME buses/hatches but that will probably be on hold until GTM 8.0.0 is out.