### PR TITLE
Polyphenylene Sulfide Quest Fix

### DIFF
--- a/kubejs/assets/ftbquests/lang/de_de.json
+++ b/kubejs/assets/ftbquests/lang/de_de.json
@@ -2144,7 +2144,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Schaltkreis-Montageeinheit",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Micro Miner&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Plutonium 239&r, &6Darmstadtium&r, and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/en_us.json
+++ b/kubejs/assets/ftbquests/lang/en_us.json
@@ -2569,7 +2569,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Microminer&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Darmstadtium&r and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/es_es.json
+++ b/kubejs/assets/ftbquests/lang/es_es.json
@@ -2142,7 +2142,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Micro Miner&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Plutonium 239&r, &6Darmstadtium&r, and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/fr_fr.json
+++ b/kubejs/assets/ftbquests/lang/fr_fr.json
@@ -2144,7 +2144,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Micro Miner&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Plutonium 239&r, &6Darmstadtium&r, and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/it_it.json
+++ b/kubejs/assets/ftbquests/lang/it_it.json
@@ -2547,7 +2547,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Microminer&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Darmstadtium&r and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/ja_jp.json
+++ b/kubejs/assets/ftbquests/lang/ja_jp.json
@@ -2142,7 +2142,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "Combines &bStellar Creation Data&r into &9Universe Creation Data&r, which is a crucial component for the Tier Ten Micro Miner mission.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "このマイクロマイナーは&6ダームスタチウム&rと&6デュラニウム&rの優れた供給源です。また、&3核融合炉MKIII&rに比べて&6ニュートロニウム&rの供給速度は若干遅いものの、安価で手に入れられます。",

--- a/kubejs/assets/ftbquests/lang/ko_kr.json
+++ b/kubejs/assets/ftbquests/lang/ko_kr.json
@@ -2546,7 +2546,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Microminer&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Darmstadtium&r and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/nl_nl.json
+++ b/kubejs/assets/ftbquests/lang/nl_nl.json
@@ -2419,7 +2419,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Micro Miner&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Plutonium 239&r, &6Darmstadtium&r, and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/pl_pl.json
+++ b/kubejs/assets/ftbquests/lang/pl_pl.json
@@ -2304,7 +2304,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Micro Miner&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Plutonium 239&r, &6Darmstadtium&r, and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/pt_br.json
+++ b/kubejs/assets/ftbquests/lang/pt_br.json
@@ -2142,7 +2142,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Micro Miner&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Plutonium 239&r, &6Darmstadtium&r, and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/pt_pt.json
+++ b/kubejs/assets/ftbquests/lang/pt_pt.json
@@ -2481,7 +2481,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Micro Miner&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Plutonium 239&r, &6Darmstadtium&r, and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/uk_ua.json
+++ b/kubejs/assets/ftbquests/lang/uk_ua.json
@@ -2560,7 +2560,7 @@
     "moni.quest.6B908DECFA46C8E0.description2": "It can also optionally overclock recipes up to 128 EU/t, gaining additional speed for relatively more power.",
     "moni.quest.6B908DECFA46C8E0.title": "&2HV Circuit Assembler",
     "moni.quest.6BBACA979DF9BA30.title": "debug: undo hm",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.6BE1CD77618EC6C7.title": "&2Polyphenylene Sulfide",
     "moni.quest.6BF4A76C5B84EEE9.description1": "The &6Tier Nine Microminer&r doesn't unlock any new items, but instead grants alternate sources for some pre-existing materials.",
     "moni.quest.6BF4A76C5B84EEE9.description2": "This miner is a great source of &6Darmstadtium&r and &6Duranium&r. It is also a slightly slower but cheaper source of &6Neutronium&r compared to the &3Fusion Reactor MKIII&r.",

--- a/kubejs/assets/ftbquests/lang/zh_tw.json
+++ b/kubejs/assets/ftbquests/lang/zh_tw.json
@@ -418,7 +418,7 @@
     "moni.quest.52B20235882063BF.description1": "Combine several components into a catalyst.",
     "moni.quest.400AD2B735FF135D.title": "Progression Tab",
     "moni.task.29F11B4491A6064D": "LV, MV, or HV Forge Hammer",
-    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required for wrapping LuV+ cables.",
+    "moni.quest.6BE1CD77618EC6C7.description1": "&2Thin Polyphenylene Sulfide Sheets are required to wrap any Cable tier from &dLuV&2 up to &3UV&2.&r",
     "moni.quest.lava.description": "&9Lava&r can be obtained in two main ways. The first is using a &3Chemical Reactor&r to turn &6Magma Blocks&r into &9Lava&r. The second is using a &bGregTech &6Fluid Drill&r in the Nether above a &9Lava&r vein.",
     "moni.quest.7979D07FBDC6D170.description1": "The final processing unit. Capable of storing and interacting with miniaturized microverses. ",
     "moni.quest.638130DC8A2BF1C1.description1": "This is your first Microminer ever. You'll need &6Phosphorous&r in its &6LV Field Generator&r.",


### PR DESCRIPTION
Polyphenylene sulphide is required to wrap cables from luv to uv inclusive but only works on cryococcus at uhv while all others at uhv and future tiers need PEEK.

This only fixes the en_us file as I don't know how you guys handle translations, feel free to copy or add the other translations accordingly.

Should fix the 2nd part of #2667 (the current pr only fixes the rubber coating inconsistencies not the plastic wrap).

Language is modified form xefyr's fix to the first part of #2667 for consistency.

Also the colours are fixed and LuV and UV are now their respective colours not dark green. 

Has been tested in game seems fine :)