### PR TITLE
Add boiler pipe to nukelist when boilers are disabled

### DIFF
--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -518,5 +518,6 @@ if (!global.doBoilers) {
         "systeams:gourmand_boiler",
         "systeams:magmatic_boiler",
         "systeams:numismatic_boiler",
+        "systeams:boiler_pipe"
     );
 }


### PR DESCRIPTION
In HM and EM, the Boiler Pipe is visible in EMI despite being unobtainable. This PR fixes that.