### PR TITLE
Update Functional Storage to 1.2.14 (fixes item voiding issue) and add back simple compacting drawers

### DIFF
--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -27,12 +27,6 @@ JEIEvents.hideItems(event => {
         event.hide("thermal:flux_drill")
     }
 
-    // Simple Compacting Drawers (TEMPORARY UNTIL BUG FIXED)
-    if (doCompacting) {
-        event.hide("functionalstorage:simple_compacting_drawer")
-        event.hide("functionalstorage:framed_simple_compacting_drawer")
-    }
-
     // Hide GT ores to prevent clutter
     GTMaterialRegistry.getRegisteredMaterials().forEach(id => {
         event.hide([

--- a/kubejs/server_scripts/mods/functionalstorage.js
+++ b/kubejs/server_scripts/mods/functionalstorage.js
@@ -22,7 +22,7 @@ ServerEvents.recipes(event => {
             P: "gtceu:lv_electric_piston",
             D: "#functionalstorage:drawer"
         }).id("functionalstorage:compacting_drawer")
-        /*
+        
         event.shaped("functionalstorage:simple_compacting_drawer", [
             "III",
             "IDP",
@@ -32,8 +32,6 @@ ServerEvents.recipes(event => {
             P: "gtceu:lv_electric_piston",
             D: "#functionalstorage:drawer"
         }).id("functionalstorage:simple_compacting_drawer")
-        */
-        event.remove("functionalstorage:simple_compacting_drawer")
 
         // Framed Compacting Drawers
         event.shaped("functionalstorage:compacting_framed_drawer", [
@@ -44,7 +42,7 @@ ServerEvents.recipes(event => {
             I: "minecraft:iron_nugget",
             B: "functionalstorage:compacting_drawer"
         }).id("functionalstorage:compacting_framed_drawer")
-        /*
+
         event.shaped("functionalstorage:framed_simple_compacting_drawer", [
             "III",
             "IBI",
@@ -53,8 +51,6 @@ ServerEvents.recipes(event => {
             I: "minecraft:iron_nugget",
             B: "functionalstorage:simple_compacting_drawer"
         }).id("functionalstorage:framed_simple_compacting_drawer")
-        */
-        event.remove("functionalstorage:framed_simple_compacting_drawer")
 
         // Custom coin compacting recipes
         event.custom({

--- a/kubejs/server_scripts/mods/functionalstorage.js
+++ b/kubejs/server_scripts/mods/functionalstorage.js
@@ -22,7 +22,7 @@ ServerEvents.recipes(event => {
             P: "gtceu:lv_electric_piston",
             D: "#functionalstorage:drawer"
         }).id("functionalstorage:compacting_drawer")
-        
+
         event.shaped("functionalstorage:simple_compacting_drawer", [
             "III",
             "IDP",

--- a/manifest.json
+++ b/manifest.json
@@ -591,7 +591,7 @@
       "required": true
     },
     {
-      "fileID": 6702553,
+      "fileID": 8412552,
       "projectID": 556861,
       "required": true
     },


### PR DESCRIPTION
Functional Storage 1.2.14 fixes the item voiding issue that caused Simple Compacting Drawers to be removed (in #1761), so this PR updates the mod and adds back Simple Compacting Drawer and Framed Simple Compacting Drawer. The update also fixes a few other bugs with drawers, most importantly one that prevented inserting Storage Downgrades in compacting drawers in cases where it should be possible.

Closes #2552