### PR TITLE
Add the TE wires to deprecation pipeline

### DIFF
--- a/kubejs/startup_scripts/deprecations.js
+++ b/kubejs/startup_scripts/deprecations.js
@@ -3,6 +3,8 @@
  * See deprecation_pipeline.js in this folder to see how the process works.
  */
 
+/* *** TO BE REMOVED FROM THIS FILE IN MONIFACTORY 0.14 *** */
+
 // Exoskeleton Legs
 deprecateItem("kubejs:lv_exoskeleton_legs", "gtexolegs:lv_exoskeleton_legs", "LV Exoskeleton Legs")
 deprecateItem("kubejs:mv_exoskeleton_legs", "gtexolegs:mv_exoskeleton_legs", "MV Exoskeleton Legs")
@@ -113,3 +115,15 @@ deprecateItem("kubejs:universe_wafer", "kubejs:null_wafer", "Universe Wafer")
 // Guardian Scale processing
 deprecateItem("kubejs:guardian_scale", "minecraft:prismarine_shard", "Guardian Scale")
 deprecateFluid("gtceu:guardian_scale_slurry", "gtceu:prismarine_slurry", "Guardian Scale Slurry")
+
+/* *** TO BE REMOVED FROM THIS FILE IN MONIFACTORY 0.15 *** */
+
+// Lumium, Signalum, Enderium, Cryolobus wires. Sculk Superconductor as a material was removed entirely.
+const deprecated_thermal_wire_materials = ["lumium", "signalum", "enderium", "cryolobus"]
+deprecated_thermal_wire_materials.forEach(material => {
+    deprecateBlock(`gtceu:${material}_single_wire`, `4x gtceu:${material}_nugget`)
+    deprecateBlock(`gtceu:${material}_double_wire`, `1x gtceu:${material}_ingot`)
+    deprecateBlock(`gtceu:${material}_quadruple_wire`, `2x gtceu:${material}_ingot`)
+    deprecateBlock(`gtceu:${material}_octal_wire`, `4x gtceu:${material}_ingot`)
+    deprecateBlock(`gtceu:${material}_hex_wire`, `8x gtceu:${material}_ingot`)
+})


### PR DESCRIPTION
With this players should get a refund when they update if they were using the wires in question and didn't clean them up in advance.
Also includes a reminder on when to remove certain entries.