### PR TITLE
Update spatial tools

### DIFF
--- a/kubejs/server_scripts/mods/spatialtoolscmp.js
+++ b/kubejs/server_scripts/mods/spatialtoolscmp.js
@@ -44,7 +44,7 @@ ServerEvents.recipes(event => {
             C: "#gtceu:circuits/lv",
             B: "#gtceu:batteries/hv"
         })
-                event.shaped("spatialtoolscmp:portable_spatial_piper", [
+        event.shaped("spatialtoolscmp:portable_spatial_piper", [
             "SE",
             "CM",
             "PB"

--- a/kubejs/server_scripts/mods/spatialtoolscmp.js
+++ b/kubejs/server_scripts/mods/spatialtoolscmp.js
@@ -3,7 +3,10 @@
  */
 ServerEvents.recipes(event => {
     if (doHarderRecipes) {
-        event.remove({ id: /spatialtoolscmp/ })
+        event.remove({
+            id: /spatialtoolscmp/,
+            not: { id: /spatial_tool_merge|crafting_buffer/ } // Merge is custom recipe so the tools won't loose their upgrades etc.
+        })
 
         // Crafting Table recipes are near-identical to Building Gadgets counterparts
         event.shaped("spatialtoolscmp:portable_spatial_replacer", [
@@ -41,6 +44,18 @@ ServerEvents.recipes(event => {
             C: "#gtceu:circuits/lv",
             B: "#gtceu:batteries/hv"
         })
+                event.shaped("spatialtoolscmp:portable_spatial_piper", [
+            "SE",
+            "CM",
+            "PB"
+        ], {
+            M: "#forge:plates/glass",
+            P: "gtceu:aluminium_plate",
+            E: "gtceu:lv_emitter",
+            S: "gtceu:lv_sensor",
+            C: "#gtceu:circuits/lv",
+            B: "#gtceu:batteries/lv"
+        })
     } else {
         event.replaceInput({ id: /^spatialtoolscmp:/}, "minecraft:nether_star", "gtceu:mv_emitter")
     }
@@ -50,7 +65,8 @@ ServerEvents.recipes(event => {
     const GadgetReconstructPairs = [
         { gadget: "gadget_exchanging", spatialtool: "portable_spatial_replacer"},
         { gadget: "gadget_copy_paste", spatialtool: "portable_spatial_cloner"},
-        { gadget: "gadget_cut_paste", spatialtool: "portable_spatial_storage"}
+        { gadget: "gadget_cut_paste", spatialtool: "portable_spatial_storage"},
+        { gadget: "gadget_building", spatialtool: "portable_spatial_piper"}
     ]
 
     GadgetReconstructPairs.forEach(pair => {

--- a/manifest.json
+++ b/manifest.json
@@ -1121,7 +1121,7 @@
       "required": false
     },
     {
-      "fileID": 8415567,
+      "fileID": 8481024,
       "projectID": 1528726,
       "required": true
     },

--- a/manifest.json
+++ b/manifest.json
@@ -1121,7 +1121,7 @@
       "required": false
     },
     {
-      "fileID": 8198871,
+      "fileID": 8415567,
       "projectID": 1528726,
       "required": true
     },

--- a/manifest.json
+++ b/manifest.json
@@ -1121,7 +1121,7 @@
       "required": false
     },
     {
-      "fileID": 8481024,
+      "fileID": 8533862,
       "projectID": 1528726,
       "required": true
     },

--- a/manifest.json
+++ b/manifest.json
@@ -1121,7 +1121,7 @@
       "required": false
     },
     {
-      "fileID": 8533862,
+      "fileID": 8580329,
       "projectID": 1528726,
       "required": true
     },


### PR DESCRIPTION
Updated spatial tools from 1.6.2 to 1.10.0

Changes regarding monifactory: 

### Added
- chisels and bits compat
- Anchor has new button image :3
- Support for AE2 facades
- Better error handling
- add support for double cammo framed blocks 

### Fixed
- Lootr chests duplicating loot when moved with the storage
- Greg multis not recognizing coils changed with the replacer
- Greg machines that were replaced had default orientation
- Greg covers and fluid hatches not working properly when moved with the storage
- Greg machines loosing their painting when moved/cloned
- Bug that greg energy hatches on active transformers were not working after being moved with the storage
- Fluid locking on hatches moved with the storage
- about 5 other minor bugs
- gregtechs multis not visually forming after they been pasted with the portable spatial storage

### Changed
- Some small UI changes to make it more intuitive to use


