### PR TITLE
Add tooltip explaining how Battery Buffers work.

### DIFF
--- a/kubejs/assets/gtceu/lang/en_us.json
+++ b/kubejs/assets/gtceu/lang/en_us.json
@@ -601,4 +601,6 @@
     "material.gtceu.titanite_slurry": "Titanite Slurry",
     "material.gtceu.malachite_slurry": "Malachite Slurry",
     "material.gtceu.olivine_slurry": "Olivine Slurry"
+    "block.gtceu.battery_buffer.tooltip": "§cEach battery provides 2A input and 1A output!"
+}
 }

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -270,6 +270,9 @@ ItemEvents.tooltip(tooltip => {
         "packagedexexcrafting:epic_crafter"
     ], Text.translatable("packagedexcrafting.crafterspeed.tooltip"))
 
+    // Battery Buffer tooltips
+    tooltip.add(/gtceu:.*_battery_buffer_.*/, Text.translatable("block.gtceu.battery_buffer.tooltip"))
+
     // Tempad
     if (Platform.isLoaded("tempad")) {
         tooltip.add("tempad:tempad", Text.translatable("tempad.tempad.tooltip"))


### PR DESCRIPTION
Tooltip: Each battery provides 2A input and 1A output!
(Listed in red using format code 'c', as it's meant to be a warning)