### PR TITLE
Change §tTeal to §3Teal in Prismatic Crucible lang entries

### DIFF
--- a/kubejs/assets/monilabs/lang/en_us.json
+++ b/kubejs/assets/monilabs/lang/en_us.json
@@ -99,7 +99,7 @@
   "monilabs.prismatic.color_name.orange": "§6Orange§r",
   "monilabs.prismatic.color_name.pink": "§cPink§r",
   "monilabs.prismatic.color_name.red": "§4Red§r",
-  "monilabs.prismatic.color_name.teal": "§tTeal§r",
+  "monilabs.prismatic.color_name.teal": "§3Teal§r",
   "monilabs.prismatic.color_name.yellow": "§eYellow§r",
   "monilabs.prismatic.current_color": "Current color: %s",
   "monilabs.recipe.accepted_colors": "Accepted Initial Colors: ",

--- a/kubejs/assets/monilabs/lang/it_it.json
+++ b/kubejs/assets/monilabs/lang/it_it.json
@@ -99,7 +99,7 @@
   "monilabs.prismatic.color_name.orange": "§6Arancione§r",
   "monilabs.prismatic.color_name.pink": "§cRosa§r",
   "monilabs.prismatic.color_name.red": "§4Rosso§r",
-  "monilabs.prismatic.color_name.teal": "§tTeal§r",
+  "monilabs.prismatic.color_name.teal": "§3Teal§r",
   "monilabs.prismatic.color_name.yellow": "§eGiallo§r",
   "monilabs.prismatic.current_color": "colore corrente: %s",
   "monilabs.recipe.accepted_colors": "Colori Iniziali Accettati: ",

--- a/kubejs/assets/monilabs/lang/lv_lv.json
+++ b/kubejs/assets/monilabs/lang/lv_lv.json
@@ -99,7 +99,7 @@
     "monilabs.prismatic.color_name.orange": "§6Orange§r",
     "monilabs.prismatic.color_name.pink": "§cPink§r",
     "monilabs.prismatic.color_name.red": "§4Red§r",
-    "monilabs.prismatic.color_name.teal": "§tTeal§r",
+    "monilabs.prismatic.color_name.teal": "§3Teal§r",
     "monilabs.prismatic.color_name.yellow": "§eYellow§r",
     "monilabs.prismatic.current_color": "Current color: %s",
     "monilabs.recipe.accepted_colors": "Accepted Initial Colors: ",

--- a/kubejs/assets/monilabs/lang/uk_ua.json
+++ b/kubejs/assets/monilabs/lang/uk_ua.json
@@ -99,7 +99,7 @@
     "monilabs.prismatic.color_name.orange": "§6Orange§r",
     "monilabs.prismatic.color_name.pink": "§cPink§r",
     "monilabs.prismatic.color_name.red": "§4Red§r",
-    "monilabs.prismatic.color_name.teal": "§tTeal§r",
+    "monilabs.prismatic.color_name.teal": "§3Teal§r",
     "monilabs.prismatic.color_name.yellow": "§eYellow§r",
     "monilabs.prismatic.current_color": "Current color: %s",
     "monilabs.recipe.accepted_colors": "Accepted Initial Colors: ",

--- a/kubejs/assets/monilabs/lang/zh_tw.json
+++ b/kubejs/assets/monilabs/lang/zh_tw.json
@@ -18,7 +18,7 @@
     "monilabs.prismatic.color_name.lime": "§aLime§r",
     "monilabs.recipe.mistake_input_colors": "You made a mistake defining this recipe's input colors.",
     "block.monilabs.max_256a_laser_source_hatch": "§c§lMAX§r 256§eA§r Laser Source Hatch",
-    "monilabs.prismatic.color_name.teal": "§tTeal§r",
+    "monilabs.prismatic.color_name.teal": "§3Teal§r",
     "monilabs.recipe.fully_random_color": "Resulting Color State: \n§5R§dA§4N§cD§eO§aM §bC§3O§7L§1O§5R§r!",
     "gtceu.placeholder_info.microverseStability.2": "Usage:",
     "monilabs.recipe.basic_input": "Primary | Secondary",


### PR DESCRIPTION
Fixes a server crash when selecting Teal in the Advanced Chroma Detector Hatch.


When changing the Teal color from the standard §3 to the Chroma Colors §t, the MoniLabs Prismatic Crucible code didn't get the memo and so trying to set an Advanced Chroma Detector Hatch to Teal sets the hatch to detect the color `null`, which causes a server crash and also a small (but correctable) bit of savefile corruption.

(The corruption is that if a hatch is saved detecting `null` and is then Loaded, this load will cause all future placed Adv.Chroma Detectors to also be placed detecting `null` not Red. Changing the color of a detector in an invalid state triggers another crash. To fix this, all invalid hatches must be removed and then the server must be restarted.)